### PR TITLE
feat: 군민증 선택지 조회와 발급 기반 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,5 +16,9 @@ APPLE_TEAM_ID=ABCDEFGHIJ
 APPLE_KEY_ID=1234567890
 APPLE_PRIVATE_KEY_BASE64=replace-with-base64-encoded-p8-key
 
+# Private S3 Bucket. EC2 Instance Role provides credentials in production.
+IMAGE_BUCKET=buyeoon-prod-images
+AWS_REGION=ap-northeast-2
+
 # Docker Compose exposes Nginx on this host port.
 HTTP_PORT=8080

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'org.hibernate.orm:hibernate-spatial'
+    implementation 'software.amazon.awssdk:s3:2.47.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,8 @@ services:
       APPLE_TEAM_ID: ${APPLE_TEAM_ID:?APPLE_TEAM_ID is required}
       APPLE_KEY_ID: ${APPLE_KEY_ID:?APPLE_KEY_ID is required}
       APPLE_PRIVATE_KEY_BASE64: ${APPLE_PRIVATE_KEY_BASE64:?APPLE_PRIVATE_KEY_BASE64 is required}
+      IMAGE_BUCKET: ${IMAGE_BUCKET:-}
+      AWS_REGION: ${AWS_REGION:-ap-northeast-2}
       JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS:--XX:MaxRAMPercentage=75.0}
     expose:
       - "8080"

--- a/src/main/java/com/buyeoon/common/storage/PublicImageUrlService.java
+++ b/src/main/java/com/buyeoon/common/storage/PublicImageUrlService.java
@@ -1,0 +1,43 @@
+package com.buyeoon.common.storage;
+
+import jakarta.annotation.PreDestroy;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+@Service
+public class PublicImageUrlService {
+
+	private static final Duration VALIDITY = Duration.ofMinutes(10);
+
+	private final String bucket;
+	private final S3Presigner presigner;
+
+	public PublicImageUrlService(@Value("${storage.images.bucket:}") String bucket,
+			@Value("${storage.images.region:ap-northeast-2}") String region) {
+		this.bucket = bucket;
+		this.presigner = S3Presigner.builder().region(Region.of(region)).build();
+	}
+
+	public String create(String imageKey) {
+		if (bucket.isBlank()) {
+			throw new IllegalStateException("IMAGE_BUCKET 설정이 필요합니다.");
+		}
+		if (!imageKey.startsWith("public/")) {
+			throw new IllegalArgumentException("공개 이미지 객체 키가 아닙니다.");
+		}
+		GetObjectRequest objectRequest = GetObjectRequest.builder().bucket(bucket).key(imageKey).build();
+		return presigner.presignGetObject(
+				GetObjectPresignRequest.builder().signatureDuration(VALIDITY).getObjectRequest(objectRequest).build())
+				.url().toExternalForm();
+	}
+
+	@PreDestroy
+	void close() {
+		presigner.close();
+	}
+}

--- a/src/main/java/com/buyeoon/member/api/CitizenCardController.java
+++ b/src/main/java/com/buyeoon/member/api/CitizenCardController.java
@@ -1,0 +1,22 @@
+package com.buyeoon.member.api;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.member.application.CitizenCardQueryService;
+import com.buyeoon.member.application.CitizenCardQueryService.CitizenCardOptionsView;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CitizenCardController {
+
+	private final CitizenCardQueryService citizenCards;
+
+	public CitizenCardController(CitizenCardQueryService citizenCards) {
+		this.citizenCards = citizenCards;
+	}
+
+	@GetMapping("/citizen-cards/options")
+	public SuccessResponse<CitizenCardOptionsView> getOptions() {
+		return SuccessResponse.of(citizenCards.getOptions());
+	}
+}

--- a/src/main/java/com/buyeoon/member/application/CitizenCardQueryService.java
+++ b/src/main/java/com/buyeoon/member/application/CitizenCardQueryService.java
@@ -1,0 +1,44 @@
+package com.buyeoon.member.application;
+
+import com.buyeoon.common.storage.PublicImageUrlService;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CitizenCardQueryService {
+
+	private final JdbcOperations jdbcOperations;
+	private final PublicImageUrlService imageUrls;
+
+	public CitizenCardQueryService(JdbcOperations jdbcOperations, PublicImageUrlService imageUrls) {
+		this.jdbcOperations = jdbcOperations;
+		this.imageUrls = imageUrls;
+	}
+
+	public CitizenCardOptionsView getOptions() {
+		List<CardOptionView> characters = jdbcOperations
+				.query("SELECT id, name, image_key FROM card_characters ORDER BY sort_order", this::mapOption);
+		List<CardOptionView> themes = jdbcOperations
+				.query("SELECT id, name, image_key FROM card_themes ORDER BY sort_order", this::mapOption);
+		return new CitizenCardOptionsView(characters, themes);
+	}
+
+	private CardOptionView mapOption(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new CardOptionView(resultSet.getObject("id", UUID.class), resultSet.getString("name"),
+				imageUrls.create(resultSet.getString("image_key")));
+	}
+
+	public record CitizenCardOptionsView(List<CardOptionView> characters, List<CardOptionView> themes) {
+		public CitizenCardOptionsView {
+			characters = List.copyOf(characters);
+			themes = List.copyOf(themes);
+		}
+	}
+
+	public record CardOptionView(UUID id, String name, String imageUrl) {
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,3 +27,6 @@ social.apple.api-base-url=${APPLE_API_BASE_URL:https://appleid.apple.com}
 social.apple.client-secret-ttl=${APPLE_CLIENT_SECRET_TTL:5m}
 social.apple.connect-timeout=${APPLE_CONNECT_TIMEOUT:2s}
 social.apple.read-timeout=${APPLE_READ_TIMEOUT:3s}
+
+storage.images.bucket=${IMAGE_BUCKET:}
+storage.images.region=${AWS_REGION:ap-northeast-2}

--- a/src/main/resources/db/migration/V7__add_citizen_card_constraints.sql
+++ b/src/main/resources/db/migration/V7__add_citizen_card_constraints.sql
@@ -1,0 +1,44 @@
+ALTER TABLE card_characters ADD COLUMN sort_order smallint;
+ALTER TABLE card_themes ADD COLUMN sort_order smallint;
+
+WITH ranked AS (
+    SELECT id, row_number() OVER (ORDER BY id)::smallint AS sort_order
+    FROM card_characters
+)
+UPDATE card_characters character
+SET sort_order = ranked.sort_order
+FROM ranked
+WHERE character.id = ranked.id;
+
+WITH ranked AS (
+    SELECT id, row_number() OVER (ORDER BY id)::smallint AS sort_order
+    FROM card_themes
+)
+UPDATE card_themes theme
+SET sort_order = ranked.sort_order
+FROM ranked
+WHERE theme.id = ranked.id;
+
+ALTER TABLE card_characters ALTER COLUMN sort_order SET NOT NULL;
+ALTER TABLE card_characters ADD CONSTRAINT card_characters_sort_order_ck CHECK (sort_order > 0);
+ALTER TABLE card_characters ADD CONSTRAINT card_characters_sort_order_uq UNIQUE (sort_order);
+
+ALTER TABLE card_themes ALTER COLUMN sort_order SET NOT NULL;
+ALTER TABLE card_themes ADD CONSTRAINT card_themes_sort_order_ck CHECK (sort_order > 0);
+ALTER TABLE card_themes ADD CONSTRAINT card_themes_sort_order_uq UNIQUE (sort_order);
+
+ALTER TABLE member_profiles DROP CONSTRAINT member_profiles_display_name_check;
+ALTER TABLE member_profiles ADD CONSTRAINT member_profiles_display_name_ck CHECK (
+    char_length(display_name) BETWEEN 1 AND 8
+    AND display_name = btrim(display_name)
+    AND display_name !~ '[[:cntrl:]]'
+);
+
+-- MVP 운영 전 마이그레이션이며 기존 시연 값은 UUID 바코드로 교체한다.
+UPDATE citizen_cards
+SET barcode_value = gen_random_uuid()::text
+WHERE barcode_value !~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$';
+
+ALTER TABLE citizen_cards ADD CONSTRAINT citizen_cards_barcode_value_ck CHECK (
+    barcode_value ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+);

--- a/src/test/java/com/buyeoon/member/CitizenCardOptionsIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/CitizenCardOptionsIntegrationTests.java
@@ -1,0 +1,171 @@
+package com.buyeoon.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import java.net.URI;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class CitizenCardOptionsIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeAll
+	static void configureAwsCredentials() {
+		System.setProperty("aws.accessKeyId", "test-access-key");
+		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	@AfterAll
+	static void clearAwsCredentials() {
+		System.clearProperty("aws.accessKeyId");
+		System.clearProperty("aws.secretAccessKey");
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+		jdbcTemplate.update("DELETE FROM card_characters");
+		jdbcTemplate.update("DELETE FROM card_themes");
+	}
+
+	/** 승인된 캐릭터와 테마를 정해진 순서와 10분 유효 이미지 URL로 반환한다. */
+	@Test
+	@DisplayName("군민증 선택지는 표시 순서와 임시 이미지 URL을 포함한다")
+	void optionsAreOrderedAndContainPresignedImageUrls() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		insertCharacter("둘째", "public/characters/second.webp", 2);
+		insertCharacter("첫째", "public/characters/first.webp", 1);
+		insertTheme("둘째 테마", "public/themes/second.webp", 2);
+		insertTheme("첫째 테마", "public/themes/first.webp", 1);
+
+		// 실제 인증 HTTP 응답의 순서와 S3 서명 만료 시간을 함께 검증한다.
+		MvcResult result = mockMvc
+				.perform(get("/citizen-cards/options").header("Authorization", "Bearer " + member.accessToken()))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.characters[0].name").value("첫째"))
+				.andExpect(jsonPath("$.data.characters[1].name").value("둘째"))
+				.andExpect(jsonPath("$.data.themes[0].name").value("첫째 테마"))
+				.andExpect(jsonPath("$.data.themes[1].name").value("둘째 테마")).andReturn();
+
+		JsonNode data = objectMapper.readTree(result.getResponse().getContentAsString()).get("data");
+		assertPresignedUrl(data.get("characters").get(0).get("imageUrl").stringValue(),
+				"/public/characters/first.webp");
+		assertPresignedUrl(data.get("themes").get(0).get("imageUrl").stringValue(), "/public/themes/first.webp");
+	}
+
+	/** 선택지 API는 활성 인증 세션이 없으면 사용할 수 없다. */
+	@Test
+	@DisplayName("군민증 선택지 조회에는 인증이 필요하다")
+	void authenticationIsRequired() throws Exception {
+		// 인증 헤더 없는 요청은 보안 필터에서 401로 거부한다.
+		mockMvc.perform(get("/citizen-cards/options")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** 카탈로그 표시 순서는 양수이며 같은 카탈로그 안에서 중복될 수 없다. */
+	@Test
+	@DisplayName("카탈로그 표시 순서는 양수이고 중복될 수 없다")
+	void sortOrderConstraintsAreEnforced() {
+		insertCharacter("첫째", "public/characters/first.webp", 1);
+
+		// 실제 PostgreSQL 제약이 중복과 0 이하 값을 거부하는지 확인한다.
+		assertThatThrownBy(() -> insertCharacter("중복", "public/characters/duplicate.webp", 1))
+				.isInstanceOf(Exception.class);
+		assertThatThrownBy(() -> insertTheme("잘못된 순서", "public/themes/invalid.webp", 0)).isInstanceOf(Exception.class);
+	}
+
+	private void assertPresignedUrl(String value, String expectedPath) {
+		URI uri = URI.create(value);
+		assertThat(uri.getHost()).isEqualTo("buyeoon-test-images.s3.ap-northeast-2.amazonaws.com");
+		assertThat(uri.getPath()).isEqualTo(expectedPath);
+		assertThat(uri.getQuery()).contains("X-Amz-Expires=600");
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(accessTokenService.issue(memberId, sessionId));
+	}
+
+	private void insertCharacter(String name, String imageKey, int sortOrder) {
+		jdbcTemplate.update("INSERT INTO card_characters (name, image_key, sort_order) VALUES (?, ?, ?)", name,
+				imageKey, sortOrder);
+	}
+
+	private void insertTheme(String name, String imageKey, int sortOrder) {
+		jdbcTemplate.update("INSERT INTO card_themes (name, image_key, sort_order) VALUES (?, ?, ?)", name, imageKey,
+				sortOrder);
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("storage.images.bucket", () -> "buyeoon-test-images");
+		registry.add("storage.images.region", () -> "ap-northeast-2");
+	}
+
+	private record AuthenticatedMember(String accessToken) {
+	}
+}

--- a/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
@@ -77,8 +77,8 @@ class MemberMeIntegrationTests {
 	}
 
 	/**
-	 * 프로필을 생성하지 않은 ACTIVE 회원이 GET /members/me를 호출하면
-	 * displayName, characterId는 null이고 requiredTermsAgreed, citizenCardIssued는 false로 반환된다.
+	 * 프로필을 생성하지 않은 ACTIVE 회원이 GET /members/me를 호출하면 displayName, characterId는
+	 * null이고 requiredTermsAgreed, citizenCardIssued는 false로 반환된다.
 	 */
 	@Test
 	@DisplayName("프로필이 없는 활성 회원은 초기 온보딩 상태를 반환한다")
@@ -103,8 +103,8 @@ class MemberMeIntegrationTests {
 	}
 
 	/**
-	 * 프로필, 약관 동의, 군민증이 모두 설정된 회원이 GET /members/me를 호출하면
-	 * displayName, characterId, requiredTermsAgreed, citizenCardIssued가 모두 최신 상태로 반환된다.
+	 * 프로필, 약관 동의, 군민증이 모두 설정된 회원이 GET /members/me를 호출하면 displayName, characterId,
+	 * requiredTermsAgreed, citizenCardIssued가 모두 최신 상태로 반환된다.
 	 */
 	@Test
 	@DisplayName("최신 프로필·약관·군민증 상태를 반환한다")
@@ -115,11 +115,14 @@ class MemberMeIntegrationTests {
 		UUID themeId = UUID.randomUUID();
 		insertMember(memberId, "ACTIVE", Instant.parse("2026-08-01T00:00:00Z"));
 		insertSession(sessionId, memberId, Instant.now().plus(30, ChronoUnit.DAYS), null);
-		jdbcTemplate.update(
-				"INSERT INTO card_characters (id, name, image_key) VALUES (?, '금동이', 'public/characters/geumdong.webp')",
-				characterId);
-		jdbcTemplate.update(
-				"INSERT INTO card_themes (id, name, image_key) VALUES (?, '백제', 'public/themes/baekje.webp')", themeId);
+		jdbcTemplate.update("""
+				INSERT INTO card_characters (id, name, image_key, sort_order)
+				VALUES (?, '금동이', 'public/characters/geumdong.webp', 1)
+				""", characterId);
+		jdbcTemplate.update("""
+				INSERT INTO card_themes (id, name, image_key, sort_order)
+				VALUES (?, '백제', 'public/themes/baekje.webp', 1)
+				""", themeId);
 		jdbcTemplate.update(
 				"INSERT INTO member_profiles (member_id, display_name, character_id) VALUES (?, '부여여행자', ?)", memberId,
 				characterId);
@@ -141,8 +144,8 @@ class MemberMeIntegrationTests {
 	}
 
 	/**
-	 * 발급된 액세스 토큰을 JWT 디코딩하면 subject에 memberId,
-	 * sid 클레임에 sessionId가 포함되고 만료 시간이 정확히 1시간이다.
+	 * 발급된 액세스 토큰을 JWT 디코딩하면 subject에 memberId, sid 클레임에 sessionId가 포함되고 만료 시간이 정확히
+	 * 1시간이다.
 	 */
 	@Test
 	@DisplayName("액세스 토큰은 회원 ID·세션 ID·1시간 만료를 포함한다")
@@ -161,8 +164,7 @@ class MemberMeIntegrationTests {
 	}
 
 	/**
-	 * Authorization 헤더가 없거나, JWT 형식이 아니거나, 서명이 변조되었거나,
-	 * 만료된 액세스 토큰은 모두 401로 거부된다.
+	 * Authorization 헤더가 없거나, JWT 형식이 아니거나, 서명이 변조되었거나, 만료된 액세스 토큰은 모두 401로 거부된다.
 	 */
 	@Test
 	@DisplayName("없음·형식 오류·서명 불일치·만료된 액세스 토큰은 거부된다")
@@ -184,8 +186,7 @@ class MemberMeIntegrationTests {
 	}
 
 	/**
-	 * 액세스 토큰의 sid가 DB에 존재하지 않거나, 해당 세션이 만료되었거나,
-	 * revoked_at이 설정되어 있으면 401로 거부된다.
+	 * 액세스 토큰의 sid가 DB에 존재하지 않거나, 해당 세션이 만료되었거나, revoked_at이 설정되어 있으면 401로 거부된다.
 	 */
 	@Test
 	@DisplayName("세션 없음·만료·폐기된 액세스 토큰은 거부된다")
@@ -205,8 +206,7 @@ class MemberMeIntegrationTests {
 	}
 
 	/**
-	 * 회원 상태가 WITHDRAWN이면 유효한 액세스 토큰으로
-	 * GET /members/me를 호출해도 401로 거부된다.
+	 * 회원 상태가 WITHDRAWN이면 유효한 액세스 토큰으로 GET /members/me를 호출해도 401로 거부된다.
 	 */
 	@Test
 	@DisplayName("탈퇴 회원의 액세스 토큰은 거부된다")
@@ -223,8 +223,8 @@ class MemberMeIntegrationTests {
 	}
 
 	/**
-	 * 액세스 토큰으로 GET /members/me를 호출하면 응답의 memberId는
-	 * 반드시 토큰에 포함된 회원의 ID와 일치하고 다른 회원의 ID는 반환되지 않는다.
+	 * 액세스 토큰으로 GET /members/me를 호출하면 응답의 memberId는 반드시 토큰에 포함된 회원의 ID와 일치하고 다른 회원의
+	 * ID는 반환되지 않는다.
 	 */
 	@Test
 	@DisplayName("토큰은 자신의 회원 정보만 조회할 수 있다")

--- a/src/test/java/com/buyeoon/persistence/SchemaMappingTests.java
+++ b/src/test/java/com/buyeoon/persistence/SchemaMappingTests.java
@@ -27,6 +27,8 @@ class SchemaMappingTests {
 			.of("src/main/resources/db/migration/V3__align_mission_constraints.sql");
 	private static final Path PUBLIC_IMAGE_KEYS_MIGRATION = Path
 			.of("src/main/resources/db/migration/V5__replace_public_image_urls_with_keys.sql");
+	private static final Path CITIZEN_CARD_CONSTRAINTS_MIGRATION = Path
+			.of("src/main/resources/db/migration/V7__add_citizen_card_constraints.sql");
 	private static final Pattern CREATE_TABLE = Pattern.compile("CREATE TABLE ([a-z_]+) ");
 
 	/** 초기 스키마에 후속 마이그레이션을 적용한 정의가 기준 DB 스키마와 같음을 보장한다. */
@@ -53,15 +55,36 @@ class SchemaMappingTests {
 				"    CHECK (", "        (type = 'OX' AND ox_correct_answer IS NOT NULL)",
 				"        OR (type <> 'OX' AND ox_correct_answer IS NULL)", "    ),",
 				"    CHECK (type <> 'PHOTO' OR max_attempts IS NULL)", ");");
+		String imageKeyConstraint = "image_key text NOT NULL CHECK (image_key LIKE 'public/%'),";
+		String characterImageKeyColumn = imageKeyConstraint + " -- 캐릭터 이미지 객체 키";
+		String themeImageKeyColumn = imageKeyConstraint + " -- 테마 이미지 객체 키";
+		String sortOrderColumn = "    sort_order smallint NOT NULL UNIQUE CHECK (sort_order > 0)";
+		String displayNameConstraintEnd = "    )," + " -- 앞뒤 공백과 제어문자가 없는 표시 이름";
 		String publicImageKeySchema = baseline
+				.replace("expires_at timestamptz NOT NULL, -- 키 보관 만료 시각",
+						"expires_at timestamptz NOT NULL, -- 최초 성공 확정 시각부터 24시간인 키 보관 만료 시각")
+				.replace("    UNIQUE (type, version)\n);",
+						"    UNIQUE (type, version),\n    UNIQUE (type, effective_at)\n);")
 				.replace("image_url text NOT NULL -- 캐릭터 이미지 URL",
-						"image_key text NOT NULL CHECK (image_key LIKE 'public/%') -- 캐릭터 이미지 객체 키")
+						String.join("\n", characterImageKeyColumn, sortOrderColumn + " -- 화면 표시 순서"))
 				.replace("image_url text NOT NULL -- 테마 이미지 URL",
-						"image_key text NOT NULL CHECK (image_key LIKE 'public/%') -- 테마 이미지 객체 키")
+						String.join("\n", themeImageKeyColumn, sortOrderColumn + " -- 화면 표시 순서"))
 				.replace("image_url text, -- 대표 이미지 URL",
 						"image_key text CHECK (image_key IS NULL OR image_key LIKE 'public/%'), -- 대표 이미지 객체 키")
 				.replace("image_url text, -- 배지 이미지 URL",
-						"image_key text CHECK (image_key IS NULL OR image_key LIKE 'public/%'), -- 배지 이미지 객체 키");
+						"image_key text CHECK (image_key IS NULL OR image_key LIKE 'public/%'), -- 배지 이미지 객체 키")
+				.replace(
+						"display_name varchar(8) NOT NULL CHECK (char_length(display_name) BETWEEN 1 AND 8),"
+								+ " -- 표시 이름",
+						String.join("\n", "display_name varchar(8) NOT NULL CHECK (",
+								"        char_length(display_name) BETWEEN 1 AND 8",
+								"        AND display_name = btrim(display_name)",
+								"        AND display_name !~ '[[:cntrl:]]'", displayNameConstraintEnd))
+				.replace("barcode_value text NOT NULL UNIQUE, -- 시연용 바코드 값",
+						String.join("\n", "barcode_value text NOT NULL UNIQUE CHECK (",
+								"        barcode_value ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}"
+										+ "-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'",
+								"    ), -- UUID 형식의 시연용 바코드 값"));
 
 		assertThat(baseline).contains(placeSourceColumns).contains(placeLocationIndex).contains(legacyMissionStatus)
 				.contains(legacyMissionConstraints);
@@ -114,6 +137,20 @@ class SchemaMappingTests {
 		assertThat(migration).contains("RENAME COLUMN image_url TO image_key")
 				.contains("Public image URLs must be replaced with public/ S3 object keys before V5")
 				.contains("CHECK (image_key LIKE 'public/%')");
+	}
+
+	/** 군민증 카탈로그, 표시 이름과 바코드 제약이 기준 스키마와 업그레이드 경로에 함께 존재하는지 검증한다. */
+	@Test
+	@DisplayName("군민증 발급 기반 제약은 기준 스키마와 마이그레이션에 정의되어 있다")
+	void citizenCardConstraintsAreDefinedInSchemaAndMigration() throws IOException {
+		String canonicalSchema = Files.readString(SCHEMA_SOURCE, StandardCharsets.UTF_8);
+		String migration = Files.readString(CITIZEN_CARD_CONSTRAINTS_MIGRATION, StandardCharsets.UTF_8);
+
+		assertThat(canonicalSchema).contains("sort_order smallint NOT NULL UNIQUE CHECK (sort_order > 0)")
+				.contains("display_name = btrim(display_name)").contains("citizen_cards")
+				.contains("barcode_value ~ '^[0-9a-f]");
+		assertThat(migration).contains("card_characters_sort_order_uq").contains("member_profiles_display_name_ck")
+				.contains("citizen_cards_barcode_value_ck");
 	}
 
 	/** 기준 스키마의 테이블과 JPA 엔티티가 누락이나 잉여 매핑 없이 일대일로 대응함을 보장한다. */


### PR DESCRIPTION
## 변경 사항
- 군민증 캐릭터·테마 선택지 조회 API를 구현했습니다.
- 비공개 S3 객체 키를 10분 유효 임시 URL로 변환합니다.
- 카탈로그 표시 순서, 표시 이름, UUID 바코드 DB 제약을 추가했습니다.
- 실제 PostgreSQL·Flyway·JWT 기반 통합 테스트를 추가했습니다.
- Docker 환경에 이미지 저장소 설정을 전달합니다.

## 검증
- `./scripts/test/format.sh`
- `./scripts/test/static-check.sh`
- `./scripts/test/test.sh`
- 테스트 설정을 사용한 `./scripts/test/docker-build.sh` 헬스체크

Closes #39