### PR TITLE
feat: 서비스 인증과 내 회원 조회 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,8 @@ FLYWAY_URL=jdbc:postgresql://db.example.com:5432/buyeoon
 FLYWAY_USERNAME=buyeoon_migrator
 FLYWAY_PASSWORD=change-me
 
+# 32바이트 이상의 CSPRNG 값을 Base64로 인코딩한 HS256 서명 키.
+JWT_SECRET=replace-with-base64-encoded-256-bit-secret
+
 # Docker Compose exposes Nginx on this host port.
 HTTP_PORT=8080

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-flyway'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,7 @@ services:
       FLYWAY_URL: ${FLYWAY_URL:?FLYWAY_URL is required}
       FLYWAY_USERNAME: ${FLYWAY_USERNAME:?FLYWAY_USERNAME is required}
       FLYWAY_PASSWORD: ${FLYWAY_PASSWORD:?FLYWAY_PASSWORD is required}
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS:--XX:MaxRAMPercentage=75.0}
     expose:
       - "8080"

--- a/src/main/java/com/buyeoon/common/api/SuccessResponse.java
+++ b/src/main/java/com/buyeoon/common/api/SuccessResponse.java
@@ -1,0 +1,8 @@
+package com.buyeoon.common.api;
+
+public record SuccessResponse<T>(boolean success, T data) {
+
+	public static <T> SuccessResponse<T> of(T data) {
+		return new SuccessResponse<>(true, data);
+	}
+}

--- a/src/main/java/com/buyeoon/member/api/MemberController.java
+++ b/src/main/java/com/buyeoon/member/api/MemberController.java
@@ -1,0 +1,29 @@
+package com.buyeoon.member.api;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.member.application.MemberQueryService;
+import com.buyeoon.member.application.MemberQueryService.MemberView;
+import java.util.Objects;
+import java.util.UUID;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+public class MemberController {
+
+	private final MemberQueryService memberQueryService;
+
+	public MemberController(MemberQueryService memberQueryService) {
+		this.memberQueryService = memberQueryService;
+	}
+
+	@GetMapping("/me")
+	public SuccessResponse<MemberView> getMyMember(@AuthenticationPrincipal Jwt jwt) {
+		return SuccessResponse
+				.of(memberQueryService.getActiveMember(UUID.fromString(Objects.requireNonNull(jwt.getSubject()))));
+	}
+}

--- a/src/main/java/com/buyeoon/member/application/MemberQueryService.java
+++ b/src/main/java/com/buyeoon/member/application/MemberQueryService.java
@@ -1,0 +1,68 @@
+package com.buyeoon.member.application;
+
+import com.buyeoon.member.entity.MemberStatus;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberQueryService {
+
+	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+
+	private final JdbcOperations jdbcOperations;
+
+	public MemberQueryService(JdbcOperations jdbcOperations) {
+		this.jdbcOperations = jdbcOperations;
+	}
+
+	public MemberView getActiveMember(UUID memberId) {
+		return jdbcOperations.query("""
+				SELECT member.id,
+				       member.status::text,
+				       profile.display_name,
+				       profile.character_id,
+				       COALESCE((
+				           SELECT bool_and(COALESCE(consent.agreed, false))
+				           FROM (
+				               SELECT DISTINCT ON (term.type) term.id
+				               FROM terms term
+				               WHERE term.required = true
+				                 AND term.effective_at <= CURRENT_TIMESTAMP
+				               ORDER BY term.type, term.effective_at DESC
+				           ) latest_required_term
+				           LEFT JOIN term_consents consent
+				             ON consent.term_id = latest_required_term.id
+				            AND consent.member_id = member.id
+				       ), false) AS required_terms_agreed,
+				       EXISTS (
+				           SELECT 1
+				           FROM citizen_cards card
+				           WHERE card.member_id = member.id
+				       ) AS citizen_card_issued,
+				       member.created_at
+				FROM members member
+				LEFT JOIN member_profiles profile ON profile.member_id = member.id
+				WHERE member.id = ?
+				  AND member.status = 'ACTIVE'
+				""", this::mapMember, memberId).stream().findFirst()
+				.orElseThrow(() -> new AuthenticationCredentialsNotFoundException("활성 회원이 아닙니다."));
+	}
+
+	private MemberView mapMember(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new MemberView(resultSet.getObject("id", UUID.class),
+				MemberStatus.valueOf(resultSet.getString("status")), resultSet.getString("display_name"),
+				resultSet.getObject("character_id", UUID.class), resultSet.getBoolean("required_terms_agreed"),
+				resultSet.getBoolean("citizen_card_issued"),
+				resultSet.getTimestamp("created_at").toInstant().atZone(ASIA_SEOUL));
+	}
+
+	public record MemberView(UUID memberId, MemberStatus status, String displayName, UUID characterId,
+			boolean requiredTermsAgreed, boolean citizenCardIssued, ZonedDateTime createdAt) {
+	}
+}

--- a/src/main/java/com/buyeoon/member/auth/AccessTokenService.java
+++ b/src/main/java/com/buyeoon/member/auth/AccessTokenService.java
@@ -1,0 +1,31 @@
+package com.buyeoon.member.auth;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AccessTokenService {
+
+	public static final Duration ACCESS_TOKEN_LIFETIME = Duration.ofHours(1);
+
+	private final JwtEncoder jwtEncoder;
+
+	public AccessTokenService(JwtEncoder jwtEncoder) {
+		this.jwtEncoder = jwtEncoder;
+	}
+
+	public String issue(UUID memberId, UUID sessionId) {
+		Instant issuedAt = Instant.now();
+		JwtClaimsSet claims = JwtClaimsSet.builder().subject(memberId.toString()).claim("sid", sessionId.toString())
+				.issuedAt(issuedAt).expiresAt(issuedAt.plus(ACCESS_TOKEN_LIFETIME)).build();
+		JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
+		return jwtEncoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
+	}
+}

--- a/src/main/java/com/buyeoon/member/auth/SecurityConfig.java
+++ b/src/main/java/com/buyeoon/member/auth/SecurityConfig.java
@@ -1,0 +1,115 @@
+package com.buyeoon.member.auth;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+	private static final OAuth2Error INVALID_TOKEN = new OAuth2Error("invalid_token", "유효하지 않은 인증입니다.", null);
+
+	@Bean
+	SecretKey jwtSecretKey(@Value("${security.jwt.secret-base64}") String encodedSecret) {
+		byte[] secret = Base64.getDecoder().decode(encodedSecret);
+		if (secret.length < 32) {
+			throw new IllegalArgumentException("JWT_SECRET은 256비트 이상이어야 합니다.");
+		}
+		return new SecretKeySpec(secret, "HmacSHA256");
+	}
+
+	@Bean
+	JwtEncoder jwtEncoder(SecretKey secretKey) {
+		return NimbusJwtEncoder.withSecretKey(secretKey).algorithm(MacAlgorithm.HS256).build();
+	}
+
+	@Bean
+	JwtDecoder jwtDecoder(SecretKey secretKey, JdbcTemplate jdbcTemplate) {
+		NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(secretKey).macAlgorithm(MacAlgorithm.HS256).build();
+		decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(new JwtTimestampValidator(Duration.ZERO),
+				activeSessionValidator(jdbcTemplate)));
+		return decoder;
+	}
+
+	@Bean
+	AuthenticationEntryPoint authenticationEntryPoint() {
+		return (request, response, exception) -> {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+			response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+			response.getWriter()
+					.write("{\"success\":false,\"data\":{\"code\":\"UNAUTHORIZED\",\"message\":\"인증이 필요합니다.\"}}");
+		};
+	}
+
+	@Bean
+	SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationEntryPoint entryPoint) throws Exception {
+		return http.csrf(AbstractHttpConfigurer::disable)
+				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+				.authorizeHttpRequests(requests -> requests.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+						.requestMatchers("/auth/**", "/terms", "/actuator/health").permitAll().anyRequest()
+						.authenticated())
+				.exceptionHandling(exceptions -> exceptions.authenticationEntryPoint(entryPoint))
+				.oauth2ResourceServer(resourceServer -> resourceServer.jwt(Customizer.withDefaults())
+						.authenticationEntryPoint(entryPoint))
+				.build();
+	}
+
+	private OAuth2TokenValidator<Jwt> activeSessionValidator(JdbcTemplate jdbcTemplate) {
+		return jwt -> {
+			try {
+				String subject = jwt.getSubject();
+				String sessionClaim = jwt.getClaimAsString("sid");
+				if (subject == null || sessionClaim == null) {
+					return OAuth2TokenValidatorResult.failure(INVALID_TOKEN);
+				}
+				UUID memberId = UUID.fromString(subject);
+				UUID sessionId = UUID.fromString(sessionClaim);
+				Boolean active = jdbcTemplate.queryForObject("""
+						SELECT EXISTS (
+						    SELECT 1
+						    FROM auth_sessions session
+						    JOIN members member ON member.id = session.member_id
+						    WHERE session.id = ?
+						      AND session.member_id = ?
+						      AND session.expires_at > CURRENT_TIMESTAMP
+						      AND session.revoked_at IS NULL
+						      AND member.status = 'ACTIVE'
+						)
+						""", Boolean.class, sessionId, memberId);
+				return Boolean.TRUE.equals(active)
+						? OAuth2TokenValidatorResult.success()
+						: OAuth2TokenValidatorResult.failure(INVALID_TOKEN);
+			} catch (IllegalArgumentException exception) {
+				return OAuth2TokenValidatorResult.failure(INVALID_TOKEN);
+			}
+		};
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,5 @@ spring.flyway.locations=classpath:db/migration
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC
+
+security.jwt.secret-base64=${JWT_SECRET}

--- a/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
@@ -1,0 +1,265 @@
+package com.buyeoon.member;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class MemberMeIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_application";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+	private static final String JWT_SECRET = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_migrator").withPassword("migrator-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@Autowired
+	private JwtEncoder jwtEncoder;
+
+	@Autowired
+	private JwtDecoder jwtDecoder;
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM citizen_cards");
+		jdbcTemplate.update("DELETE FROM member_profiles");
+		jdbcTemplate.update("DELETE FROM term_consents");
+		jdbcTemplate.update("DELETE FROM terms");
+		jdbcTemplate.update("DELETE FROM card_characters");
+		jdbcTemplate.update("DELETE FROM card_themes");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	@Test
+	void activeMemberWithoutProfileGetsInitialOnboardingState() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		Instant createdAt = Instant.parse("2026-08-11T03:00:00Z");
+		insertMember(memberId, "ACTIVE", createdAt);
+		insertSession(sessionId, memberId, Instant.now().plus(30, ChronoUnit.DAYS), null);
+
+		mockMvc.perform(
+				get("/members/me").header("Authorization", "Bearer " + accessTokenService.issue(memberId, sessionId)))
+				.andExpect(status().isOk()).andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.memberId").value(memberId.toString()))
+				.andExpect(jsonPath("$.data.status").value("ACTIVE"))
+				.andExpect(jsonPath("$.data.displayName").value((Object) null))
+				.andExpect(jsonPath("$.data.characterId").value((Object) null))
+				.andExpect(jsonPath("$.data.requiredTermsAgreed").value(false))
+				.andExpect(jsonPath("$.data.citizenCardIssued").value(false))
+				.andExpect(jsonPath("$.data.createdAt").value("2026-08-11T12:00:00+09:00"));
+	}
+
+	@Test
+	void latestProfileTermsAndCitizenCardStateIsReturned() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		UUID characterId = UUID.randomUUID();
+		UUID themeId = UUID.randomUUID();
+		insertMember(memberId, "ACTIVE", Instant.parse("2026-08-01T00:00:00Z"));
+		insertSession(sessionId, memberId, Instant.now().plus(30, ChronoUnit.DAYS), null);
+		jdbcTemplate.update("INSERT INTO card_characters (id, name, image_url) VALUES (?, '금동이', 'https://image')",
+				characterId);
+		jdbcTemplate.update("INSERT INTO card_themes (id, name, image_url) VALUES (?, '백제', 'https://image')", themeId);
+		jdbcTemplate.update(
+				"INSERT INTO member_profiles (member_id, display_name, character_id) VALUES (?, '부여여행자', ?)", memberId,
+				characterId);
+		jdbcTemplate.update("INSERT INTO citizen_cards (member_id, theme_id, barcode_value) VALUES (?, ?, ?)", memberId,
+				themeId, UUID.randomUUID().toString());
+		UUID oldServiceTermId = insertTerm("SERVICE", "1.0", Instant.parse("2026-01-01T00:00:00Z"));
+		UUID currentServiceTermId = insertTerm("SERVICE", "2.0", Instant.parse("2026-08-01T00:00:00Z"));
+		UUID privacyTermId = insertTerm("PRIVACY", "1.0", Instant.parse("2026-01-01T00:00:00Z"));
+		insertConsent(memberId, oldServiceTermId, false);
+		insertConsent(memberId, currentServiceTermId, true);
+		insertConsent(memberId, privacyTermId, true);
+
+		mockMvc.perform(
+				get("/members/me").header("Authorization", "Bearer " + accessTokenService.issue(memberId, sessionId)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.displayName").value("부여여행자"))
+				.andExpect(jsonPath("$.data.characterId").value(characterId.toString()))
+				.andExpect(jsonPath("$.data.requiredTermsAgreed").value(true))
+				.andExpect(jsonPath("$.data.citizenCardIssued").value(true));
+	}
+
+	@Test
+	void accessTokenContainsMemberSessionAndOneHourLifetime() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		insertMember(memberId, "ACTIVE", Instant.now());
+		insertSession(sessionId, memberId, Instant.now().plus(30, ChronoUnit.DAYS), null);
+
+		Jwt jwt = jwtDecoder.decode(accessTokenService.issue(memberId, sessionId));
+
+		org.assertj.core.api.Assertions.assertThat(jwt.getSubject()).isEqualTo(memberId.toString());
+		org.assertj.core.api.Assertions.assertThat(jwt.getClaimAsString("sid")).isEqualTo(sessionId.toString());
+		org.assertj.core.api.Assertions.assertThat(Duration.between(jwt.getIssuedAt(), jwt.getExpiresAt()))
+				.isEqualTo(Duration.ofHours(1));
+	}
+
+	@Test
+	void missingMalformedInvalidSignatureAndExpiredTokensAreRejected() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		insertMember(memberId, "ACTIVE", Instant.now());
+		insertSession(sessionId, memberId, Instant.now().plus(30, ChronoUnit.DAYS), null);
+		String validToken = accessTokenService.issue(memberId, sessionId);
+		String changedLastCharacter = validToken.substring(0, validToken.length() - 1)
+				+ (validToken.endsWith("A") ? "B" : "A");
+
+		assertUnauthorized(null);
+		assertUnauthorized("not-a-jwt");
+		assertUnauthorized(changedLastCharacter);
+		assertUnauthorized(expiredToken(memberId, sessionId));
+	}
+
+	@Test
+	void missingExpiredAndRevokedSessionsAreRejected() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		insertMember(memberId, "ACTIVE", Instant.now());
+
+		assertUnauthorized(accessTokenService.issue(memberId, UUID.randomUUID()));
+
+		UUID expiredSessionId = UUID.randomUUID();
+		insertSession(expiredSessionId, memberId, Instant.now().minusSeconds(1), null);
+		assertUnauthorized(accessTokenService.issue(memberId, expiredSessionId));
+
+		UUID revokedSessionId = UUID.randomUUID();
+		insertSession(revokedSessionId, memberId, Instant.now().plusSeconds(3600), Instant.now());
+		assertUnauthorized(accessTokenService.issue(memberId, revokedSessionId));
+	}
+
+	@Test
+	void withdrawnMemberIsRejected() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("""
+				INSERT INTO members (id, status, created_at, withdrawn_at, purge_after)
+				VALUES (?, 'WITHDRAWN', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '30 days')
+				""", memberId);
+		insertSession(sessionId, memberId, Instant.now().plus(30, ChronoUnit.DAYS), null);
+
+		assertUnauthorized(accessTokenService.issue(memberId, sessionId));
+	}
+
+	@Test
+	void tokenCanOnlyReadItsOwnMember() throws Exception {
+		UUID authenticatedMemberId = UUID.randomUUID();
+		UUID otherMemberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		insertMember(authenticatedMemberId, "ACTIVE", Instant.now());
+		insertMember(otherMemberId, "ACTIVE", Instant.now());
+		insertSession(sessionId, authenticatedMemberId, Instant.now().plus(30, ChronoUnit.DAYS), null);
+
+		mockMvc.perform(get("/members/me").header("Authorization",
+				"Bearer " + accessTokenService.issue(authenticatedMemberId, sessionId))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.memberId").value(authenticatedMemberId.toString()))
+				.andExpect(jsonPath("$.data.memberId").value(org.hamcrest.Matchers.not(otherMemberId.toString())));
+	}
+
+	private void insertMember(UUID memberId, String status, Instant createdAt) {
+		jdbcTemplate.update("INSERT INTO members (id, status, created_at) VALUES (?, ?::member_status, ?)", memberId,
+				status, Timestamp.from(createdAt));
+	}
+
+	private void insertSession(UUID sessionId, UUID memberId, Instant expiresAt, Instant revokedAt) {
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions
+				    (id, member_id, refresh_token_hash, expires_at, revoked_at)
+				VALUES (?, ?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(), Timestamp.from(expiresAt),
+				revokedAt == null ? null : Timestamp.from(revokedAt));
+	}
+
+	private UUID insertTerm(String type, String version, Instant effectiveAt) {
+		UUID termId = UUID.randomUUID();
+		jdbcTemplate.update("""
+				INSERT INTO terms (id, type, version, required, title, content, effective_at)
+				VALUES (?, ?::term_type, ?, true, '약관', '내용', ?)
+				""", termId, type, version, Timestamp.from(effectiveAt));
+		return termId;
+	}
+
+	private void insertConsent(UUID memberId, UUID termId, boolean agreed) {
+		jdbcTemplate.update("INSERT INTO term_consents (member_id, term_id, agreed) VALUES (?, ?, ?)", memberId, termId,
+				agreed);
+	}
+
+	private String expiredToken(UUID memberId, UUID sessionId) {
+		Instant issuedAt = Instant.now().minus(1, ChronoUnit.HOURS).minusSeconds(1);
+		JwtClaimsSet claims = JwtClaimsSet.builder().subject(memberId.toString()).claim("sid", sessionId.toString())
+				.issuedAt(issuedAt).expiresAt(issuedAt.plus(1, ChronoUnit.HOURS)).build();
+		return jwtEncoder.encode(JwtEncoderParameters.from(JwsHeader.with(MacAlgorithm.HS256).build(), claims))
+				.getTokenValue();
+	}
+
+	private void assertUnauthorized(String token) throws Exception {
+		var request = get("/members/me");
+		if (token != null) {
+			request.header("Authorization", "Bearer " + token);
+		}
+		mockMvc.perform(request).andExpect(status().isUnauthorized()).andExpect(content().json("""
+				{"success":false,"data":{"code":"UNAUTHORIZED","message":"인증이 필요합니다."}}
+				"""));
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.flyway.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.flyway.user", POSTGIS::getUsername);
+		registry.add("spring.flyway.password", POSTGIS::getPassword);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("security.jwt.secret-base64", () -> JWT_SECRET);
+	}
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -7,3 +7,5 @@ spring.flyway.enabled=false
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.open-in-view=false
+
+security.jwt.secret-base64=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=


### PR DESCRIPTION
## 관련 이슈

- Closes #14
- Parent Epic: #12

## 변경 사항

- HS256 Access JWT 발급과 검증을 구현했습니다.
  - Access Token 수명 1시간
  - `sub` 회원 ID와 `sid` 인증 세션 ID 포함
  - 만료 즉시 거절
- Spring Security Bearer 인증을 구성했습니다.
  - 인증 세션 누락·만료·폐기 검증
  - 탈퇴 회원 접근 차단
  - OpenAPI 공통 형식의 `401 UNAUTHORIZED` 응답
- `GET /members/me`를 구현했습니다.
  - 회원과 프로필 조회
  - 현재 유효한 최신 필수 약관 동의 상태 조회
  - 군민증 발급 상태 조회
  - 인증된 회원 자신의 정보만 반환
- Docker와 애플리케이션 실행 환경에 `JWT_SECRET` 설정을 추가했습니다.
- PostgreSQL/PostGIS와 Spring Security를 통과하는 HTTP 통합 테스트를 추가했습니다.

## 사용자·개발자 영향

- 후속 소셜 로그인 및 Refresh Token 티켓에서 재사용할 Access Token 발급 seam이 생겼습니다.
- 인증이 필요한 API는 유효한 JWT뿐 아니라 활성 인증 세션과 활성 회원 상태까지 확인합니다.
- 로컬과 배포 환경에서 256비트 이상의 Base64 JWT 비밀 키가 필요합니다.

## 검증

- `./scripts/test/format.sh`
- `./scripts/test/static-check.sh`
- `./scripts/test/test.sh`
- `./scripts/test/docker-build.sh`
  - 공유 개발 DB가 아닌 임시 로컬 PostGIS로 검증
  - Docker 이미지 빌드, Flyway, Nginx, 헬스체크 통과

## 리뷰 포인트

- 요청마다 JWT의 `sid`와 `sub` 조합으로 활성 세션과 활성 회원을 확인합니다.
- 필수 약관 동의 여부는 약관 유형별 현재 시행 중인 최신 필수 버전을 기준으로 계산합니다.
