### PR TITLE
feat: 카카오 인증 정보 검증 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,8 @@ FLYWAY_PASSWORD=change-me
 # 32바이트 이상의 CSPRNG 값을 Base64로 인코딩한 HS256 서명 키.
 JWT_SECRET=replace-with-base64-encoded-256-bit-secret
 
+# 카카오 토큰 정보 API가 반환하는 숫자형 앱 ID. Native App Key나 비밀 키가 아니다.
+KAKAO_APP_ID=1234
+
 # Docker Compose exposes Nginx on this host port.
 HTTP_PORT=8080

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,7 @@ services:
       FLYWAY_USERNAME: ${FLYWAY_USERNAME:?FLYWAY_USERNAME is required}
       FLYWAY_PASSWORD: ${FLYWAY_PASSWORD:?FLYWAY_PASSWORD is required}
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
+      KAKAO_APP_ID: ${KAKAO_APP_ID:?KAKAO_APP_ID is required}
       JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS:--XX:MaxRAMPercentage=75.0}
     expose:
       - "8080"

--- a/src/main/java/com/buyeoon/member/auth/social/KakaoSocialAuthenticationConfiguration.java
+++ b/src/main/java/com/buyeoon/member/auth/social/KakaoSocialAuthenticationConfiguration.java
@@ -1,0 +1,28 @@
+package com.buyeoon.member.auth.social;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class KakaoSocialAuthenticationConfiguration {
+
+	@Bean
+	SocialCredentialVerifier kakaoSocialCredentialVerifier(@Value("${social.kakao.api-base-url}") String apiBaseUrl,
+			@Value("${social.kakao.app-id}") long appId,
+			@Value("${social.kakao.connect-timeout}") Duration connectTimeout,
+			@Value("${social.kakao.read-timeout}") Duration readTimeout) {
+		if (appId <= 0) {
+			throw new IllegalArgumentException("카카오 앱 ID는 양수여야 합니다.");
+		}
+		HttpClient httpClient = HttpClient.newBuilder().connectTimeout(connectTimeout).build();
+		JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
+		requestFactory.setReadTimeout(readTimeout);
+		RestClient.Builder restClientBuilder = RestClient.builder().baseUrl(apiBaseUrl).requestFactory(requestFactory);
+		return new KakaoSocialCredentialVerifier(restClientBuilder, appId);
+	}
+}

--- a/src/main/java/com/buyeoon/member/auth/social/KakaoSocialCredential.java
+++ b/src/main/java/com/buyeoon/member/auth/social/KakaoSocialCredential.java
@@ -1,0 +1,9 @@
+package com.buyeoon.member.auth.social;
+
+public record KakaoSocialCredential(String accessToken) implements SocialCredential {
+
+	@Override
+	public String toString() {
+		return "KakaoSocialCredential[accessToken=REDACTED]";
+	}
+}

--- a/src/main/java/com/buyeoon/member/auth/social/KakaoSocialCredentialVerifier.java
+++ b/src/main/java/com/buyeoon/member/auth/social/KakaoSocialCredentialVerifier.java
@@ -1,0 +1,77 @@
+package com.buyeoon.member.auth.social;
+
+import com.buyeoon.member.entity.SocialProvider;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+public class KakaoSocialCredentialVerifier implements SocialCredentialVerifier {
+
+	private static final String TOKEN_INFO_PATH = "/v1/user/access_token_info";
+	private static final Pattern ERROR_CODE = Pattern.compile("\\\"code\\\"\\s*:\\s*(-?\\d+)");
+
+	private final RestClient restClient;
+	private final long expectedAppId;
+
+	public KakaoSocialCredentialVerifier(RestClient.Builder restClientBuilder, long expectedAppId) {
+		this.restClient = restClientBuilder.build();
+		this.expectedAppId = expectedAppId;
+	}
+
+	@Override
+	public SocialProvider provider() {
+		return SocialProvider.KAKAO;
+	}
+
+	@Override
+	public VerifiedSocialIdentity verify(SocialCredential credential) {
+		if (!(credential instanceof KakaoSocialCredential kakaoCredential) || kakaoCredential.accessToken() == null
+				|| kakaoCredential.accessToken().isBlank()) {
+			throw new SocialAuthenticationFailedException();
+		}
+
+		KakaoAccessTokenInfo tokenInfo;
+		try {
+			tokenInfo = restClient.get().uri(TOKEN_INFO_PATH)
+					.headers(headers -> headers.setBearerAuth(kakaoCredential.accessToken())).retrieve()
+					.body(KakaoAccessTokenInfo.class);
+		} catch (HttpClientErrorException exception) {
+			if (exception.getStatusCode() == HttpStatus.BAD_REQUEST && kakaoErrorCode(exception) == -1) {
+				throw new SocialProviderUnavailableException(exception);
+			}
+			throw new SocialAuthenticationFailedException();
+		} catch (HttpServerErrorException exception) {
+			throw new SocialProviderUnavailableException(exception);
+		} catch (RestClientException exception) {
+			throw new SocialProviderUnavailableException(exception);
+		}
+
+		if (tokenInfo == null || tokenInfo.id() == null || tokenInfo.id() <= 0 || tokenInfo.appId() == null) {
+			throw new SocialProviderUnavailableException();
+		}
+		if (tokenInfo.expiresIn() == null || tokenInfo.expiresIn() <= 0 || tokenInfo.appId() != expectedAppId) {
+			throw new SocialAuthenticationFailedException();
+		}
+		return new VerifiedSocialIdentity(SocialProvider.KAKAO, tokenInfo.id().toString());
+	}
+
+	private int kakaoErrorCode(HttpClientErrorException exception) {
+		Matcher matcher = ERROR_CODE.matcher(exception.getResponseBodyAsString());
+		return matcher.find() ? Integer.parseInt(matcher.group(1)) : 0;
+	}
+
+	private record KakaoAccessTokenInfo(Long id, Long expires_in, Long app_id) {
+
+		private Long expiresIn() {
+			return expires_in;
+		}
+
+		private Long appId() {
+			return app_id;
+		}
+	}
+}

--- a/src/main/java/com/buyeoon/member/auth/social/SocialAuthenticationFailedException.java
+++ b/src/main/java/com/buyeoon/member/auth/social/SocialAuthenticationFailedException.java
@@ -1,0 +1,8 @@
+package com.buyeoon.member.auth.social;
+
+public class SocialAuthenticationFailedException extends RuntimeException {
+
+	public SocialAuthenticationFailedException() {
+		super("소셜 인증 정보가 유효하지 않습니다.");
+	}
+}

--- a/src/main/java/com/buyeoon/member/auth/social/SocialCredential.java
+++ b/src/main/java/com/buyeoon/member/auth/social/SocialCredential.java
@@ -1,0 +1,4 @@
+package com.buyeoon.member.auth.social;
+
+public interface SocialCredential {
+}

--- a/src/main/java/com/buyeoon/member/auth/social/SocialCredentialVerifier.java
+++ b/src/main/java/com/buyeoon/member/auth/social/SocialCredentialVerifier.java
@@ -1,0 +1,10 @@
+package com.buyeoon.member.auth.social;
+
+import com.buyeoon.member.entity.SocialProvider;
+
+public interface SocialCredentialVerifier {
+
+	SocialProvider provider();
+
+	VerifiedSocialIdentity verify(SocialCredential credential);
+}

--- a/src/main/java/com/buyeoon/member/auth/social/SocialProviderUnavailableException.java
+++ b/src/main/java/com/buyeoon/member/auth/social/SocialProviderUnavailableException.java
@@ -1,0 +1,12 @@
+package com.buyeoon.member.auth.social;
+
+public class SocialProviderUnavailableException extends RuntimeException {
+
+	public SocialProviderUnavailableException() {
+		super("소셜 인증 제공자를 일시적으로 사용할 수 없습니다.");
+	}
+
+	public SocialProviderUnavailableException(Throwable cause) {
+		super("소셜 인증 제공자를 일시적으로 사용할 수 없습니다.", cause);
+	}
+}

--- a/src/main/java/com/buyeoon/member/auth/social/VerifiedSocialIdentity.java
+++ b/src/main/java/com/buyeoon/member/auth/social/VerifiedSocialIdentity.java
@@ -1,0 +1,6 @@
+package com.buyeoon.member.auth.social;
+
+import com.buyeoon.member.entity.SocialProvider;
+
+public record VerifiedSocialIdentity(SocialProvider provider, String subject) {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,8 @@ spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 
 security.jwt.secret-base64=${JWT_SECRET}
+
+social.kakao.app-id=${KAKAO_APP_ID}
+social.kakao.api-base-url=${KAKAO_API_BASE_URL:https://kapi.kakao.com}
+social.kakao.connect-timeout=${KAKAO_CONNECT_TIMEOUT:2s}
+social.kakao.read-timeout=${KAKAO_READ_TIMEOUT:3s}

--- a/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
@@ -149,12 +149,14 @@ class MemberMeIntegrationTests {
 		insertMember(memberId, "ACTIVE", Instant.now());
 		insertSession(sessionId, memberId, Instant.now().plus(30, ChronoUnit.DAYS), null);
 		String validToken = accessTokenService.issue(memberId, sessionId);
-		String changedLastCharacter = validToken.substring(0, validToken.length() - 1)
-				+ (validToken.endsWith("A") ? "B" : "A");
+		int signatureStart = validToken.lastIndexOf('.') + 1;
+		char firstSignatureCharacter = validToken.charAt(signatureStart);
+		String changedSignature = validToken.substring(0, signatureStart) + (firstSignatureCharacter == 'A' ? 'B' : 'A')
+				+ validToken.substring(signatureStart + 1);
 
 		assertUnauthorized(null);
 		assertUnauthorized("not-a-jwt");
-		assertUnauthorized(changedLastCharacter);
+		assertUnauthorized(changedSignature);
 		assertUnauthorized(expiredToken(memberId, sessionId));
 	}
 

--- a/src/test/java/com/buyeoon/member/auth/social/KakaoSocialCredentialVerifierTests.java
+++ b/src/test/java/com/buyeoon/member/auth/social/KakaoSocialCredentialVerifierTests.java
@@ -1,0 +1,122 @@
+package com.buyeoon.member.auth.social;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withException;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.buyeoon.member.entity.SocialProvider;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class KakaoSocialCredentialVerifierTests {
+
+	private static final long EXPECTED_APP_ID = 1234L;
+	private static final String TOKEN = "kakao-access-token";
+	private static final String TOKEN_INFO_URL = "https://kapi.kakao.test/v1/user/access_token_info";
+
+	private MockRestServiceServer server;
+	private SocialCredentialVerifier verifier;
+
+	@BeforeEach
+	void setUp() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://kapi.kakao.test");
+		server = MockRestServiceServer.bindTo(builder).build();
+		verifier = new KakaoSocialCredentialVerifier(builder, EXPECTED_APP_ID);
+	}
+
+	@Test
+	void validAccessTokenReturnsVerifiedKakaoSubject() {
+		server.expect(once(), requestTo(TOKEN_INFO_URL)).andExpect(method(GET))
+				.andExpect(header("Authorization", "Bearer " + TOKEN)).andRespond(withSuccess("""
+						{"id":123456789,"expires_in":7199,"app_id":1234}
+						""", MediaType.APPLICATION_JSON));
+
+		VerifiedSocialIdentity identity = verifier.verify(new KakaoSocialCredential(TOKEN));
+
+		assertEquals(SocialProvider.KAKAO, verifier.provider());
+		assertEquals(SocialProvider.KAKAO, identity.provider());
+		assertEquals("123456789", identity.subject());
+		server.verify();
+	}
+
+	@Test
+	void tokenFromAnotherKakaoAppIsRejected() {
+		respondSuccess(123456789L, 7199L, 9999L);
+
+		assertThrows(SocialAuthenticationFailedException.class,
+				() -> verifier.verify(new KakaoSocialCredential(TOKEN)));
+		server.verify();
+	}
+
+	@Test
+	void expiredTokenIsRejected() {
+		respondSuccess(123456789L, 0L, EXPECTED_APP_ID);
+
+		assertThrows(SocialAuthenticationFailedException.class,
+				() -> verifier.verify(new KakaoSocialCredential(TOKEN)));
+		server.verify();
+	}
+
+	@Test
+	void kakaoAuthenticationRejectionIsClassifiedAsAuthenticationFailure() {
+		server.expect(requestTo(TOKEN_INFO_URL)).andRespond(withStatus(HttpStatus.UNAUTHORIZED)
+				.contentType(MediaType.APPLICATION_JSON).body("{\"msg\":\"invalid token\",\"code\":-401}"));
+
+		assertThrows(SocialAuthenticationFailedException.class,
+				() -> verifier.verify(new KakaoSocialCredential(TOKEN)));
+		server.verify();
+	}
+
+	@Test
+	void kakaoTemporaryFailureIsClassifiedAsProviderUnavailable() {
+		server.expect(requestTo(TOKEN_INFO_URL)).andRespond(withStatus(HttpStatus.BAD_REQUEST)
+				.contentType(MediaType.APPLICATION_JSON).body("{\"msg\":\"temporary failure\",\"code\":-1}"));
+
+		assertThrows(SocialProviderUnavailableException.class, () -> verifier.verify(new KakaoSocialCredential(TOKEN)));
+		server.verify();
+	}
+
+	@Test
+	void kakaoServerErrorIsClassifiedAsProviderUnavailable() {
+		server.expect(requestTo(TOKEN_INFO_URL)).andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
+
+		assertThrows(SocialProviderUnavailableException.class, () -> verifier.verify(new KakaoSocialCredential(TOKEN)));
+		server.verify();
+	}
+
+	@Test
+	void networkFailureIsClassifiedAsProviderUnavailableWithoutExposingToken() {
+		server.expect(requestTo(TOKEN_INFO_URL)).andRespond(withException(new IOException("connection reset")));
+
+		SocialProviderUnavailableException exception = assertThrows(SocialProviderUnavailableException.class,
+				() -> verifier.verify(new KakaoSocialCredential(TOKEN)));
+
+		assertFalse(exception.getMessage().contains(TOKEN));
+		server.verify();
+	}
+
+	@Test
+	void credentialStringDoesNotExposeAccessToken() {
+		KakaoSocialCredential credential = new KakaoSocialCredential(TOKEN);
+
+		assertFalse(credential.toString().contains(TOKEN));
+	}
+
+	private void respondSuccess(long id, long expiresIn, long appId) {
+		String response = "{\"id\":%d,\"expires_in\":%d,\"app_id\":%d}".formatted(id, expiresIn, appId);
+		server.expect(requestTo(TOKEN_INFO_URL)).andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+	}
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -9,3 +9,8 @@ spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.open-in-view=false
 
 security.jwt.secret-base64=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+
+social.kakao.app-id=1234
+social.kakao.api-base-url=https://kapi.kakao.test
+social.kakao.connect-timeout=2s
+social.kakao.read-timeout=3s


### PR DESCRIPTION
## 관련 이슈

- Closes #15
- Parent Epic: #12

## 변경 사항

- 소셜 인증 제공자 검증 공개 인터페이스와 검증된 provider subject 모델을 추가했습니다.
- 카카오 `GET /v1/user/access_token_info`를 호출하는 검증 어댑터를 구현했습니다.
  - 회원 식별자, 토큰 만료, 발급 앱 ID 검증
  - 다른 앱에서 발급된 토큰 거절
- 오류를 후속 로그인 API에서 사용할 수 있도록 구분했습니다.
  - 잘못되거나 만료된 토큰: `SocialAuthenticationFailedException`
  - 카카오 임시 장애, 5xx, 네트워크 오류: `SocialProviderUnavailableException`
- 토큰 원문이 자격 증명 문자열 표현에 노출되지 않도록 마스킹했습니다.
- `KAKAO_APP_ID`와 카카오 API 연결·응답 제한 시간 설정을 추가했습니다.
- 실제 카카오 서버 대신 제어 가능한 HTTP Stub을 사용하는 어댑터 계약 테스트를 추가했습니다.
- 검증 중 발견한 기존 JWT 위변조 테스트의 비결정적인 Base64URL 마지막 문자 변경을 첫 서명 문자 변경으로 안정화했습니다.

## 사용자·개발자 영향

- #16 소셜 로그인 구현에서 검증된 카카오 subject만 회원 조회·생성에 사용할 수 있습니다.
- 로컬 및 배포 환경에 숫자형 `KAKAO_APP_ID` 설정이 필요합니다. Native App Key나 비밀 키가 아닙니다.
- 자동 테스트에서는 실제 카카오 계정이나 토큰이 필요하지 않습니다.
- 실제 제공자 Smoke Test는 카카오 개발 앱 설정 후 별도로 수행합니다.

## 검증

- `./scripts/test/format.sh`
- `./scripts/test/static-check.sh`
  - 컴파일
  - Spotless
  - Checkstyle
  - SpotBugs
  - 전체 33개 테스트

## 리뷰 포인트

- 카카오 공식 토큰 정보 API의 `id`, `expires_in`, `app_id`를 모두 검증합니다.
- 카카오 오류 코드 `-1`과 5xx·네트워크 오류는 제공자 장애로 분류합니다.
- 외부 access token은 DB에 저장하거나 로그로 출력하지 않습니다.
- 이번 PR에는 `POST /auth/social-login`과 회원·인증 세션 생성이 포함되지 않습니다.
