### PR TITLE
fix: UC-02 테스트 null 경고 해소

### DIFF
--- a/src/test/java/com/buyeoon/member/SignUpOnboardingIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/SignUpOnboardingIntegrationTests.java
@@ -16,6 +16,7 @@ import com.buyeoon.member.auth.social.VerifiedSocialIdentity;
 import com.buyeoon.member.entity.SocialProvider;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -214,7 +215,7 @@ class SignUpOnboardingIntegrationTests {
 	}
 
 	private long count(String table) {
-		return jdbcTemplate.queryForObject("SELECT count(*) FROM " + table, Long.class);
+		return Objects.requireNonNull(jdbcTemplate.queryForObject("SELECT count(*) FROM " + table, Long.class));
 	}
 
 	@DynamicPropertySource


### PR DESCRIPTION
## 변경 사항
- UC-02 통합 테스트의 `queryForObject` 반환값을 `Objects.requireNonNull`로 명시적으로 검증합니다.
- `Long` 자동 언박싱에서 발생한 SpotBugs null 역참조 경고를 해소합니다.

## 검증
- `./scripts/test/static-check.sh`
- 컴파일·Spotless·Checkstyle·SpotBugs·전체 테스트 통과
