### PR TITLE
feat: 리프레시 토큰 회전 구현

### DIFF
--- a/src/main/java/com/buyeoon/common/api/ErrorResponse.java
+++ b/src/main/java/com/buyeoon/common/api/ErrorResponse.java
@@ -1,0 +1,11 @@
+package com.buyeoon.common.api;
+
+public record ErrorResponse(boolean success, ErrorData data) {
+
+	public static ErrorResponse unauthorized() {
+		return new ErrorResponse(false, new ErrorData("UNAUTHORIZED", "인증이 필요합니다."));
+	}
+
+	public record ErrorData(String code, String message) {
+	}
+}

--- a/src/main/java/com/buyeoon/member/api/AuthController.java
+++ b/src/main/java/com/buyeoon/member/api/AuthController.java
@@ -1,0 +1,33 @@
+package com.buyeoon.member.api;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.member.application.RefreshTokenRotationService;
+import com.buyeoon.member.application.RefreshTokenRotationService.AuthResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+	private final RefreshTokenRotationService refreshTokenRotationService;
+
+	public AuthController(RefreshTokenRotationService refreshTokenRotationService) {
+		this.refreshTokenRotationService = refreshTokenRotationService;
+	}
+
+	@PostMapping("/refresh")
+	public SuccessResponse<AuthResult> refresh(@RequestBody RefreshTokenRequest request) {
+		return SuccessResponse.of(refreshTokenRotationService.rotate(request.refreshToken()));
+	}
+
+	public record RefreshTokenRequest(String refreshToken) {
+
+		@Override
+		public String toString() {
+			return "RefreshTokenRequest[refreshToken=REDACTED]";
+		}
+	}
+}

--- a/src/main/java/com/buyeoon/member/api/AuthExceptionHandler.java
+++ b/src/main/java/com/buyeoon/member/api/AuthExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.buyeoon.member.api;
+
+import com.buyeoon.common.api.ErrorResponse;
+import com.buyeoon.member.auth.InvalidRefreshTokenException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = AuthController.class)
+public class AuthExceptionHandler {
+
+	@ExceptionHandler(InvalidRefreshTokenException.class)
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	public ErrorResponse handleInvalidRefreshToken() {
+		return ErrorResponse.unauthorized();
+	}
+}

--- a/src/main/java/com/buyeoon/member/application/RefreshTokenRotationService.java
+++ b/src/main/java/com/buyeoon/member/application/RefreshTokenRotationService.java
@@ -1,0 +1,97 @@
+package com.buyeoon.member.application;
+
+import com.buyeoon.member.application.MemberQueryService.MemberView;
+import com.buyeoon.member.auth.AccessTokenService;
+import com.buyeoon.member.auth.InvalidRefreshTokenException;
+import com.buyeoon.member.auth.RefreshTokenService;
+import com.buyeoon.member.auth.RefreshTokenService.IssuedRefreshToken;
+import com.buyeoon.member.auth.RefreshTokenService.ParsedRefreshToken;
+import com.buyeoon.member.entity.MemberStatus;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RefreshTokenRotationService {
+
+	private final JdbcOperations jdbcOperations;
+	private final RefreshTokenService refreshTokenService;
+	private final AccessTokenService accessTokenService;
+	private final MemberQueryService memberQueryService;
+
+	public RefreshTokenRotationService(JdbcOperations jdbcOperations, RefreshTokenService refreshTokenService,
+			AccessTokenService accessTokenService, MemberQueryService memberQueryService) {
+		this.jdbcOperations = jdbcOperations;
+		this.refreshTokenService = refreshTokenService;
+		this.accessTokenService = accessTokenService;
+		this.memberQueryService = memberQueryService;
+	}
+
+	@Transactional
+	public AuthResult rotate(String rawRefreshToken) {
+		ParsedRefreshToken parsed = refreshTokenService.parse(rawRefreshToken);
+		SessionState session = lockSession(parsed.sessionId());
+		Instant now = Instant.now();
+		if (session.revokedAt() != null || !session.expiresAt().isAfter(now)
+				|| session.memberStatus() != MemberStatus.ACTIVE
+				|| !refreshTokenService.matches(session.refreshTokenHash(), parsed)) {
+			throw new InvalidRefreshTokenException();
+		}
+
+		IssuedRefreshToken issuedRefreshToken = refreshTokenService.issue(session.sessionId());
+		int updated = jdbcOperations.update("""
+				UPDATE auth_sessions
+				SET refresh_token_hash = ?, expires_at = ?
+				WHERE id = ?
+				""", issuedRefreshToken.hash(), Timestamp.from(issuedRefreshToken.expiresAt()), session.sessionId());
+		if (updated != 1) {
+			throw new IllegalStateException("인증 세션 갱신에 실패했습니다.");
+		}
+
+		MemberView member = memberQueryService.getActiveMember(session.memberId());
+		String accessToken = accessTokenService.issue(session.memberId(), session.sessionId());
+		return new AuthResult(accessToken, issuedRefreshToken.token(),
+				AccessTokenService.ACCESS_TOKEN_LIFETIME.toSeconds(), false, member);
+	}
+
+	private SessionState lockSession(UUID sessionId) {
+		return jdbcOperations.query("""
+				SELECT session.id,
+				       session.member_id,
+				       session.refresh_token_hash,
+				       session.expires_at,
+				       session.revoked_at,
+				       member.status::text AS member_status
+				FROM auth_sessions session
+				JOIN members member ON member.id = session.member_id
+				WHERE session.id = ?
+				FOR UPDATE OF session, member
+				""", this::mapSession, sessionId).stream().findFirst().orElseThrow(InvalidRefreshTokenException::new);
+	}
+
+	private SessionState mapSession(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new SessionState(resultSet.getObject("id", UUID.class), resultSet.getObject("member_id", UUID.class),
+				resultSet.getString("refresh_token_hash"), resultSet.getTimestamp("expires_at").toInstant(),
+				resultSet.getTimestamp("revoked_at") == null ? null : resultSet.getTimestamp("revoked_at").toInstant(),
+				MemberStatus.valueOf(resultSet.getString("member_status")));
+	}
+
+	public record AuthResult(String accessToken, String refreshToken, long expiresInSeconds, boolean isNewMember,
+			MemberView member) {
+
+		@Override
+		public String toString() {
+			return "AuthResult[accessToken=REDACTED, refreshToken=REDACTED, expiresInSeconds=" + expiresInSeconds
+					+ ", isNewMember=" + isNewMember + ", member=" + member + "]";
+		}
+	}
+
+	private record SessionState(UUID sessionId, UUID memberId, String refreshTokenHash, Instant expiresAt,
+			Instant revokedAt, MemberStatus memberStatus) {
+	}
+}

--- a/src/main/java/com/buyeoon/member/auth/InvalidRefreshTokenException.java
+++ b/src/main/java/com/buyeoon/member/auth/InvalidRefreshTokenException.java
@@ -1,0 +1,8 @@
+package com.buyeoon.member.auth;
+
+public class InvalidRefreshTokenException extends RuntimeException {
+
+	public InvalidRefreshTokenException() {
+		super("유효하지 않은 리프레시 토큰입니다.");
+	}
+}

--- a/src/main/java/com/buyeoon/member/auth/RefreshTokenService.java
+++ b/src/main/java/com/buyeoon/member/auth/RefreshTokenService.java
@@ -1,0 +1,82 @@
+package com.buyeoon.member.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RefreshTokenService {
+
+	public static final Duration REFRESH_TOKEN_LIFETIME = Duration.ofDays(30);
+	private static final int SECRET_BYTES = 32;
+
+	private final SecureRandom secureRandom = new SecureRandom();
+
+	public IssuedRefreshToken issue(UUID sessionId) {
+		byte[] secretBytes = new byte[SECRET_BYTES];
+		secureRandom.nextBytes(secretBytes);
+		String secret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+		return new IssuedRefreshToken(sessionId + "." + secret, hash(secret),
+				Instant.now().plus(REFRESH_TOKEN_LIFETIME));
+	}
+
+	public ParsedRefreshToken parse(String token) {
+		if (token == null) {
+			throw new InvalidRefreshTokenException();
+		}
+		int separator = token.indexOf('.');
+		if (separator <= 0 || separator != token.lastIndexOf('.')) {
+			throw new InvalidRefreshTokenException();
+		}
+
+		String sessionPart = token.substring(0, separator);
+		String secret = token.substring(separator + 1);
+		try {
+			UUID sessionId = UUID.fromString(sessionPart);
+			if (!sessionId.toString().equals(sessionPart) || secret.length() != 43
+					|| Base64.getUrlDecoder().decode(secret).length != SECRET_BYTES) {
+				throw new InvalidRefreshTokenException();
+			}
+			return new ParsedRefreshToken(sessionId, secret);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidRefreshTokenException();
+		}
+	}
+
+	public boolean matches(String storedHash, ParsedRefreshToken token) {
+		return storedHash != null && MessageDigest.isEqual(storedHash.getBytes(StandardCharsets.US_ASCII),
+				hash(token.secret()).getBytes(StandardCharsets.US_ASCII));
+	}
+
+	private String hash(String secret) {
+		try {
+			return HexFormat.of()
+					.formatHex(MessageDigest.getInstance("SHA-256").digest(secret.getBytes(StandardCharsets.UTF_8)));
+		} catch (NoSuchAlgorithmException exception) {
+			throw new IllegalStateException("SHA-256을 사용할 수 없습니다.", exception);
+		}
+	}
+
+	public record IssuedRefreshToken(String token, String hash, Instant expiresAt) {
+
+		@Override
+		public String toString() {
+			return "IssuedRefreshToken[token=REDACTED, hash=REDACTED, expiresAt=" + expiresAt + "]";
+		}
+	}
+
+	public record ParsedRefreshToken(UUID sessionId, String secret) {
+
+		@Override
+		public String toString() {
+			return "ParsedRefreshToken[sessionId=" + sessionId + ", secret=REDACTED]";
+		}
+	}
+}

--- a/src/test/java/com/buyeoon/member/RefreshTokenIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/RefreshTokenIntegrationTests.java
@@ -1,0 +1,307 @@
+package com.buyeoon.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class RefreshTokenIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_application";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+	private static final String JWT_SECRET = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=";
+	private static final String UNAUTHORIZED_RESPONSE = """
+			{"success":false,"data":{"code":"UNAUTHORIZED","message":"인증이 필요합니다."}}
+			""";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_migrator").withPassword("migrator-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private JwtDecoder jwtDecoder;
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM citizen_cards");
+		jdbcTemplate.update("DELETE FROM member_profiles");
+		jdbcTemplate.update("DELETE FROM term_consents");
+		jdbcTemplate.update("DELETE FROM terms");
+		jdbcTemplate.update("DELETE FROM card_characters");
+		jdbcTemplate.update("DELETE FROM card_themes");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	@Test
+	void validRefreshTokenRotatesBothTokensAndReturnsLatestMemberState() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		Instant createdAt = Instant.parse("2026-08-11T03:00:00Z");
+		RefreshFixture fixture = refreshFixture(sessionId, "initial");
+		insertMember(memberId, "ACTIVE", createdAt);
+		insertSession(sessionId, memberId, fixture.hash(), Instant.now().plus(30, ChronoUnit.DAYS), null);
+		Instant beforeRefresh = Instant.now();
+
+		MvcResult result = refresh(fixture.token()).andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.success").value(true)).andExpect(jsonPath("$.data.expiresInSeconds").value(3600))
+				.andExpect(jsonPath("$.data.isNewMember").value(false))
+				.andExpect(jsonPath("$.data.member.memberId").value(memberId.toString()))
+				.andExpect(jsonPath("$.data.member.status").value("ACTIVE"))
+				.andExpect(jsonPath("$.data.member.requiredTermsAgreed").value(false))
+				.andExpect(jsonPath("$.data.member.citizenCardIssued").value(false))
+				.andExpect(jsonPath("$.data.member.createdAt").value("2026-08-11T12:00:00+09:00")).andReturn();
+
+		String response = result.getResponse().getContentAsString();
+		String accessToken = JsonPath.read(response, "$.data.accessToken");
+		String refreshToken = JsonPath.read(response, "$.data.refreshToken");
+		assertThat(refreshToken).isNotEqualTo(fixture.token());
+		assertThat(refreshToken).startsWith(sessionId + ".");
+		String newSecret = refreshToken.substring(refreshToken.indexOf('.') + 1);
+		assertThat(Base64.getUrlDecoder().decode(newSecret)).hasSize(32);
+
+		SessionState state = sessionState(sessionId);
+		assertThat(state.refreshTokenHash()).isEqualTo(hash(newSecret));
+		assertThat(state.refreshTokenHash()).doesNotContain(refreshToken).doesNotContain(newSecret);
+		assertThat(state.expiresAt()).isAfter(beforeRefresh.plus(29, ChronoUnit.DAYS));
+		assertThat(state.expiresAt()).isBeforeOrEqualTo(Instant.now().plus(30, ChronoUnit.DAYS));
+
+		Jwt jwt = jwtDecoder.decode(accessToken);
+		assertThat(jwt.getSubject()).isEqualTo(memberId.toString());
+		assertThat(jwt.getClaimAsString("sid")).isEqualTo(sessionId.toString());
+		assertThat(Duration.between(jwt.getIssuedAt(), jwt.getExpiresAt())).isEqualTo(Duration.ofHours(1));
+	}
+
+	@Test
+	void rotatedTokenRejectsPreviousTokenWithoutRevokingSession() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		RefreshFixture fixture = refreshFixture(sessionId, "initial");
+		insertMember(memberId, "ACTIVE", Instant.now());
+		insertSession(sessionId, memberId, fixture.hash(), Instant.now().plus(30, ChronoUnit.DAYS), null);
+
+		String rotatedToken = JsonPath.read(
+				refresh(fixture.token()).andExpect(status().isOk()).andReturn().getResponse().getContentAsString(),
+				"$.data.refreshToken");
+
+		assertUnauthorized(fixture.token());
+		assertThat(sessionState(sessionId).revokedAt()).isNull();
+		refresh(rotatedToken).andExpect(status().isOk());
+	}
+
+	@Test
+	void malformedMismatchedExpiredAndRevokedRefreshTokensAreRejected() throws Exception {
+		assertUnauthorized("not-a-refresh-token");
+		assertUnauthorized(UUID.randomUUID() + ".short");
+		assertUnauthorized(UUID.randomUUID() + ".aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.extra");
+		mockMvc.perform(post("/auth/refresh").contentType(MediaType.APPLICATION_JSON).content("{}"))
+				.andExpect(status().isUnauthorized()).andExpect(content().json(UNAUTHORIZED_RESPONSE));
+
+		UUID memberId = UUID.randomUUID();
+		insertMember(memberId, "ACTIVE", Instant.now());
+
+		UUID mismatchSessionId = UUID.randomUUID();
+		RefreshFixture stored = refreshFixture(mismatchSessionId, "stored");
+		RefreshFixture mismatch = refreshFixture(mismatchSessionId, "other");
+		insertSession(mismatchSessionId, memberId, stored.hash(), Instant.now().plus(30, ChronoUnit.DAYS), null);
+		assertUnauthorized(mismatch.token());
+
+		UUID expiredSessionId = UUID.randomUUID();
+		RefreshFixture expired = refreshFixture(expiredSessionId, "expired");
+		insertSession(expiredSessionId, memberId, expired.hash(), Instant.now().minusSeconds(1), null);
+		assertUnauthorized(expired.token());
+
+		UUID revokedSessionId = UUID.randomUUID();
+		RefreshFixture revoked = refreshFixture(revokedSessionId, "revoked");
+		insertSession(revokedSessionId, memberId, revoked.hash(), Instant.now().plus(30, ChronoUnit.DAYS),
+				Instant.now());
+		assertUnauthorized(revoked.token());
+	}
+
+	@Test
+	void withdrawnMemberRefreshTokenIsRejected() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		RefreshFixture fixture = refreshFixture(sessionId, "withdrawn");
+		jdbcTemplate.update("""
+				INSERT INTO members (id, status, created_at, withdrawn_at, purge_after)
+				VALUES (?, 'WITHDRAWN', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '30 days')
+				""", memberId);
+		insertSession(sessionId, memberId, fixture.hash(), Instant.now().plus(30, ChronoUnit.DAYS), null);
+
+		assertUnauthorized(fixture.token());
+	}
+
+	@Test
+	void concurrentRefreshWithSameTokenSucceedsOnlyOnce() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		RefreshFixture fixture = refreshFixture(sessionId, "concurrent");
+		insertMember(memberId, "ACTIVE", Instant.now());
+		insertSession(sessionId, memberId, fixture.hash(), Instant.now().plus(30, ChronoUnit.DAYS), null);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+
+		try {
+			var request = (java.util.concurrent.Callable<MvcResult>) () -> {
+				ready.countDown();
+				start.await();
+				return refresh(fixture.token()).andReturn();
+			};
+			Future<MvcResult> first = executor.submit(request);
+			Future<MvcResult> second = executor.submit(request);
+			ready.await();
+			start.countDown();
+
+			List<Integer> statuses = List
+					.of(first.get().getResponse().getStatus(), second.get().getResponse().getStatus()).stream().sorted()
+					.toList();
+			assertThat(statuses).containsExactly(200, 401);
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	void failedRotationSaveKeepsPreviousTokenValid() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		RefreshFixture fixture = refreshFixture(sessionId, "rollback");
+		insertMember(memberId, "ACTIVE", Instant.now());
+		insertSession(sessionId, memberId, fixture.hash(), Instant.now().plus(30, ChronoUnit.DAYS), null);
+
+		executeAsMigrator("REVOKE UPDATE ON auth_sessions FROM buyeoon_application");
+		try {
+			assertThatThrownBy(() -> refresh(fixture.token()).andReturn())
+					.isInstanceOf(jakarta.servlet.ServletException.class);
+			assertThat(sessionState(sessionId).refreshTokenHash()).isEqualTo(fixture.hash());
+		} finally {
+			executeAsMigrator("GRANT UPDATE ON auth_sessions TO buyeoon_application");
+		}
+
+		refresh(fixture.token()).andExpect(status().isOk());
+	}
+
+	private org.springframework.test.web.servlet.ResultActions refresh(String refreshToken) throws Exception {
+		return mockMvc.perform(post("/auth/refresh").contentType(MediaType.APPLICATION_JSON)
+				.content("{\"refreshToken\":\"%s\"}".formatted(refreshToken)));
+	}
+
+	private void assertUnauthorized(String refreshToken) throws Exception {
+		refresh(refreshToken).andExpect(status().isUnauthorized()).andExpect(content().json(UNAUTHORIZED_RESPONSE));
+	}
+
+	private void insertMember(UUID memberId, String status, Instant createdAt) {
+		jdbcTemplate.update("INSERT INTO members (id, status, created_at) VALUES (?, ?::member_status, ?)", memberId,
+				status, Timestamp.from(createdAt));
+	}
+
+	private void insertSession(UUID sessionId, UUID memberId, String hash, Instant expiresAt, Instant revokedAt) {
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at, revoked_at)
+				VALUES (?, ?, ?, ?, ?)
+				""", sessionId, memberId, hash, Timestamp.from(expiresAt),
+				revokedAt == null ? null : Timestamp.from(revokedAt));
+	}
+
+	private SessionState sessionState(UUID sessionId) {
+		return jdbcTemplate.queryForObject("""
+				SELECT refresh_token_hash, expires_at, revoked_at
+				FROM auth_sessions
+				WHERE id = ?
+				""", (resultSet, rowNumber) -> new SessionState(resultSet.getString("refresh_token_hash"),
+				resultSet.getTimestamp("expires_at").toInstant(),
+				resultSet.getTimestamp("revoked_at") == null ? null : resultSet.getTimestamp("revoked_at").toInstant()),
+				sessionId);
+	}
+
+	private RefreshFixture refreshFixture(UUID sessionId, String salt) throws Exception {
+		byte[] secretBytes = MessageDigest.getInstance("SHA-256")
+				.digest((sessionId + salt).getBytes(StandardCharsets.UTF_8));
+		String secret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+		return new RefreshFixture(sessionId + "." + secret, hash(secret));
+	}
+
+	private String hash(String secret) throws Exception {
+		return HexFormat.of()
+				.formatHex(MessageDigest.getInstance("SHA-256").digest(secret.getBytes(StandardCharsets.UTF_8)));
+	}
+
+	private void executeAsMigrator(String sql) throws SQLException {
+		try (var connection = DriverManager.getConnection(POSTGIS.getJdbcUrl(), POSTGIS.getUsername(),
+				POSTGIS.getPassword()); var statement = connection.createStatement()) {
+			statement.execute(sql);
+		}
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.flyway.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.flyway.user", POSTGIS::getUsername);
+		registry.add("spring.flyway.password", POSTGIS::getPassword);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("security.jwt.secret-base64", () -> JWT_SECRET);
+	}
+
+	private record RefreshFixture(String token, String hash) {
+	}
+
+	private record SessionState(String refreshTokenHash, Instant expiresAt, Instant revokedAt) {
+	}
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #17
- Parent Epic: #12

## 변경 사항

- `POST /auth/refresh`를 구현했습니다.
- Refresh Token을 `sessionId.randomSecret` 형식으로 발급합니다.
  - `randomSecret`은 CSPRNG 256비트
  - 토큰 수명 30일
  - DB에는 SHA-256 해시만 저장
- 인증 세션과 회원 행을 `SELECT ... FOR UPDATE`로 잠근 뒤 토큰을 회전합니다.
- 새 Access Token과 Refresh Token, 최신 회원·온보딩 상태를 반환합니다.
- 형식 오류, 해시 불일치, 만료·폐기 세션과 탈퇴 회원을 `401 UNAUTHORIZED`로 처리합니다.
- 이전 Refresh Token 재사용은 거절하되 세션 전체를 자동 폐기하지 않습니다.
- 요청·응답·내부 토큰 객체의 문자열 표현에서 토큰 원문을 마스킹했습니다.

## 동시성 및 롤백

- 동일 Refresh Token의 동시 요청은 DB 행 잠금으로 하나만 성공하고 나머지는 `401`입니다.
- DB 저장 실패 시 트랜잭션을 롤백해 기존 해시와 기존 Refresh Token 유효성을 유지합니다.
- 저장 실패 검증은 테스트 DB에서 애플리케이션 역할의 UPDATE 권한을 일시 회수하는 방식으로 실제 PostgreSQL 오류를 재현했습니다.

## 사용자·개발자 영향

- #16 소셜 로그인 구현에서 초기 인증 세션과 Refresh Token 발급 seam을 재사용할 수 있습니다.
- Flutter는 갱신 성공 시 Access Token과 Refresh Token을 모두 교체해야 합니다.
- Refresh Token 원문은 DB에 저장되지 않습니다.

## 검증

- `./scripts/test/format.sh`
- `./scripts/test/static-check.sh`
- `./scripts/test/test.sh --tests com.buyeoon.member.RefreshTokenIntegrationTests`
- `./scripts/test/docker-build.sh`
  - 공유 DB가 아닌 임시 로컬 PostGIS 사용
  - Docker 이미지, Flyway, 애플리케이션, Nginx, 헬스체크 통과
- 전체 30개 테스트 통과

## 리뷰 포인트

- 토큰 해시는 전체 토큰이 아닌 `randomSecret`의 SHA-256 값입니다.
- 회전 시 세션 만료 시각도 현재 시각 기준 30일로 갱신합니다.
- 로그인·신규 회원 생성, 로그아웃, Refresh Token family 탐지는 이번 범위에 포함하지 않습니다.
