### PR TITLE
feat: 현재 인증 세션 푸시 토큰 생명주기 구현

### DIFF
--- a/src/main/java/com/buyeoon/member/api/InvalidPushTokenRequestException.java
+++ b/src/main/java/com/buyeoon/member/api/InvalidPushTokenRequestException.java
@@ -1,0 +1,4 @@
+package com.buyeoon.member.api;
+
+public class InvalidPushTokenRequestException extends RuntimeException {
+}

--- a/src/main/java/com/buyeoon/member/api/MemberController.java
+++ b/src/main/java/com/buyeoon/member/api/MemberController.java
@@ -6,6 +6,8 @@ import com.buyeoon.member.application.MemberQueryService.MemberView;
 import com.buyeoon.member.application.MemberQueryService.SettingsView;
 import com.buyeoon.member.application.MemberSettingsUpdateService;
 import com.buyeoon.member.application.MemberSettingsUpdateService.SettingsUpdateCommand;
+import com.buyeoon.member.application.PushTokenService;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -13,7 +15,9 @@ import java.util.UUID;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,11 +32,13 @@ public class MemberController {
 
 	private final MemberQueryService memberQueryService;
 	private final MemberSettingsUpdateService memberSettingsUpdateService;
+	private final PushTokenService pushTokenService;
 
 	public MemberController(MemberQueryService memberQueryService,
-			MemberSettingsUpdateService memberSettingsUpdateService) {
+			MemberSettingsUpdateService memberSettingsUpdateService, PushTokenService pushTokenService) {
 		this.memberQueryService = memberQueryService;
 		this.memberSettingsUpdateService = memberSettingsUpdateService;
+		this.pushTokenService = pushTokenService;
 	}
 
 	@GetMapping("/me")
@@ -52,6 +58,19 @@ public class MemberController {
 			@RequestBody JsonNode request) {
 		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
 		return SuccessResponse.of(memberSettingsUpdateService.update(memberId, parseSettingsUpdate(request)));
+	}
+
+	@PutMapping("/me/push-token")
+	public SuccessResponse<Map<String, Object>> upsertMyPushToken(@AuthenticationPrincipal Jwt jwt,
+			@RequestBody JsonNode request) {
+		pushTokenService.upsert(memberId(jwt), sessionId(jwt), pushToken(request));
+		return SuccessResponse.of(Map.of());
+	}
+
+	@DeleteMapping("/me/push-token")
+	public SuccessResponse<Map<String, Object>> deleteMyPushToken(@AuthenticationPrincipal Jwt jwt) {
+		pushTokenService.unregister(memberId(jwt), sessionId(jwt));
+		return SuccessResponse.of(Map.of());
 	}
 
 	private SettingsUpdateCommand parseSettingsUpdate(JsonNode request) {
@@ -89,5 +108,28 @@ public class MemberController {
 			throw new InvalidSettingsRequestException();
 		}
 		return Optional.of(value.booleanValue());
+	}
+
+	private String pushToken(JsonNode request) {
+		if (request == null || !request.isObject() || request.size() != 1 || !request.has("token")) {
+			throw new InvalidPushTokenRequestException();
+		}
+		JsonNode tokenNode = request.get("token");
+		if (tokenNode == null || !tokenNode.isString()) {
+			throw new InvalidPushTokenRequestException();
+		}
+		String token = tokenNode.stringValue();
+		if (token.isBlank() || token.codePointCount(0, token.length()) > 4_096) {
+			throw new InvalidPushTokenRequestException();
+		}
+		return token;
+	}
+
+	private UUID memberId(Jwt jwt) {
+		return UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+	}
+
+	private UUID sessionId(Jwt jwt) {
+		return UUID.fromString(Objects.requireNonNull(jwt.getClaimAsString("sid")));
 	}
 }

--- a/src/main/java/com/buyeoon/member/api/MemberExceptionHandler.java
+++ b/src/main/java/com/buyeoon/member/api/MemberExceptionHandler.java
@@ -4,6 +4,7 @@ import com.buyeoon.common.api.ErrorResponse;
 import com.buyeoon.member.application.InvalidStateTransitionException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,7 +12,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(assignableTypes = MemberController.class)
 public class MemberExceptionHandler {
 
-	@ExceptionHandler({InvalidSettingsRequestException.class, HttpMessageNotReadableException.class})
+	@ExceptionHandler({InvalidSettingsRequestException.class, InvalidPushTokenRequestException.class,
+			HttpMessageNotReadableException.class})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ErrorResponse handleInvalidRequest() {
 		return ErrorResponse.invalidRequest();
@@ -21,5 +23,11 @@ public class MemberExceptionHandler {
 	@ResponseStatus(HttpStatus.CONFLICT)
 	public ErrorResponse handleInvalidStateTransition() {
 		return ErrorResponse.invalidStateTransition();
+	}
+
+	@ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	public ErrorResponse handleUnauthorized() {
+		return ErrorResponse.unauthorized();
 	}
 }

--- a/src/main/java/com/buyeoon/member/application/PushTokenService.java
+++ b/src/main/java/com/buyeoon/member/application/PushTokenService.java
@@ -1,0 +1,83 @@
+package com.buyeoon.member.application;
+
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+public final class PushTokenService {
+
+	private final JdbcOperations jdbcOperations;
+	private final TransactionTemplate transactions;
+
+	public PushTokenService(JdbcOperations jdbcOperations, PlatformTransactionManager transactionManager) {
+		this.jdbcOperations = jdbcOperations;
+		this.transactions = new TransactionTemplate(transactionManager);
+	}
+
+	public void upsert(UUID memberId, UUID sessionId, String registrationToken) {
+		transactions.executeWithoutResult(status -> {
+			lockActiveSession(memberId, sessionId);
+			String currentToken = currentToken(sessionId);
+			if (registrationToken.equals(currentToken)) {
+				return;
+			}
+			jdbcOperations.update("DELETE FROM push_tokens WHERE auth_session_id = ?", sessionId);
+			jdbcOperations.update("""
+					INSERT INTO push_tokens (auth_session_id, registration_token)
+					VALUES (?, ?)
+					ON CONFLICT (registration_token) DO UPDATE
+					SET auth_session_id = EXCLUDED.auth_session_id,
+					    updated_at = CURRENT_TIMESTAMP
+					""", sessionId, registrationToken);
+		});
+	}
+
+	public void unregister(UUID memberId, UUID sessionId) {
+		transactions.executeWithoutResult(status -> {
+			lockActiveSession(memberId, sessionId);
+			jdbcOperations.update("DELETE FROM push_tokens WHERE auth_session_id = ?", sessionId);
+		});
+	}
+
+	private void lockActiveSession(UUID memberId, UUID sessionId) {
+		lockActiveMember(memberId);
+		boolean sessionExists = !jdbcOperations.query("""
+				SELECT id
+				FROM auth_sessions
+				WHERE id = ?
+				  AND member_id = ?
+				  AND expires_at > CURRENT_TIMESTAMP
+				  AND revoked_at IS NULL
+				FOR UPDATE
+				""", (resultSet, rowNumber) -> resultSet.getObject("id", UUID.class), sessionId, memberId).isEmpty();
+		if (!sessionExists) {
+			throw new AuthenticationCredentialsNotFoundException("활성 인증 세션이 아닙니다.");
+		}
+	}
+
+	private void lockActiveMember(UUID memberId) {
+		boolean memberExists = !jdbcOperations.query("""
+				SELECT id
+				FROM members
+				WHERE id = ? AND status = 'ACTIVE'
+				FOR UPDATE
+				""", (resultSet, rowNumber) -> resultSet.getObject("id", UUID.class), memberId).isEmpty();
+		if (!memberExists) {
+			throw new AuthenticationCredentialsNotFoundException("활성 회원이 아닙니다.");
+		}
+	}
+
+	private String currentToken(UUID sessionId) {
+		return jdbcOperations.query("""
+				SELECT registration_token
+				FROM push_tokens
+				WHERE auth_session_id = ?
+				FOR UPDATE
+				""", (resultSet, rowNumber) -> resultSet.getString("registration_token"), sessionId).stream()
+				.findFirst().orElse(null);
+	}
+}

--- a/src/test/java/com/buyeoon/member/PushTokenIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/PushTokenIntegrationTests.java
@@ -1,0 +1,336 @@
+package com.buyeoon.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class PushTokenIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.execute("DROP TRIGGER IF EXISTS fail_push_token_upsert ON push_tokens");
+		jdbcTemplate.execute("DROP TRIGGER IF EXISTS fail_push_token_delete ON push_tokens");
+		jdbcTemplate.execute("DROP FUNCTION IF EXISTS fail_push_token_upsert()");
+		jdbcTemplate.execute("DROP FUNCTION IF EXISTS fail_push_token_delete()");
+		jdbcTemplate.update("DELETE FROM push_tokens");
+		jdbcTemplate.update("DELETE FROM member_settings");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	@Test
+	@DisplayName("현재 세션에 토큰을 등록한 뒤 근처 퀴즈 알림을 활성화한다")
+	void registersCurrentSessionTokenAndEnablesNearbyQuizNotification() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Map<String, Object> settingsBefore = settings(member.memberId());
+
+		performPut(member, "{\"token\":\"fcm-current-device\"}").andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true)).andExpect(jsonPath("$.data").isMap());
+
+		assertThat(pushTokens()).singleElement().satisfies(token -> {
+			assertThat(token.get("auth_session_id")).isEqualTo(member.sessionId());
+			assertThat(token.get("registration_token")).isEqualTo("fcm-current-device");
+		});
+		assertThat(settings(member.memberId())).isEqualTo(settingsBefore);
+
+		mockMvc.perform(patch("/members/me/settings").header("Authorization", bearer(member))
+				.contentType(MediaType.APPLICATION_JSON).content("""
+						{"nearbyQuizNotificationEnabled":true,"deviceNotificationPermissionGranted":true,
+						 "deviceLocationPermissionGranted":true,"version":0}
+						""")).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.nearbyQuizNotificationEnabled").value(true))
+				.andExpect(jsonPath("$.data.version").value(1));
+	}
+
+	@Test
+	@DisplayName("현재 세션의 동일 토큰 재등록은 DB 상태를 변경하지 않는다")
+	void sameTokenRegistrationIsNoOp() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		insertPushToken(member.sessionId(), "same-token");
+		Map<String, Object> before = pushToken(member.sessionId());
+
+		performPut(member, "{\"token\":\"same-token\"}").andExpect(status().isOk());
+
+		assertThat(pushToken(member.sessionId())).isEqualTo(before);
+	}
+
+	@Test
+	@DisplayName("새 토큰은 현재 세션의 기존 토큰을 교체하고 다른 세션에서 소유권을 옮긴다")
+	void newTokenReplacesCurrentAndMovesFromAnotherSession() throws Exception {
+		AuthenticatedMember first = insertAuthenticatedMember();
+		AuthenticatedMember second = insertAuthenticatedMember();
+		insertPushToken(first.sessionId(), "shared-token");
+		insertPushToken(second.sessionId(), "second-old-token");
+
+		performPut(second, "{\"token\":\"shared-token\"}").andExpect(status().isOk());
+
+		assertThat(pushTokens()).singleElement().satisfies(token -> {
+			assertThat(token.get("auth_session_id")).isEqualTo(second.sessionId());
+			assertThat(token.get("registration_token")).isEqualTo("shared-token");
+		});
+	}
+
+	@Test
+	@DisplayName("같은 토큰의 동시 등록은 확정된 세션 하나에만 연결한다")
+	void concurrentRegistrationKeepsOneSessionOwner() throws Exception {
+		AuthenticatedMember first = insertAuthenticatedMember();
+		AuthenticatedMember second = insertAuthenticatedMember();
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+
+		try {
+			Future<MvcResult> firstResult = executor.submit(() -> concurrentPut(first, ready, start));
+			Future<MvcResult> secondResult = executor.submit(() -> concurrentPut(second, ready, start));
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			assertThat(List.of(firstResult.get(10, TimeUnit.SECONDS).getResponse().getStatus(),
+					secondResult.get(10, TimeUnit.SECONDS).getResponse().getStatus())).containsOnly(200);
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertThat(pushTokens()).singleElement().satisfies(token -> {
+			assertThat(token.get("registration_token")).isEqualTo("concurrent-token");
+			assertThat(token.get("auth_session_id")).isIn(first.sessionId(), second.sessionId());
+		});
+	}
+
+	@Test
+	@DisplayName("삭제는 현재 세션의 토큰만 제거하며 토큰이 없어도 성공한다")
+	void deleteRemovesOnlyCurrentSessionAndIsIdempotent() throws Exception {
+		AuthenticatedMember current = insertAuthenticatedMember();
+		AuthenticatedMember other = insertAuthenticatedMember();
+		insertPushToken(current.sessionId(), "current-token");
+		insertPushToken(other.sessionId(), "other-token");
+		Map<String, Object> settingsBefore = settings(current.memberId());
+
+		performDelete(current).andExpect(status().isOk()).andExpect(jsonPath("$.data").isMap());
+		performDelete(current).andExpect(status().isOk());
+
+		assertThat(pushTokens()).singleElement().satisfies(token -> {
+			assertThat(token.get("auth_session_id")).isEqualTo(other.sessionId());
+			assertThat(token.get("registration_token")).isEqualTo("other-token");
+		});
+		assertThat(settings(current.memberId())).isEqualTo(settingsBefore);
+	}
+
+	@Test
+	@DisplayName("엄격한 요청 계약 위반은 기존 토큰을 변경하지 않는다")
+	void invalidRequestsDoNotChangeToken() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		insertPushToken(member.sessionId(), "existing-token");
+		Map<String, Object> before = pushToken(member.sessionId());
+		List<String> invalidRequests = List.of("{}", "{\"token\":null}", "{\"token\":123}", "{\"token\":\"   \"}",
+				"{\"token\":\"valid\",\"unknown\":true}", "{\"token\":\"" + "a".repeat(4_097) + "\"}", "{");
+
+		for (String request : invalidRequests) {
+			performPut(member, request).andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+			assertThat(pushToken(member.sessionId())).isEqualTo(before);
+		}
+	}
+
+	@Test
+	@DisplayName("토큰 API는 활성 인증 세션이 필요하다")
+	void authenticationIsRequired() throws Exception {
+		mockMvc.perform(
+				put("/members/me/push-token").contentType(MediaType.APPLICATION_JSON).content("{\"token\":\"token\"}"))
+				.andExpect(status().isUnauthorized()).andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+		mockMvc.perform(delete("/members/me/push-token")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+
+		AuthenticatedMember member = insertAuthenticatedMember();
+		String invalidSessionToken = accessTokenService.issue(member.memberId(), UUID.randomUUID());
+		mockMvc.perform(put("/members/me/push-token").header("Authorization", "Bearer " + invalidSessionToken)
+				.contentType(MediaType.APPLICATION_JSON).content("{\"token\":\"token\"}"))
+				.andExpect(status().isUnauthorized()).andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	@Test
+	@DisplayName("토큰 교체 저장 실패는 기존 연결을 유지한다")
+	void failedUpsertRollsBackExistingToken() {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		insertPushToken(member.sessionId(), "existing-token");
+		Map<String, Object> before = pushToken(member.sessionId());
+		jdbcTemplate.execute("""
+				CREATE FUNCTION fail_push_token_upsert() RETURNS trigger AS $$
+				BEGIN
+				    RAISE EXCEPTION 'forced push token upsert failure';
+				END;
+				$$ LANGUAGE plpgsql
+				""");
+		jdbcTemplate.execute("""
+				CREATE TRIGGER fail_push_token_upsert
+				BEFORE INSERT OR UPDATE ON push_tokens
+				FOR EACH ROW EXECUTE FUNCTION fail_push_token_upsert()
+				""");
+
+		assertThatThrownBy(() -> performPut(member, "{\"token\":\"new-token\"}").andReturn())
+				.isInstanceOf(Exception.class);
+		assertThat(pushToken(member.sessionId())).isEqualTo(before);
+	}
+
+	@Test
+	@DisplayName("토큰 삭제 저장 실패는 기존 연결을 유지한다")
+	void failedDeleteRollsBackExistingToken() {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		insertPushToken(member.sessionId(), "existing-token");
+		Map<String, Object> before = pushToken(member.sessionId());
+		jdbcTemplate.execute("""
+				CREATE FUNCTION fail_push_token_delete() RETURNS trigger AS $$
+				BEGIN
+				    RAISE EXCEPTION 'forced push token delete failure';
+				END;
+				$$ LANGUAGE plpgsql
+				""");
+		jdbcTemplate.execute("""
+				CREATE TRIGGER fail_push_token_delete
+				BEFORE DELETE ON push_tokens
+				FOR EACH ROW EXECUTE FUNCTION fail_push_token_delete()
+				""");
+
+		assertThatThrownBy(() -> performDelete(member).andReturn()).isInstanceOf(Exception.class);
+		assertThat(pushToken(member.sessionId())).isEqualTo(before);
+	}
+
+	private MvcResult concurrentPut(AuthenticatedMember member, CountDownLatch ready, CountDownLatch start)
+			throws Exception {
+		ready.countDown();
+		if (!start.await(5, TimeUnit.SECONDS)) {
+			throw new IllegalStateException("동시 요청 시작 신호를 받지 못했습니다.");
+		}
+		return performPut(member, "{\"token\":\"concurrent-token\"}").andReturn();
+	}
+
+	private org.springframework.test.web.servlet.ResultActions performPut(AuthenticatedMember member, String body)
+			throws Exception {
+		return mockMvc.perform(put("/members/me/push-token").header("Authorization", bearer(member))
+				.contentType(MediaType.APPLICATION_JSON).content(body));
+	}
+
+	private org.springframework.test.web.servlet.ResultActions performDelete(AuthenticatedMember member)
+			throws Exception {
+		return mockMvc.perform(delete("/members/me/push-token").header("Authorization", bearer(member)));
+	}
+
+	private String bearer(AuthenticatedMember member) {
+		return "Bearer " + member.accessToken();
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO member_settings
+				    (member_id, nearby_quiz_notification_enabled, dark_mode_enabled, version)
+				VALUES (?, false, false, 0)
+				""", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, sessionId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private void insertPushToken(UUID sessionId, String registrationToken) {
+		jdbcTemplate.update("""
+				INSERT INTO push_tokens (auth_session_id, registration_token, created_at, updated_at)
+				VALUES (?, ?, CURRENT_TIMESTAMP - INTERVAL '1 hour', CURRENT_TIMESTAMP - INTERVAL '1 hour')
+				""", sessionId, registrationToken);
+	}
+
+	private List<Map<String, Object>> pushTokens() {
+		return jdbcTemplate.queryForList("""
+				SELECT auth_session_id, registration_token, created_at, updated_at
+				FROM push_tokens
+				ORDER BY registration_token
+				""");
+	}
+
+	private Map<String, Object> pushToken(UUID sessionId) {
+		return jdbcTemplate.queryForMap("""
+				SELECT auth_session_id, registration_token, created_at, updated_at
+				FROM push_tokens
+				WHERE auth_session_id = ?
+				""", sessionId);
+	}
+
+	private Map<String, Object> settings(UUID memberId) {
+		return jdbcTemplate.queryForMap("""
+				SELECT nearby_quiz_notification_enabled, dark_mode_enabled, version
+				FROM member_settings
+				WHERE member_id = ?
+				""", memberId);
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private record AuthenticatedMember(UUID memberId, UUID sessionId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## 변경 사항

- `PUT /members/me/push-token`으로 현재 JWT `sid`에 FCM 토큰을 등록·교체하도록 구현했습니다.
- 동일 토큰 재등록은 DB를 변경하지 않고 성공으로 처리합니다.
- 같은 토큰이 다른 활성 세션에 있으면 현재 세션으로 소유권을 옮깁니다.
- `DELETE /members/me/push-token`으로 현재 세션의 토큰만 무부작용 삭제합니다.
- 회원과 인증 세션 잠금 및 DB unique 제약으로 동시 등록 후 토큰 연결을 하나만 유지합니다.
- 공백·초과 길이·알 수 없는 필드·잘못된 타입 등 엄격한 요청 검증을 추가했습니다.
- 토큰 등록·삭제와 서비스 설정이 독립적이며 UC-19 설정 API로 알림을 활성화하는 흐름을 통합 검증했습니다.

## 검증

- `./gradlew test --tests com.buyeoon.member.PushTokenIntegrationTests --tests com.buyeoon.member.MemberSettingsUpdateIntegrationTests`
- `./scripts/test/static-check.sh`
- 전체 125개 테스트 통과
- Spotless, Checkstyle, SpotBugs 통과

## 범위 제외

- Flutter 권한 요청과 FCM 토큰 발급
- 실제 근처 퀴즈 판정·FCM 발송·무효 토큰 백그라운드 정리

Closes #59
