### PR TITLE
refactor: UC-10 알림 목록 조회 JPQL + constructor projection 전환

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,7 @@ iOS Flutter
 - AWS RDS PostgreSQL과 PostGIS를 사용한다.
 - 장소는 `geography(Point, 4326)`와 GiST 인덱스로 저장한다.
 - 운영 JPA는 `ddl-auto=validate`를 사용한다.
-- 데이터 접근은 Spring Data JPA를 기본으로 사용하고, 조회·집계 로직에는 raw SQL(네이티브 쿼리)을 허용한다.
+- 데이터 접근은 Spring Data JPA를 기본으로 사용한다. 조회는 JPQL + constructor projection을 기본으로 하고, JPQL로 표현할 수 없는 SQL(집계·PostgreSQL 전용 문법)에만 네이티브 쿼리를 허용한다.
 - Spring Boot가 시작될 때 런타임 DB Role로 Flyway 마이그레이션을 실행하며 실패하면 애플리케이션 시작도 실패한다.
 - MVP에서는 Flyway DDL과 애플리케이션 DML에 하나의 PostgreSQL Role을 사용한다. RDS 관리자 계정은 최초 bootstrap에만 사용하고 애플리케이션에 제공하지 않는다.
 - 운영 PostGIS 확장은 최초 애플리케이션 배포 전에 인프라 bootstrap 단계에서 설치한다.

--- a/src/main/java/com/buyeoon/notification/application/NotificationQueryService.java
+++ b/src/main/java/com/buyeoon/notification/application/NotificationQueryService.java
@@ -1,15 +1,13 @@
 package com.buyeoon.notification.application;
 
 import com.buyeoon.notification.entity.NotificationType;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.Instant;
+import com.buyeoon.notification.repository.NotificationProjection;
+import com.buyeoon.notification.repository.NotificationQueryRepository;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,26 +15,20 @@ public class NotificationQueryService {
 
 	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
 
-	private static final String SELECT = """
-			SELECT id, type::text AS type, title, body, (read_at IS NOT NULL) AS read,
-			       occurred_at, target_type, target_id
-			FROM notifications
-			WHERE member_id = ?
-			""";
+	private final NotificationQueryRepository notificationQueryRepository;
 
-	private final JdbcOperations jdbcOperations;
-
-	public NotificationQueryService(JdbcOperations jdbcOperations) {
-		this.jdbcOperations = jdbcOperations;
+	public NotificationQueryService(NotificationQueryRepository notificationQueryRepository) {
+		this.notificationQueryRepository = notificationQueryRepository;
 	}
 
 	public NotificationListView list(UUID memberId, NotificationCursor cursor, int size) {
-		List<NotificationRow> rows = cursor == null
-				? notificationsFromStart(memberId, size)
-				: notificationsAfterCursor(memberId, cursor, size);
+		List<NotificationProjection> rows = cursor == null
+				? notificationQueryRepository.findFromStart(memberId, PageRequest.of(0, size + 1))
+				: notificationQueryRepository.findAfter(memberId, cursor.occurredAt(), cursor.notificationId(),
+						PageRequest.of(0, size + 1));
 
 		boolean hasNext = rows.size() > size;
-		List<NotificationRow> page = hasNext ? rows.subList(0, size) : rows;
+		List<NotificationProjection> page = hasNext ? rows.subList(0, size) : rows;
 		String nextCursor = hasNext
 				? new NotificationCursor(page.getLast().occurredAt(), page.getLast().id()).encode()
 				: null;
@@ -44,34 +36,10 @@ public class NotificationQueryService {
 		return new NotificationListView(items, new PageInfoView(nextCursor, hasNext));
 	}
 
-	private List<NotificationRow> notificationsFromStart(UUID memberId, int size) {
-		return jdbcOperations.query(SELECT + "ORDER BY occurred_at DESC, id DESC LIMIT ?", this::mapRow, memberId,
-				size + 1);
-	}
-
-	private List<NotificationRow> notificationsAfterCursor(UUID memberId, NotificationCursor cursor, int size) {
-		Timestamp occurredAt = Timestamp.from(cursor.occurredAt());
-		return jdbcOperations.query(
-				SELECT + "  AND (occurred_at, id) < (?, ?) ORDER BY occurred_at DESC, id DESC LIMIT ?", this::mapRow,
-				memberId, occurredAt, cursor.notificationId(), size + 1);
-	}
-
-	private NotificationRow mapRow(ResultSet resultSet, int rowNumber) throws SQLException {
-		return new NotificationRow(resultSet.getObject("id", UUID.class),
-				NotificationType.valueOf(resultSet.getString("type")), resultSet.getString("title"),
-				resultSet.getString("body"), resultSet.getBoolean("read"),
-				resultSet.getTimestamp("occurred_at").toInstant(), resultSet.getString("target_type"),
-				resultSet.getObject("target_id", UUID.class));
-	}
-
-	private NotificationItemView toView(NotificationRow row) {
+	private NotificationItemView toView(NotificationProjection row) {
 		String targetId = row.targetId() == null ? null : row.targetId().toString();
 		return new NotificationItemView(row.id(), row.type(), row.title(), row.body(), row.read(),
 				row.occurredAt().atZone(ASIA_SEOUL), row.targetType(), targetId);
-	}
-
-	private record NotificationRow(UUID id, NotificationType type, String title, String body, boolean read,
-			Instant occurredAt, String targetType, UUID targetId) {
 	}
 
 	public record NotificationListView(List<NotificationItemView> items, PageInfoView page) {

--- a/src/main/java/com/buyeoon/notification/repository/NotificationProjection.java
+++ b/src/main/java/com/buyeoon/notification/repository/NotificationProjection.java
@@ -1,0 +1,9 @@
+package com.buyeoon.notification.repository;
+
+import com.buyeoon.notification.entity.NotificationType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationProjection(UUID id, NotificationType type, String title, String body, Boolean read,
+		Instant occurredAt, String targetType, UUID targetId) {
+}

--- a/src/main/java/com/buyeoon/notification/repository/NotificationQueryRepository.java
+++ b/src/main/java/com/buyeoon/notification/repository/NotificationQueryRepository.java
@@ -1,0 +1,35 @@
+package com.buyeoon.notification.repository;
+
+import com.buyeoon.notification.entity.NotificationEntity;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface NotificationQueryRepository extends JpaRepository<NotificationEntity, UUID> {
+
+	@Query("""
+			SELECT new com.buyeoon.notification.repository.NotificationProjection(
+			       n.id, n.type, n.title, n.body, (n.readAt IS NOT NULL),
+			       n.occurredAt, n.targetType, n.targetId)
+			FROM NotificationEntity n
+			WHERE n.memberId = :memberId
+			ORDER BY n.occurredAt DESC, n.id DESC
+			""")
+	List<NotificationProjection> findFromStart(@Param("memberId") UUID memberId, Pageable pageable);
+
+	@Query("""
+			SELECT new com.buyeoon.notification.repository.NotificationProjection(
+			       n.id, n.type, n.title, n.body, (n.readAt IS NOT NULL),
+			       n.occurredAt, n.targetType, n.targetId)
+			FROM NotificationEntity n
+			WHERE n.memberId = :memberId
+			  AND (n.occurredAt < :occurredAt OR (n.occurredAt = :occurredAt AND n.id < :notificationId))
+			ORDER BY n.occurredAt DESC, n.id DESC
+			""")
+	List<NotificationProjection> findAfter(@Param("memberId") UUID memberId, @Param("occurredAt") Instant occurredAt,
+			@Param("notificationId") UUID notificationId, Pageable pageable);
+}


### PR DESCRIPTION
## 개요

UC-10 알림 목록 조회의 데이터 접근을 `JdbcTemplate` 기반 raw SQL에서 Spring Data JPA + JPQL constructor projection으로 전환합니다. 목적은 `ResultSet`/`mapRow` 보일러플레이트를 제거해 가독성을 높이는 것입니다.

Parent: #77 (알림 목록 조회)

## 변경 사항

- `NotificationQueryRepository` + JPQL `@Query`로 조회 이동
- keyset cursor의 PostgreSQL row-value comparison `(occurred_at, id) < (?, ?)`을 JPQL로 표현 가능한 `(occurred_at < :occurredAt OR (occurred_at = :occurredAt AND id < :notificationId))`로 분해 (인덱스 사용 동일)
- `NotificationProjection` record로 constructor projection (enum·Instant·read boolean 자동 매핑, `mapRow`·`NotificationRow`·`valueOf` 제거)
- `architecture.md` 데이터 접근 컨벤션을 "조회는 JPQL + constructor projection 기본, 네이티브 쿼리는 JPQL 불가능한 경우만"으로 갱신

## 검증

- 정적 검사: Spotless, Checkstyle, SpotBugs 통과
- 전체 테스트 156개 통과 (알림 목록 통합 테스트 7개 포함)

## 참고

- base가 `feat/uc-10-view-notifications`(#79)라서 stacked PR입니다. #79 merge 후 main으로 retarget 예정.
- `NotificationQueryRepository`는 #80의 `NotificationRepository`와 파일 충돌을 피하기 위해 분리했습니다. 추후 병합 시 통합 여부는 리뷰에서 결정해 주세요.
- 회원 도메인의 `JdbcTemplate` 기반 조회 서비스들은 이번 범위에서 제외했습니다(문서·코드 괴리는 별도 마이그레이션).
