### PR TITLE
feat: UC-21 기한 도래 회원 정보 파기

### DIFF
--- a/docs/raw/db-schema.sql
+++ b/docs/raw/db-schema.sql
@@ -221,7 +221,7 @@ CREATE TABLE mission_photos (
     member_id uuid NOT NULL REFERENCES members(id) ON DELETE CASCADE, -- 촬영 회원 ID
     trip_id uuid NOT NULL REFERENCES trips(id) ON DELETE CASCADE, -- 여행 ID
     mission_id uuid NOT NULL REFERENCES missions(id), -- 사진 미션 ID
-    object_key text NOT NULL UNIQUE, -- 스토리지 객체 키
+    object_key text NOT NULL UNIQUE CHECK (object_key LIKE 'private/%'), -- 비공개 스토리지 객체 키
     content_type text NOT NULL CHECK (content_type IN ('image/jpeg', 'image/png', 'image/webp')), -- 파일 MIME 타입
     file_size_bytes bigint NOT NULL CHECK (file_size_bytes > 0), -- 파일 크기
     uploaded_at timestamptz NOT NULL DEFAULT now() -- 업로드 완료 시각
@@ -345,6 +345,9 @@ CREATE TABLE idempotency_requests (
 );
 
 CREATE INDEX auth_sessions_member_idx ON auth_sessions (member_id, expires_at);
+CREATE INDEX members_due_purge_idx
+    ON members (purge_after, id)
+    WHERE status = 'WITHDRAWN' AND purged_at IS NULL;
 CREATE INDEX trips_member_idx ON trips (member_id, started_at DESC);
 CREATE INDEX places_location_gix ON places USING GIST (location);
 CREATE UNIQUE INDEX places_source_external_id_uq

--- a/src/main/java/com/buyeoon/BuyeoOnApplication.java
+++ b/src/main/java/com/buyeoon/BuyeoOnApplication.java
@@ -2,8 +2,10 @@ package com.buyeoon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BuyeoOnApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/buyeoon/common/storage/PrivateImageObjectStore.java
+++ b/src/main/java/com/buyeoon/common/storage/PrivateImageObjectStore.java
@@ -1,0 +1,6 @@
+package com.buyeoon.common.storage;
+
+public interface PrivateImageObjectStore {
+
+	void delete(String objectKey);
+}

--- a/src/main/java/com/buyeoon/common/storage/S3PrivateImageObjectStore.java
+++ b/src/main/java/com/buyeoon/common/storage/S3PrivateImageObjectStore.java
@@ -1,0 +1,37 @@
+package com.buyeoon.common.storage;
+
+import jakarta.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+@Service
+public final class S3PrivateImageObjectStore implements PrivateImageObjectStore {
+
+	private final String bucket;
+	private final S3Client s3Client;
+
+	public S3PrivateImageObjectStore(@Value("${storage.images.bucket:}") String bucket,
+			@Value("${storage.images.region:ap-northeast-2}") String region) {
+		this.bucket = bucket;
+		this.s3Client = S3Client.builder().region(Region.of(region)).build();
+	}
+
+	@Override
+	public void delete(String objectKey) {
+		if (bucket.isBlank()) {
+			throw new IllegalStateException("IMAGE_BUCKET 설정이 필요합니다.");
+		}
+		if (!objectKey.startsWith("private/")) {
+			throw new IllegalArgumentException("비공개 이미지 객체 키가 아닙니다.");
+		}
+		s3Client.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(objectKey).build());
+	}
+
+	@PreDestroy
+	void close() {
+		s3Client.close();
+	}
+}

--- a/src/main/java/com/buyeoon/member/application/WithdrawnMemberDataPurgeScheduler.java
+++ b/src/main/java/com/buyeoon/member/application/WithdrawnMemberDataPurgeScheduler.java
@@ -1,0 +1,19 @@
+package com.buyeoon.member.application;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class WithdrawnMemberDataPurgeScheduler {
+
+	private final WithdrawnMemberDataPurgeService purgeService;
+
+	public WithdrawnMemberDataPurgeScheduler(WithdrawnMemberDataPurgeService purgeService) {
+		this.purgeService = purgeService;
+	}
+
+	@Scheduled(fixedDelayString = "${member.purge.interval:PT1M}", initialDelayString = "${member.purge.initial-delay:PT1M}")
+	public void purgeDueMembers() {
+		purgeService.purgeDueMembers();
+	}
+}

--- a/src/main/java/com/buyeoon/member/application/WithdrawnMemberDataPurgeService.java
+++ b/src/main/java/com/buyeoon/member/application/WithdrawnMemberDataPurgeService.java
@@ -1,0 +1,158 @@
+package com.buyeoon.member.application;
+
+import com.buyeoon.common.storage.PrivateImageObjectStore;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+public final class WithdrawnMemberDataPurgeService {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(WithdrawnMemberDataPurgeService.class);
+
+	private final JdbcOperations jdbcOperations;
+	private final Consumer<String> deleteObject;
+	private final TransactionTemplate transactions;
+	private final int batchSize;
+
+	public WithdrawnMemberDataPurgeService(JdbcOperations jdbcOperations, PrivateImageObjectStore objectStore,
+			PlatformTransactionManager transactionManager, @Value("${member.purge.batch-size:100}") int batchSize) {
+		if (batchSize < 1 || batchSize > 1_000) {
+			throw new IllegalArgumentException("회원 정보 파기 배치 크기는 1~1000이어야 합니다.");
+		}
+		this.jdbcOperations = jdbcOperations;
+		this.deleteObject = objectStore::delete;
+		this.transactions = new TransactionTemplate(transactionManager);
+		this.batchSize = batchSize;
+	}
+
+	public int purgeDueMembers() {
+		int purged = 0;
+		DueMember cursor = null;
+		while (true) {
+			List<DueMember> dueMembers = dueMembersAfter(cursor);
+			if (dueMembers.isEmpty()) {
+				return purged;
+			}
+			for (DueMember dueMember : dueMembers) {
+				try {
+					if (purge(dueMember.memberId())) {
+						purged++;
+					}
+				} catch (RuntimeException exception) {
+					LOGGER.warn("탈퇴 회원 정보 파기에 실패했습니다. memberId={}", dueMember.memberId(), exception);
+				}
+			}
+			cursor = dueMembers.getLast();
+		}
+	}
+
+	private List<DueMember> dueMembersAfter(DueMember cursor) {
+		if (cursor == null) {
+			return jdbcOperations.query("""
+					SELECT id, purge_after
+					FROM members
+					WHERE status = 'WITHDRAWN'
+					  AND purge_after <= CURRENT_TIMESTAMP
+					  AND purged_at IS NULL
+					ORDER BY purge_after, id
+					LIMIT ?
+					""", this::mapDueMember, batchSize);
+		}
+		return jdbcOperations.query("""
+				SELECT id, purge_after
+				FROM members
+				WHERE status = 'WITHDRAWN'
+				  AND purge_after <= CURRENT_TIMESTAMP
+				  AND purged_at IS NULL
+				  AND (purge_after, id) > (?, ?)
+				ORDER BY purge_after, id
+				LIMIT ?
+				""", this::mapDueMember, Timestamp.from(cursor.purgeAfter()), cursor.memberId(), batchSize);
+	}
+
+	private DueMember mapDueMember(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new DueMember(resultSet.getObject("id", UUID.class), resultSet.getTimestamp("purge_after").toInstant());
+	}
+
+	private boolean purge(UUID memberId) {
+		for (String objectKey : photoObjectKeys(memberId)) {
+			deleteObject.accept(objectKey);
+		}
+		return Boolean.TRUE.equals(transactions.execute(status -> purgeRelationalData(memberId)));
+	}
+
+	private List<String> photoObjectKeys(UUID memberId) {
+		return jdbcOperations.query("""
+				SELECT object_key
+				FROM mission_photos
+				WHERE member_id = ?
+				ORDER BY id
+				""", (resultSet, rowNumber) -> resultSet.getString("object_key"), memberId);
+	}
+
+	private boolean purgeRelationalData(UUID memberId) {
+		if (!lockDueMember(memberId)) {
+			return false;
+		}
+		jdbcOperations.update("DELETE FROM idempotency_requests WHERE member_id = ?", memberId);
+		jdbcOperations.update("DELETE FROM notifications WHERE member_id = ?", memberId);
+		jdbcOperations.update("DELETE FROM member_badges WHERE member_id = ?", memberId);
+		jdbcOperations.update("DELETE FROM point_transactions WHERE member_id = ?", memberId);
+		jdbcOperations.update("""
+				DELETE FROM mission_submissions
+				WHERE participation_id IN (
+				    SELECT participation.id
+				    FROM mission_participations participation
+				    JOIN trips trip ON trip.id = participation.trip_id
+				    WHERE trip.member_id = ?
+				)
+				OR photo_id IN (
+				    SELECT id FROM mission_photos WHERE member_id = ?
+				)
+				""", memberId, memberId);
+		jdbcOperations.update("DELETE FROM mission_photos WHERE member_id = ?", memberId);
+		jdbcOperations.update("DELETE FROM trips WHERE member_id = ?", memberId);
+		jdbcOperations.update("DELETE FROM saved_places WHERE member_id = ?", memberId);
+		jdbcOperations.update("DELETE FROM citizen_cards WHERE member_id = ?", memberId);
+		jdbcOperations.update("DELETE FROM member_profiles WHERE member_id = ?", memberId);
+		jdbcOperations.update("DELETE FROM term_consents WHERE member_id = ?", memberId);
+		jdbcOperations.update("DELETE FROM member_settings WHERE member_id = ?", memberId);
+		jdbcOperations.update("DELETE FROM auth_sessions WHERE member_id = ?", memberId);
+		int updated = jdbcOperations.update("""
+				UPDATE members
+				SET purged_at = CURRENT_TIMESTAMP
+				WHERE id = ? AND purged_at IS NULL
+				""", memberId);
+		if (updated != 1) {
+			throw new IllegalStateException("회원 정보 파기 완료 상태를 저장할 수 없습니다.");
+		}
+		return true;
+	}
+
+	private boolean lockDueMember(UUID memberId) {
+		return !jdbcOperations.query("""
+				SELECT id
+				FROM members
+				WHERE id = ?
+				  AND status = 'WITHDRAWN'
+				  AND purge_after <= CURRENT_TIMESTAMP
+				  AND purged_at IS NULL
+				FOR UPDATE
+				""", (resultSet, rowNumber) -> resultSet.getObject("id", UUID.class), memberId).isEmpty();
+	}
+
+	private record DueMember(UUID memberId, Instant purgeAfter) {
+	}
+}

--- a/src/main/java/com/buyeoon/member/entity/MemberEntity.java
+++ b/src/main/java/com/buyeoon/member/entity/MemberEntity.java
@@ -40,6 +40,9 @@ public class MemberEntity {
 	@Column(name = "purge_after")
 	private Instant purgeAfter;
 
+	@Column(name = "purged_at")
+	private Instant purgedAt;
+
 	public static MemberEntity create() {
 		return new MemberEntity();
 	}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,7 @@ social.apple.read-timeout=${APPLE_READ_TIMEOUT:3s}
 storage.images.bucket=${IMAGE_BUCKET:}
 storage.images.region=${AWS_REGION:ap-northeast-2}
 location.buyeo-boundary=${BUYEO_BOUNDARY:classpath:boundaries/buyeo-44760.geojson}
+
+member.purge.batch-size=${MEMBER_PURGE_BATCH_SIZE:100}
+member.purge.interval=${MEMBER_PURGE_INTERVAL:PT1M}
+member.purge.initial-delay=${MEMBER_PURGE_INITIAL_DELAY:PT1M}

--- a/src/main/resources/db/migration/V8__track_member_data_purge.sql
+++ b/src/main/resources/db/migration/V8__track_member_data_purge.sql
@@ -1,0 +1,24 @@
+ALTER TABLE members
+    ADD COLUMN purged_at timestamptz;
+
+ALTER TABLE members
+    DROP CONSTRAINT members_check;
+
+ALTER TABLE members
+    ADD CONSTRAINT members_lifecycle_ck CHECK (
+        (status = 'ACTIVE' AND withdrawn_at IS NULL AND purge_after IS NULL AND purged_at IS NULL)
+        OR (
+            status = 'WITHDRAWN'
+            AND withdrawn_at IS NOT NULL
+            AND purge_after IS NOT NULL
+            AND (purged_at IS NULL OR purged_at >= withdrawn_at)
+        )
+    );
+
+CREATE INDEX members_due_purge_idx
+    ON members (purge_after, id)
+    WHERE status = 'WITHDRAWN' AND purged_at IS NULL;
+
+ALTER TABLE mission_photos
+    ADD CONSTRAINT mission_photos_object_key_prefix_ck
+    CHECK (object_key LIKE 'private/%');

--- a/src/test/java/com/buyeoon/member/WithdrawnMemberDataPurgeIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/WithdrawnMemberDataPurgeIntegrationTests.java
@@ -1,0 +1,309 @@
+package com.buyeoon.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.buyeoon.common.storage.PrivateImageObjectStore;
+import com.buyeoon.member.application.WithdrawnMemberDataPurgeService;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(properties = {"member.purge.initial-delay=PT24H", "member.purge.batch-size=1"})
+@Testcontainers
+class WithdrawnMemberDataPurgeIntegrationTests {
+
+	private static final UUID PLACE_ID = UUID.fromString("20000000-0000-0000-0000-000000000001");
+	private static final UUID PHOTO_MISSION_ID = UUID.fromString("20000000-0000-0000-0000-000000000103");
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private WithdrawnMemberDataPurgeService purgeService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@MockitoBean
+	private PrivateImageObjectStore objectStore;
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.execute("DROP TRIGGER IF EXISTS fail_member_settings_delete ON member_settings");
+		jdbcTemplate.execute("DROP FUNCTION IF EXISTS fail_member_settings_delete()");
+		jdbcTemplate.update("DELETE FROM point_transactions");
+		jdbcTemplate.update("DELETE FROM member_badges");
+		jdbcTemplate.update("DELETE FROM mission_submissions");
+		jdbcTemplate.update("DELETE FROM mission_photos");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM notifications");
+		jdbcTemplate.update("DELETE FROM idempotency_requests");
+		jdbcTemplate.update("DELETE FROM saved_places");
+		jdbcTemplate.update("DELETE FROM citizen_cards");
+		jdbcTemplate.update("DELETE FROM member_profiles");
+		jdbcTemplate.update("DELETE FROM term_consents");
+		jdbcTemplate.update("DELETE FROM terms");
+		jdbcTemplate.update("DELETE FROM push_tokens");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM member_settings");
+		jdbcTemplate.update("DELETE FROM social_accounts");
+		jdbcTemplate.update("DELETE FROM members");
+		jdbcTemplate.update("DELETE FROM badges");
+		jdbcTemplate.update("DELETE FROM card_characters");
+		jdbcTemplate.update("DELETE FROM card_themes");
+		reset(objectStore);
+	}
+
+	@Test
+	@DisplayName("기한이 지난 회원의 사진을 먼저 지우고 서비스 이용 데이터를 파기한다")
+	void purgesDueMemberDataAndKeepsMinimalTombstone() {
+		Fixture due = insertRichWithdrawnMember("private/missions/due-photo.webp", Instant.now().minusSeconds(1));
+		UUID futureMemberId = insertMinimalWithdrawnMember(Instant.now().plus(1, ChronoUnit.DAYS));
+
+		assertThat(purgeService.purgeDueMembers()).isEqualTo(1);
+
+		verify(objectStore).delete(due.objectKey());
+		assertPurged(due);
+		assertThat(member(futureMemberId).get("purged_at")).isNull();
+		assertThat(count("member_settings", "member_id", futureMemberId)).isEqualTo(1);
+		assertThat(purgeService.purgeDueMembers()).isZero();
+		verify(objectStore).delete(due.objectKey());
+	}
+
+	@Test
+	@DisplayName("한 회원의 S3 삭제 실패는 DB를 유지하고 다른 회원 파기를 막지 않는다")
+	void objectFailureIsRetriedAndIsolatedByMember() {
+		Fixture failed = insertRichWithdrawnMember("private/missions/failed-photo.webp", Instant.now().minusSeconds(2));
+		Fixture successful = insertRichWithdrawnMember("private/missions/success-photo.webp",
+				Instant.now().minusSeconds(1));
+		doAnswer(invocation -> {
+			if (failed.objectKey().equals(invocation.getArgument(0))) {
+				throw new IllegalStateException("forced object deletion failure");
+			}
+			return null;
+		}).when(objectStore).delete(anyString());
+
+		assertThat(purgeService.purgeDueMembers()).isEqualTo(1);
+		assertThat(member(failed.memberId()).get("purged_at")).isNull();
+		assertThat(count("member_settings", "member_id", failed.memberId())).isEqualTo(1);
+		assertPurged(successful);
+
+		reset(objectStore);
+		assertThat(purgeService.purgeDueMembers()).isEqualTo(1);
+		assertPurged(failed);
+	}
+
+	@Test
+	@DisplayName("DB 파기 실패는 관계형 변경을 롤백하고 다음 실행에서 객체 삭제부터 재시도한다")
+	void databaseFailureRollsBackAndRetries() {
+		Fixture fixture = insertRichWithdrawnMember("private/missions/retry-photo.webp", Instant.now().minusSeconds(1));
+		jdbcTemplate.execute("""
+				CREATE FUNCTION fail_member_settings_delete() RETURNS trigger AS $$
+				BEGIN
+				    RAISE EXCEPTION 'forced relational purge failure';
+				END;
+				$$ LANGUAGE plpgsql
+				""");
+		jdbcTemplate.execute("""
+				CREATE TRIGGER fail_member_settings_delete
+				BEFORE DELETE ON member_settings
+				FOR EACH ROW EXECUTE FUNCTION fail_member_settings_delete()
+				""");
+
+		assertThat(purgeService.purgeDueMembers()).isZero();
+		assertThat(member(fixture.memberId()).get("purged_at")).isNull();
+		assertThat(count("trips", "member_id", fixture.memberId())).isEqualTo(1);
+		assertThat(count("member_settings", "member_id", fixture.memberId())).isEqualTo(1);
+
+		jdbcTemplate.execute("DROP TRIGGER fail_member_settings_delete ON member_settings");
+		assertThat(purgeService.purgeDueMembers()).isEqualTo(1);
+		assertPurged(fixture);
+		verify(objectStore, times(2)).delete(fixture.objectKey());
+	}
+
+	@Test
+	@DisplayName("S3 객체가 없는 기한 도래 회원도 파기한다")
+	void purgesDueMemberWithoutPhoto() {
+		UUID memberId = insertMinimalWithdrawnMember(Instant.now().minusSeconds(1));
+
+		assertThat(purgeService.purgeDueMembers()).isEqualTo(1);
+
+		assertThat(member(memberId).get("purged_at")).isNotNull();
+		assertThat(count("member_settings", "member_id", memberId)).isZero();
+		verify(objectStore, times(0)).delete(anyString());
+	}
+
+	private Fixture insertRichWithdrawnMember(String objectKey, Instant purgeAfter) {
+		UUID memberId = insertMinimalWithdrawnMember(purgeAfter);
+		UUID sessionId = UUID.randomUUID();
+		UUID characterId = UUID.randomUUID();
+		UUID themeId = UUID.randomUUID();
+		UUID termId = UUID.randomUUID();
+		UUID tripId = UUID.randomUUID();
+		UUID participationId = UUID.randomUUID();
+		UUID photoId = UUID.randomUUID();
+		UUID badgeId = UUID.randomUUID();
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at, revoked_at)
+				VALUES (?, ?, ?, CURRENT_TIMESTAMP + INTERVAL '1 day', CURRENT_TIMESTAMP)
+				""", sessionId, memberId, UUID.randomUUID().toString());
+		jdbcTemplate.update("INSERT INTO push_tokens (auth_session_id, registration_token) VALUES (?, ?)", sessionId,
+				UUID.randomUUID().toString());
+		jdbcTemplate.update("""
+				INSERT INTO terms (id, type, version, required, title, content, effective_at)
+				VALUES (?, 'SERVICE', ?, true, '약관', '본문', CURRENT_TIMESTAMP - INTERVAL '2 days')
+				""", termId, UUID.randomUUID().toString());
+		jdbcTemplate.update("INSERT INTO term_consents (member_id, term_id, agreed) VALUES (?, ?, true)", memberId,
+				termId);
+		jdbcTemplate.update("""
+				INSERT INTO card_characters (id, name, image_key, sort_order)
+				VALUES (?, ?, ?, ?)
+				""", characterId, "캐릭터-" + memberId, "public/characters/" + memberId + ".webp",
+				nextSortOrder("card_characters"));
+		jdbcTemplate.update("""
+				INSERT INTO card_themes (id, name, image_key, sort_order)
+				VALUES (?, ?, ?, ?)
+				""", themeId, "테마-" + memberId, "public/themes/" + memberId + ".webp", nextSortOrder("card_themes"));
+		jdbcTemplate.update("""
+				INSERT INTO member_profiles (member_id, display_name, character_id)
+				VALUES (?, '탈퇴회원', ?)
+				""", memberId, characterId);
+		jdbcTemplate.update("INSERT INTO citizen_cards (member_id, theme_id, barcode_value) VALUES (?, ?, ?)", memberId,
+				themeId, UUID.randomUUID().toString());
+		jdbcTemplate.update("INSERT INTO saved_places (member_id, place_id) VALUES (?, ?)", memberId, PLACE_ID);
+		jdbcTemplate.update("""
+				INSERT INTO trips (id, member_id, status, started_at, ended_at, settled_at)
+				VALUES (?, ?, 'SETTLED', CURRENT_TIMESTAMP - INTERVAL '3 hours',
+				        CURRENT_TIMESTAMP - INTERVAL '2 hours', CURRENT_TIMESTAMP - INTERVAL '1 hour')
+				""", tripId, memberId);
+		jdbcTemplate.update("""
+				INSERT INTO mission_participations (id, trip_id, mission_id, status, attempt_count, completed_at)
+				VALUES (?, ?, ?, 'COMPLETED', 1, CURRENT_TIMESTAMP - INTERVAL '2 hours')
+				""", participationId, tripId, PHOTO_MISSION_ID);
+		jdbcTemplate.update("""
+				INSERT INTO mission_photos
+				    (id, member_id, trip_id, mission_id, object_key, content_type, file_size_bytes)
+				VALUES (?, ?, ?, ?, ?, 'image/jpeg', 1024)
+				""", photoId, memberId, tripId, PHOTO_MISSION_ID, objectKey);
+		jdbcTemplate.update("""
+				INSERT INTO mission_submissions (participation_id, type, photo_id, correct)
+				VALUES (?, 'PHOTO', ?, true)
+				""", participationId, photoId);
+		jdbcTemplate.update("""
+				INSERT INTO visit_records (trip_id, mission_id, place_id)
+				VALUES (?, ?, ?)
+				""", tripId, PHOTO_MISSION_ID, PLACE_ID);
+		jdbcTemplate.update("""
+				INSERT INTO point_transactions
+				    (member_id, trip_id, participation_id, type, amount, description)
+				VALUES (?, ?, ?, 'EARN', 100, '사진 미션')
+				""", memberId, tripId, participationId);
+		jdbcTemplate.update("""
+				INSERT INTO point_settlements (trip_id, choice, settled_points, settled_at)
+				VALUES (?, 'LEAVE_TO_BUYEO', 100, CURRENT_TIMESTAMP - INTERVAL '1 hour')
+				""", tripId);
+		jdbcTemplate.update("""
+				INSERT INTO badges (id, category, name, description, condition_text)
+				VALUES (?, 'RECORD', ?, '설명', '조건')
+				""", badgeId, "배지-" + memberId);
+		jdbcTemplate.update("INSERT INTO member_badges (member_id, badge_id, trip_id) VALUES (?, ?, ?)", memberId,
+				badgeId, tripId);
+		jdbcTemplate.update("""
+				INSERT INTO notifications (member_id, type, title, body)
+				VALUES (?, 'POINT', '포인트', '적립')
+				""", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO idempotency_requests
+				    (member_id, idempotency_key, operation, request_hash, expires_at)
+				VALUES (?, ?, 'test', 'hash', CURRENT_TIMESTAMP + INTERVAL '1 day')
+				""", memberId, UUID.randomUUID().toString());
+		return new Fixture(memberId, sessionId, tripId, participationId, photoId, objectKey);
+	}
+
+	private UUID insertMinimalWithdrawnMember(Instant purgeAfter) {
+		UUID memberId = UUID.randomUUID();
+		jdbcTemplate.update("""
+				INSERT INTO members (id, status, withdrawn_at, purge_after)
+				VALUES (?, 'WITHDRAWN', CURRENT_TIMESTAMP - INTERVAL '30 days', ?)
+				""", memberId, Timestamp.from(purgeAfter));
+		jdbcTemplate.update("""
+				INSERT INTO social_accounts (member_id, provider, provider_subject)
+				VALUES (?, 'KAKAO', ?)
+				""", memberId, UUID.randomUUID().toString());
+		jdbcTemplate.update("INSERT INTO member_settings (member_id) VALUES (?)", memberId);
+		return memberId;
+	}
+
+	private int nextSortOrder(String table) {
+		return Objects.requireNonNull(
+				jdbcTemplate.queryForObject("SELECT COALESCE(max(sort_order), 0) + 1 FROM " + table, Integer.class));
+	}
+
+	private void assertPurged(Fixture fixture) {
+		Map<String, Object> member = member(fixture.memberId());
+		assertThat(member.get("status").toString()).isEqualTo("WITHDRAWN");
+		assertThat(member.get("purged_at")).isNotNull();
+		assertThat(count("social_accounts", "member_id", fixture.memberId())).isEqualTo(1);
+		for (String table : new String[]{"auth_sessions", "term_consents", "member_profiles", "citizen_cards",
+				"member_settings", "saved_places", "trips", "mission_photos", "point_transactions", "member_badges",
+				"notifications", "idempotency_requests"}) {
+			assertThat(count(table, "member_id", fixture.memberId())).as(table).isZero();
+		}
+		assertThat(count("push_tokens", "auth_session_id", fixture.sessionId())).isZero();
+		assertThat(count("mission_participations", "trip_id", fixture.tripId())).isZero();
+		assertThat(count("mission_submissions", "participation_id", fixture.participationId())).isZero();
+		assertThat(count("mission_submissions", "photo_id", fixture.photoId())).isZero();
+		assertThat(count("visit_records", "trip_id", fixture.tripId())).isZero();
+		assertThat(count("point_settlements", "trip_id", fixture.tripId())).isZero();
+	}
+
+	private Map<String, Object> member(UUID memberId) {
+		return jdbcTemplate.queryForMap("SELECT * FROM members WHERE id = ?", memberId);
+	}
+
+	private long count(String table, String memberColumn, UUID memberId) {
+		return Objects.requireNonNull(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM " + table + " WHERE " + memberColumn + " = ?", Long.class, memberId));
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private record Fixture(UUID memberId, UUID sessionId, UUID tripId, UUID participationId, UUID photoId,
+			String objectKey) {
+	}
+}

--- a/src/test/java/com/buyeoon/member/application/WithdrawnMemberDataPurgeSchedulerTests.java
+++ b/src/test/java/com/buyeoon/member/application/WithdrawnMemberDataPurgeSchedulerTests.java
@@ -1,0 +1,20 @@
+package com.buyeoon.member.application;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WithdrawnMemberDataPurgeSchedulerTests {
+
+	@Test
+	@DisplayName("스케줄 실행은 회원 정보 파기 서비스에 위임한다")
+	void delegatesScheduledExecution() {
+		WithdrawnMemberDataPurgeService purgeService = mock(WithdrawnMemberDataPurgeService.class);
+
+		new WithdrawnMemberDataPurgeScheduler(purgeService).purgeDueMembers();
+
+		verify(purgeService).purgeDueMembers();
+	}
+}

--- a/src/test/java/com/buyeoon/persistence/SchemaMappingTests.java
+++ b/src/test/java/com/buyeoon/persistence/SchemaMappingTests.java
@@ -29,6 +29,8 @@ class SchemaMappingTests {
 			.of("src/main/resources/db/migration/V5__replace_public_image_urls_with_keys.sql");
 	private static final Path CITIZEN_CARD_CONSTRAINTS_MIGRATION = Path
 			.of("src/main/resources/db/migration/V7__add_citizen_card_constraints.sql");
+	private static final Path MEMBER_PURGE_MIGRATION = Path
+			.of("src/main/resources/db/migration/V8__track_member_data_purge.sql");
 	private static final Pattern CREATE_TABLE = Pattern.compile("CREATE TABLE ([a-z_]+) ");
 
 	/** 초기 스키마에 후속 마이그레이션을 적용한 정의가 기준 DB 스키마와 같음을 보장한다. */
@@ -60,6 +62,20 @@ class SchemaMappingTests {
 		String themeImageKeyColumn = imageKeyConstraint + " -- 테마 이미지 객체 키";
 		String sortOrderColumn = "    sort_order smallint NOT NULL UNIQUE CHECK (sort_order > 0)";
 		String displayNameConstraintEnd = "    )," + " -- 앞뒤 공백과 제어문자가 없는 표시 이름";
+		String legacyMemberLifecycle = String.join("\n", "    purge_after timestamptz, -- 개인정보 파기 기한", "    CHECK (",
+				"        (status = 'ACTIVE' AND withdrawn_at IS NULL AND purge_after IS NULL)",
+				"        OR (status = 'WITHDRAWN' AND withdrawn_at IS NOT NULL AND purge_after IS NOT NULL)", "    )");
+		String currentMemberLifecycle = String.join("\n", "    purge_after timestamptz, -- 개인정보 파기 기한",
+				"    purged_at timestamptz, -- 개인정보 파기 완료 시각", "    CHECK (",
+				"        (status = 'ACTIVE' AND withdrawn_at IS NULL AND purge_after IS NULL AND purged_at IS NULL)",
+				"        OR (", "            status = 'WITHDRAWN'", "            AND withdrawn_at IS NOT NULL",
+				"            AND purge_after IS NOT NULL",
+				"            AND (purged_at IS NULL OR purged_at >= withdrawn_at)", "        )", "    )");
+		String authSessionIndex = "CREATE INDEX auth_sessions_member_idx ON auth_sessions (member_id, expires_at);";
+		String memberPurgeIndexes = String.join("\n", authSessionIndex, "CREATE INDEX members_due_purge_idx",
+				"    ON members (purge_after, id)", "    WHERE status = 'WITHDRAWN' AND purged_at IS NULL;");
+		String privatePhotoObjectKey = "object_key text NOT NULL UNIQUE CHECK (object_key LIKE 'private/%'),"
+				+ " -- 비공개 스토리지 객체 키";
 		String publicImageKeySchema = baseline
 				.replace("expires_at timestamptz NOT NULL, -- 키 보관 만료 시각",
 						"expires_at timestamptz NOT NULL, -- 최초 성공 확정 시각부터 24시간인 키 보관 만료 시각")
@@ -84,13 +100,29 @@ class SchemaMappingTests {
 						String.join("\n", "barcode_value text NOT NULL UNIQUE CHECK (",
 								"        barcode_value ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}"
 										+ "-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'",
-								"    ), -- UUID 형식의 시연용 바코드 값"));
+								"    ), -- UUID 형식의 시연용 바코드 값"))
+				.replace(legacyMemberLifecycle, currentMemberLifecycle)
+				.replace("object_key text NOT NULL UNIQUE, -- 스토리지 객체 키", privatePhotoObjectKey)
+				.replace(authSessionIndex, memberPurgeIndexes);
 
 		assertThat(baseline).contains(placeSourceColumns).contains(placeLocationIndex).contains(legacyMissionStatus)
 				.contains(legacyMissionConstraints);
 		assertThat(publicImageKeySchema.replace(placeSourceColumns, placeExternalIdentityColumns)
 				.replace(placeLocationIndex, placeIndexes).replace(legacyMissionStatus, currentMissionStatus)
 				.replace(legacyMissionConstraints, currentMissionConstraints)).isEqualTo(canonicalSchema);
+	}
+
+	/** 탈퇴 회원 파기 완료 상태와 대상 조회 인덱스가 기준 스키마와 업그레이드 경로에 함께 존재하는지 검증한다. */
+	@Test
+	@DisplayName("회원 정보 파기 완료 상태는 기준 스키마와 마이그레이션에 정의되어 있다")
+	void memberPurgeCompletionIsDefinedInSchemaAndMigration() throws IOException {
+		String canonicalSchema = Files.readString(SCHEMA_SOURCE, StandardCharsets.UTF_8);
+		String migration = Files.readString(MEMBER_PURGE_MIGRATION, StandardCharsets.UTF_8);
+
+		assertThat(canonicalSchema).contains("purged_at timestamptz").contains("members_due_purge_idx")
+				.contains("purged_at IS NULL");
+		assertThat(migration).contains("ADD COLUMN purged_at timestamptz").contains("members_lifecycle_ck")
+				.contains("members_due_purge_idx").contains("mission_photos_object_key_prefix_ck");
 	}
 
 	/** 미션 상태와 시도 횟수 제약이 신규 설치용 스키마와 기존 DB 업그레이드에 모두 반영됐는지 검증한다. */


### PR DESCRIPTION
## 개요

탈퇴 후 보관 기한이 지난 회원의 서비스 이용 데이터를 정기 파기합니다.

Closes #71
Parent Epic: #70

## 변경 사항

- 1분 주기 파기 스케줄러와 페이지 기반 배치 순회
- S3 비공개 미션 사진 선삭제 후 관계형 데이터 트랜잭션 파기
- 회원별 실패 격리 및 다음 실행 재시도
- 재가입 방지용 회원·소셜 계정 최소 tombstone 유지
- `members.purged_at` 및 기한 도래 조회 인덱스 추가
- 미션 사진 객체 키의 `private/` 접두사 제약 추가

## 검증

- 정적 검사: Checkstyle, SpotBugs, Spotless 통과
- 대상 테스트 12개 통과
  - 탈퇴 회원 파기 통합 테스트 4개
  - 스케줄러 테스트 1개
  - 스키마 매핑 테스트 7개
- 최종 변경 전 전체 테스트 148개 통과
- PostgreSQL 스키마 통합 테스트 단독 통과
