### PR TITLE
feat: 서비스 설정 조회 구현

### DIFF
--- a/src/main/java/com/buyeoon/member/api/MemberController.java
+++ b/src/main/java/com/buyeoon/member/api/MemberController.java
@@ -3,6 +3,7 @@ package com.buyeoon.member.api;
 import com.buyeoon.common.api.SuccessResponse;
 import com.buyeoon.member.application.MemberQueryService;
 import com.buyeoon.member.application.MemberQueryService.MemberView;
+import com.buyeoon.member.application.MemberQueryService.SettingsView;
 import java.util.Objects;
 import java.util.UUID;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,5 +26,11 @@ public class MemberController {
 	public SuccessResponse<MemberView> getMyMember(@AuthenticationPrincipal Jwt jwt) {
 		return SuccessResponse
 				.of(memberQueryService.getActiveMember(UUID.fromString(Objects.requireNonNull(jwt.getSubject()))));
+	}
+
+	@GetMapping("/me/settings")
+	public SuccessResponse<SettingsView> getMySettings(@AuthenticationPrincipal Jwt jwt) {
+		return SuccessResponse
+				.of(memberQueryService.getSettings(UUID.fromString(Objects.requireNonNull(jwt.getSubject()))));
 	}
 }

--- a/src/main/java/com/buyeoon/member/application/MemberQueryService.java
+++ b/src/main/java/com/buyeoon/member/application/MemberQueryService.java
@@ -54,6 +54,23 @@ public class MemberQueryService {
 				.orElseThrow(() -> new AuthenticationCredentialsNotFoundException("활성 회원이 아닙니다."));
 	}
 
+	public SettingsView getSettings(UUID memberId) {
+		return jdbcOperations
+				.query("""
+						SELECT nearby_quiz_notification_enabled,
+						       dark_mode_enabled,
+						       version
+						FROM member_settings
+						WHERE member_id = ?
+						""",
+						(resultSet, rowNumber) -> new SettingsView(
+								resultSet.getBoolean("nearby_quiz_notification_enabled"),
+								resultSet.getBoolean("dark_mode_enabled"), resultSet.getLong("version")),
+						memberId)
+				.stream().findFirst()
+				.orElseThrow(() -> new AuthenticationCredentialsNotFoundException("서비스 설정이 없습니다."));
+	}
+
 	private MemberView mapMember(ResultSet resultSet, int rowNumber) throws SQLException {
 		return new MemberView(resultSet.getObject("id", UUID.class),
 				MemberStatus.valueOf(resultSet.getString("status")), resultSet.getString("display_name"),
@@ -64,5 +81,8 @@ public class MemberQueryService {
 
 	public record MemberView(UUID memberId, MemberStatus status, String displayName, UUID characterId,
 			boolean requiredTermsAgreed, boolean citizenCardIssued, ZonedDateTime createdAt) {
+	}
+
+	public record SettingsView(boolean nearbyQuizNotificationEnabled, boolean darkModeEnabled, long version) {
 	}
 }

--- a/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
@@ -1,5 +1,6 @@
 package com.buyeoon.member;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -10,6 +11,7 @@ import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -240,6 +242,71 @@ class MemberMeIntegrationTests {
 				"Bearer " + accessTokenService.issue(authenticatedMemberId, sessionId))).andExpect(status().isOk())
 				.andExpect(jsonPath("$.data.memberId").value(authenticatedMemberId.toString()))
 				.andExpect(jsonPath("$.data.memberId").value(org.hamcrest.Matchers.not(otherMemberId.toString())));
+	}
+
+	@Test
+	@DisplayName("신규 회원은 기본 서비스 설정을 조회한다")
+	void newMemberGetsDefaultSettings() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		insertMember(memberId, "ACTIVE", Instant.now());
+		insertSession(sessionId, memberId, Instant.now().plus(30, ChronoUnit.DAYS), null);
+		jdbcTemplate.update("INSERT INTO member_settings (member_id) VALUES (?)", memberId);
+
+		mockMvc.perform(get("/members/me/settings").header("Authorization",
+				"Bearer " + accessTokenService.issue(memberId, sessionId))).andExpect(status().isOk())
+				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.nearbyQuizNotificationEnabled").value(false))
+				.andExpect(jsonPath("$.data.darkModeEnabled").value(false))
+				.andExpect(jsonPath("$.data.version").value(0));
+	}
+
+	@Test
+	@DisplayName("현재 서비스 설정을 상태 변경 없이 반환한다")
+	void currentSettingsAreReturnedWithoutMutation() throws Exception {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		insertMember(memberId, "ACTIVE", Instant.now());
+		insertSession(sessionId, memberId, Instant.now().plus(30, ChronoUnit.DAYS), null);
+		jdbcTemplate.update("""
+				INSERT INTO member_settings
+				    (member_id, nearby_quiz_notification_enabled, dark_mode_enabled, version)
+				VALUES (?, true, true, 7)
+				""", memberId);
+		Map<String, Object> before = settings(memberId);
+		String token = accessTokenService.issue(memberId, sessionId);
+
+		for (int request = 0; request < 2; request++) {
+			mockMvc.perform(get("/members/me/settings").header("Authorization", "Bearer " + token))
+					.andExpect(status().isOk()).andExpect(jsonPath("$.data.nearbyQuizNotificationEnabled").value(true))
+					.andExpect(jsonPath("$.data.darkModeEnabled").value(true))
+					.andExpect(jsonPath("$.data.version").value(7));
+		}
+
+		assertThat(settings(memberId)).isEqualTo(before);
+	}
+
+	@Test
+	@DisplayName("서비스 설정 조회에는 활성 인증 세션이 필요하다")
+	void settingsAuthenticationIsRequired() throws Exception {
+		mockMvc.perform(get("/members/me/settings")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+
+		UUID memberId = UUID.randomUUID();
+		insertMember(memberId, "ACTIVE", Instant.now());
+		jdbcTemplate.update("INSERT INTO member_settings (member_id) VALUES (?)", memberId);
+		mockMvc.perform(get("/members/me/settings").header("Authorization",
+				"Bearer " + accessTokenService.issue(memberId, UUID.randomUUID()))).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	private Map<String, Object> settings(UUID memberId) {
+		return jdbcTemplate.queryForMap("""
+				SELECT nearby_quiz_notification_enabled, dark_mode_enabled, version
+				FROM member_settings
+				WHERE member_id = ?
+				""", memberId);
 	}
 
 	private void insertMember(UUID memberId, String status, Instant createdAt) {


### PR DESCRIPTION
## 변경 사항
- `GET /members/me/settings`를 추가했습니다.
- 인증 회원의 근처 퀴즈 알림·다크 모드 설정과 낙관적 잠금 버전을 반환합니다.
- 기존 `MemberQueryService`와 `member_settings`를 재사용해 별도 Repository나 의존성을 추가하지 않았습니다.
- 기본값, 기존 값, 반복 조회 무부작용, 인증 실패를 실제 JWT·PostgreSQL/PostGIS·Flyway 통합 테스트로 검증했습니다.

## 검증
- `./gradlew test --tests com.buyeoon.member.MemberMeIntegrationTests`
- `./scripts/test/static-check.sh`
- 전체 108개 테스트 통과
- Spotless, Checkstyle, SpotBugs 통과

## 범위 제외
- `PATCH /members/me/settings`는 후속 티켓 #53에서 구현합니다.
- DB 스키마와 OpenAPI 문서는 기존 계약을 그대로 사용합니다.

Closes #52
