### PR TITLE
feat: 진행 중인 여행 회원의 근처 장소 목록 조회 구현

### DIFF
--- a/src/main/java/com/buyeoon/common/api/ErrorResponse.java
+++ b/src/main/java/com/buyeoon/common/api/ErrorResponse.java
@@ -46,6 +46,10 @@ public record ErrorResponse(boolean success, ErrorData data) {
 		return new ErrorResponse(false, new ErrorData("RESOURCE_NOT_FOUND", "대상을 찾을 수 없습니다."));
 	}
 
+	public static ErrorResponse activeTripRequired() {
+		return new ErrorResponse(false, new ErrorData("ACTIVE_TRIP_REQUIRED", "진행 중인 여행이 있어야 이용할 수 있습니다."));
+	}
+
 	public record ErrorData(String code, String message) {
 	}
 }

--- a/src/main/java/com/buyeoon/place/api/InvalidPlaceRequestException.java
+++ b/src/main/java/com/buyeoon/place/api/InvalidPlaceRequestException.java
@@ -1,0 +1,4 @@
+package com.buyeoon.place.api;
+
+public class InvalidPlaceRequestException extends RuntimeException {
+}

--- a/src/main/java/com/buyeoon/place/api/PlaceController.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceController.java
@@ -1,0 +1,104 @@
+package com.buyeoon.place.api;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.place.application.PlaceCursor;
+import com.buyeoon.place.application.PlaceQueryService;
+import com.buyeoon.place.application.PlaceQueryService.PlaceListView;
+import com.buyeoon.place.entity.PlaceCategory;
+import java.util.Objects;
+import java.util.UUID;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PlaceController {
+
+	private static final int DEFAULT_SIZE = 20;
+	private static final int MIN_SIZE = 1;
+	private static final int MAX_SIZE = 100;
+
+	private final PlaceQueryService placeQueryService;
+
+	public PlaceController(PlaceQueryService placeQueryService) {
+		this.placeQueryService = placeQueryService;
+	}
+
+	@GetMapping("/places")
+	public SuccessResponse<PlaceListView> getPlaces(@AuthenticationPrincipal Jwt jwt,
+			@RequestParam(required = false) String category, @RequestParam String latitude,
+			@RequestParam String longitude, @RequestParam(required = false) String cursor,
+			@RequestParam(required = false) String size) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		return SuccessResponse.of(placeQueryService.list(memberId, parseCategory(category), latitude(latitude),
+				longitude(longitude), parseCursor(cursor), parseSize(size)));
+	}
+
+	private PlaceCategory parseCategory(String category) {
+		if (category == null) {
+			return null;
+		}
+		try {
+			return PlaceCategory.valueOf(category);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidPlaceRequestException();
+		}
+	}
+
+	private double latitude(String value) {
+		double latitude = coordinate(value);
+		if (latitude < -90 || latitude > 90) {
+			throw new InvalidPlaceRequestException();
+		}
+		return latitude;
+	}
+
+	private double longitude(String value) {
+		double longitude = coordinate(value);
+		if (longitude < -180 || longitude > 180) {
+			throw new InvalidPlaceRequestException();
+		}
+		return longitude;
+	}
+
+	private double coordinate(String value) {
+		try {
+			double coordinate = Double.parseDouble(value);
+			if (!Double.isFinite(coordinate)) {
+				throw new InvalidPlaceRequestException();
+			}
+			return coordinate;
+		} catch (NumberFormatException exception) {
+			throw new InvalidPlaceRequestException();
+		}
+	}
+
+	private PlaceCursor parseCursor(String cursor) {
+		if (cursor == null) {
+			return null;
+		}
+		try {
+			return PlaceCursor.decode(cursor);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidPlaceRequestException();
+		}
+	}
+
+	private int parseSize(String size) {
+		if (size == null) {
+			return DEFAULT_SIZE;
+		}
+		int value;
+		try {
+			value = Integer.parseInt(size);
+		} catch (NumberFormatException exception) {
+			throw new InvalidPlaceRequestException();
+		}
+		if (value < MIN_SIZE || value > MAX_SIZE) {
+			throw new InvalidPlaceRequestException();
+		}
+		return value;
+	}
+}

--- a/src/main/java/com/buyeoon/place/api/PlaceController.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class PlaceController {
 
-	private static final int DEFAULT_SIZE = 20;
 	private static final int MIN_SIZE = 1;
 	private static final int MAX_SIZE = 100;
 
@@ -30,10 +29,13 @@ public class PlaceController {
 	public SuccessResponse<PlaceListView> getPlaces(@AuthenticationPrincipal Jwt jwt,
 			@RequestParam(required = false) String category, @RequestParam String latitude,
 			@RequestParam String longitude, @RequestParam(required = false) String cursor,
-			@RequestParam(required = false) String size) {
+			@RequestParam(defaultValue = "20") int size) {
 		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		if (size < MIN_SIZE || size > MAX_SIZE) {
+			throw new InvalidPlaceRequestException();
+		}
 		return SuccessResponse.of(placeQueryService.list(memberId, parseCategory(category), latitude(latitude),
-				longitude(longitude), parseCursor(cursor), parseSize(size)));
+				longitude(longitude), parseCursor(cursor), size));
 	}
 
 	private PlaceCategory parseCategory(String category) {
@@ -84,21 +86,5 @@ public class PlaceController {
 		} catch (IllegalArgumentException exception) {
 			throw new InvalidPlaceRequestException();
 		}
-	}
-
-	private int parseSize(String size) {
-		if (size == null) {
-			return DEFAULT_SIZE;
-		}
-		int value;
-		try {
-			value = Integer.parseInt(size);
-		} catch (NumberFormatException exception) {
-			throw new InvalidPlaceRequestException();
-		}
-		if (value < MIN_SIZE || value > MAX_SIZE) {
-			throw new InvalidPlaceRequestException();
-		}
-		return value;
 	}
 }

--- a/src/main/java/com/buyeoon/place/api/PlaceExceptionHandler.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceExceptionHandler.java
@@ -7,11 +7,13 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice(assignableTypes = PlaceController.class)
 public class PlaceExceptionHandler {
 
-	@ExceptionHandler({InvalidPlaceRequestException.class, MissingServletRequestParameterException.class})
+	@ExceptionHandler({InvalidPlaceRequestException.class, MissingServletRequestParameterException.class,
+			MethodArgumentTypeMismatchException.class})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ErrorResponse handleInvalidRequest() {
 		return ErrorResponse.invalidRequest();

--- a/src/main/java/com/buyeoon/place/api/PlaceExceptionHandler.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.buyeoon.place.api;
+
+import com.buyeoon.common.api.ErrorResponse;
+import com.buyeoon.place.application.ActiveTripRequiredException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = PlaceController.class)
+public class PlaceExceptionHandler {
+
+	@ExceptionHandler({InvalidPlaceRequestException.class, MissingServletRequestParameterException.class})
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorResponse handleInvalidRequest() {
+		return ErrorResponse.invalidRequest();
+	}
+
+	@ExceptionHandler(ActiveTripRequiredException.class)
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	public ErrorResponse handleActiveTripRequired() {
+		return ErrorResponse.activeTripRequired();
+	}
+}

--- a/src/main/java/com/buyeoon/place/application/ActiveTripRequiredException.java
+++ b/src/main/java/com/buyeoon/place/application/ActiveTripRequiredException.java
@@ -1,0 +1,4 @@
+package com.buyeoon.place.application;
+
+public class ActiveTripRequiredException extends RuntimeException {
+}

--- a/src/main/java/com/buyeoon/place/application/PlaceCursor.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceCursor.java
@@ -1,0 +1,33 @@
+package com.buyeoon.place.application;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+
+/**
+ * 거리·ID 순 정렬을 이어받는 키셋 커서다. 거리를 십진 문자열로 적으면 PostGIS가 계산한 값과 마지막 자리가 어긋나 같은 장소가
+ * 다음 페이지에 다시 나오므로, 비트 패턴을 그대로 실어 왕복시킨다.
+ */
+public record PlaceCursor(double distanceMeters, UUID placeId) {
+
+	public static PlaceCursor decode(String value) {
+		try {
+			String decoded = new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
+			int separatorIndex = decoded.indexOf('_');
+			double distanceMeters = Double
+					.longBitsToDouble(Long.parseUnsignedLong(decoded.substring(0, separatorIndex), 16));
+			UUID placeId = UUID.fromString(decoded.substring(separatorIndex + 1));
+			if (!Double.isFinite(distanceMeters) || distanceMeters < 0) {
+				throw new IllegalArgumentException("잘못된 커서입니다.");
+			}
+			return new PlaceCursor(distanceMeters, placeId);
+		} catch (RuntimeException exception) {
+			throw new IllegalArgumentException("잘못된 커서입니다.", exception);
+		}
+	}
+
+	public String encode() {
+		String raw = Long.toHexString(Double.doubleToLongBits(distanceMeters)) + "_" + placeId;
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+	}
+}

--- a/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
@@ -1,0 +1,100 @@
+package com.buyeoon.place.application;
+
+import com.buyeoon.common.storage.PublicImageUrlService;
+import com.buyeoon.place.entity.PlaceCategory;
+import com.buyeoon.place.entity.PlaceEntity;
+import com.buyeoon.place.repository.PlaceProjection;
+import com.buyeoon.place.repository.PlaceQueryRepository;
+import com.buyeoon.place.repository.SavedPlaceRepository;
+import com.buyeoon.trip.TripQueryService;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class PlaceQueryService {
+
+	private static final double WALKING_METERS_PER_MINUTE = 67.0;
+
+	private final PlaceQueryRepository placeQueryRepository;
+	private final SavedPlaceRepository savedPlaceRepository;
+	private final TripQueryService tripQueryService;
+	private final PublicImageUrlService imageUrls;
+
+	public PlaceQueryService(PlaceQueryRepository placeQueryRepository, SavedPlaceRepository savedPlaceRepository,
+			TripQueryService tripQueryService, PublicImageUrlService imageUrls) {
+		this.placeQueryRepository = placeQueryRepository;
+		this.savedPlaceRepository = savedPlaceRepository;
+		this.tripQueryService = tripQueryService;
+		this.imageUrls = imageUrls;
+	}
+
+	public PlaceListView list(UUID memberId, PlaceCategory category, double latitude, double longitude,
+			PlaceCursor cursor, int size) {
+		if (!tripQueryService.hasActiveTrip(memberId)) {
+			throw new ActiveTripRequiredException();
+		}
+
+		List<PlaceProjection> rows = findRows(category, latitude, longitude, cursor, size);
+		boolean hasNext = rows.size() > size;
+		List<PlaceProjection> page = hasNext ? rows.subList(0, size) : rows;
+		String nextCursor = hasNext
+				? new PlaceCursor(page.getLast().distanceMeters(), page.getLast().place().getId()).encode()
+				: null;
+		Set<UUID> savedPlaceIds = findSavedPlaceIds(memberId, page);
+		List<PlaceItemView> items = page.stream().map(row -> toView(row, savedPlaceIds)).toList();
+		return new PlaceListView(items, new PageInfoView(nextCursor, hasNext));
+	}
+
+	private Set<UUID> findSavedPlaceIds(UUID memberId, List<PlaceProjection> page) {
+		if (page.isEmpty()) {
+			return Set.of();
+		}
+		List<UUID> placeIds = page.stream().map(row -> row.place().getId()).toList();
+		return Set.copyOf(savedPlaceRepository.findSavedPlaceIds(memberId, placeIds));
+	}
+
+	private List<PlaceProjection> findRows(PlaceCategory category, double latitude, double longitude,
+			PlaceCursor cursor, int size) {
+		PageRequest pageRequest = PageRequest.of(0, size + 1);
+		if (cursor == null) {
+			return category == null
+					? placeQueryRepository.findFromStart(latitude, longitude, pageRequest)
+					: placeQueryRepository.findFromStartByCategory(category, latitude, longitude, pageRequest);
+		}
+		return category == null
+				? placeQueryRepository.findAfter(latitude, longitude, cursor.distanceMeters(), cursor.placeId(),
+						pageRequest)
+				: placeQueryRepository.findAfterByCategory(category, latitude, longitude, cursor.distanceMeters(),
+						cursor.placeId(), pageRequest);
+	}
+
+	private PlaceItemView toView(PlaceProjection row, Set<UUID> savedPlaceIds) {
+		PlaceEntity place = row.place();
+		int distanceMeters = (int) Math.round(row.distanceMeters());
+		int walkingMinutes = (int) Math.ceil(row.distanceMeters() / WALKING_METERS_PER_MINUTE);
+		String imageUrl = place.getImageKey() == null ? null : imageUrls.create(place.getImageKey());
+
+		return new PlaceItemView(place.getId(), place.getCategory(), place.getName(), place.getSummary(),
+				place.getDescription(), place.getAddress(), imageUrl, place.getLocation().getY(),
+				place.getLocation().getX(), distanceMeters, walkingMinutes, savedPlaceIds.contains(place.getId()));
+	}
+
+	public record PlaceListView(List<PlaceItemView> items, PageInfoView page) {
+		public PlaceListView {
+			items = List.copyOf(items);
+		}
+	}
+
+	public record PlaceItemView(UUID placeId, PlaceCategory category, String name, String summary, String description,
+			String address, String imageUrl, double latitude, double longitude, Integer distanceMeters,
+			Integer walkingMinutes, boolean saved) {
+	}
+
+	public record PageInfoView(String nextCursor, boolean hasNext) {
+	}
+}

--- a/src/main/java/com/buyeoon/place/repository/PlaceProjection.java
+++ b/src/main/java/com/buyeoon/place/repository/PlaceProjection.java
@@ -1,0 +1,6 @@
+package com.buyeoon.place.repository;
+
+import com.buyeoon.place.entity.PlaceEntity;
+
+public record PlaceProjection(PlaceEntity place, double distanceMeters) {
+}

--- a/src/main/java/com/buyeoon/place/repository/PlaceQueryRepository.java
+++ b/src/main/java/com/buyeoon/place/repository/PlaceQueryRepository.java
@@ -46,7 +46,7 @@ public interface PlaceQueryRepository extends JpaRepository<PlaceEntity, UUID> {
 			      > :distanceMeters
 			   OR (ST_Distance(p.location,
 			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326))
-			       = :distanceMeters
+			       >= :distanceMeters
 			       AND p.id > :placeId)
 			ORDER BY 2 ASC, p.id ASC
 			""")
@@ -64,7 +64,7 @@ public interface PlaceQueryRepository extends JpaRepository<PlaceEntity, UUID> {
 			       > :distanceMeters
 			       OR (ST_Distance(p.location,
 			               ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326))
-			           = :distanceMeters
+			           >= :distanceMeters
 			           AND p.id > :placeId))
 			ORDER BY 2 ASC, p.id ASC
 			""")

--- a/src/main/java/com/buyeoon/place/repository/PlaceQueryRepository.java
+++ b/src/main/java/com/buyeoon/place/repository/PlaceQueryRepository.java
@@ -1,0 +1,74 @@
+package com.buyeoon.place.repository;
+
+import com.buyeoon.place.entity.PlaceCategory;
+import com.buyeoon.place.entity.PlaceEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 카테고리 지정 여부와 커서 유무를 각각 다른 쿼리로 나눠 둔다. nullable 파라미터를 {@code IS NULL OR ...}로
+ * 합치면 PostgreSQL이 파라미터 타입을 정하지 못해 실패한다.
+ */
+public interface PlaceQueryRepository extends JpaRepository<PlaceEntity, UUID> {
+
+	@Query("""
+			SELECT new com.buyeoon.place.repository.PlaceProjection(p,
+			       ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
+			FROM PlaceEntity p
+			ORDER BY 2 ASC, p.id ASC
+			""")
+	List<PlaceProjection> findFromStart(@Param("latitude") double latitude, @Param("longitude") double longitude,
+			Pageable pageable);
+
+	@Query("""
+			SELECT new com.buyeoon.place.repository.PlaceProjection(p,
+			       ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
+			FROM PlaceEntity p
+			WHERE p.category = :category
+			ORDER BY 2 ASC, p.id ASC
+			""")
+	List<PlaceProjection> findFromStartByCategory(@Param("category") PlaceCategory category,
+			@Param("latitude") double latitude, @Param("longitude") double longitude, Pageable pageable);
+
+	@Query("""
+			SELECT new com.buyeoon.place.repository.PlaceProjection(p,
+			       ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
+			FROM PlaceEntity p
+			WHERE ST_Distance(p.location,
+			          ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326))
+			      > :distanceMeters
+			   OR (ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326))
+			       = :distanceMeters
+			       AND p.id > :placeId)
+			ORDER BY 2 ASC, p.id ASC
+			""")
+	List<PlaceProjection> findAfter(@Param("latitude") double latitude, @Param("longitude") double longitude,
+			@Param("distanceMeters") double distanceMeters, @Param("placeId") UUID placeId, Pageable pageable);
+
+	@Query("""
+			SELECT new com.buyeoon.place.repository.PlaceProjection(p,
+			       ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
+			FROM PlaceEntity p
+			WHERE p.category = :category
+			  AND (ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326))
+			       > :distanceMeters
+			       OR (ST_Distance(p.location,
+			               ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326))
+			           = :distanceMeters
+			           AND p.id > :placeId))
+			ORDER BY 2 ASC, p.id ASC
+			""")
+	List<PlaceProjection> findAfterByCategory(@Param("category") PlaceCategory category,
+			@Param("latitude") double latitude, @Param("longitude") double longitude,
+			@Param("distanceMeters") double distanceMeters, @Param("placeId") UUID placeId, Pageable pageable);
+}

--- a/src/main/java/com/buyeoon/place/repository/SavedPlaceRepository.java
+++ b/src/main/java/com/buyeoon/place/repository/SavedPlaceRepository.java
@@ -1,0 +1,22 @@
+package com.buyeoon.place.repository;
+
+import com.buyeoon.place.entity.SavedPlaceEntity;
+import com.buyeoon.place.entity.SavedPlaceId;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SavedPlaceRepository extends JpaRepository<SavedPlaceEntity, SavedPlaceId> {
+
+	/** 조회한 페이지의 장소만 한 번에 확인해 장소 수만큼 질의가 늘어나지 않게 한다. */
+	@Query("""
+			SELECT s.id.placeId
+			FROM SavedPlaceEntity s
+			WHERE s.id.memberId = :memberId
+			  AND s.id.placeId IN :placeIds
+			""")
+	List<UUID> findSavedPlaceIds(@Param("memberId") UUID memberId, @Param("placeIds") Collection<UUID> placeIds);
+}

--- a/src/main/java/com/buyeoon/trip/TripQueryService.java
+++ b/src/main/java/com/buyeoon/trip/TripQueryService.java
@@ -1,0 +1,22 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.trip.entity.TripStatus;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 다른 도메인이 여행 상태를 확인할 때 사용하는 trip 도메인의 공개 seam이다. */
+@Service
+@Transactional(readOnly = true)
+public class TripQueryService {
+
+	private final TripRepository tripRepository;
+
+	public TripQueryService(TripRepository tripRepository) {
+		this.tripRepository = tripRepository;
+	}
+
+	public boolean hasActiveTrip(UUID memberId) {
+		return tripRepository.findByMemberIdAndStatus(memberId, TripStatus.IN_PROGRESS).isPresent();
+	}
+}

--- a/src/main/java/com/buyeoon/trip/TripRepository.java
+++ b/src/main/java/com/buyeoon/trip/TripRepository.java
@@ -1,0 +1,12 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.trip.entity.TripEntity;
+import com.buyeoon.trip.entity.TripStatus;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRepository extends JpaRepository<TripEntity, UUID> {
+
+	Optional<TripEntity> findByMemberIdAndStatus(UUID memberId, TripStatus status);
+}

--- a/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
@@ -1,0 +1,301 @@
+package com.buyeoon.place;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import com.buyeoon.place.entity.PlaceCategory;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import tools.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class PlaceControllerIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	// 시드 마이그레이션이 부여 지역에 장소 데이터를 채워두므로, 격리를 위해 남극 인근 좌표를
+	// 기준으로 테스트 데이터를 배치한다.
+	private static final double ORIGIN_LATITUDE = -75.0;
+	private static final double ORIGIN_LONGITUDE = 0.0;
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	private AuthenticatedMember member;
+
+	@BeforeAll
+	static void configureAwsCredentials() {
+		System.setProperty("aws.accessKeyId", "test-access-key");
+		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	@AfterAll
+	static void clearAwsCredentials() {
+		System.clearProperty("aws.accessKeyId");
+		System.clearProperty("aws.secretAccessKey");
+	}
+
+	@BeforeEach
+	void setUpMember() {
+		member = insertAuthenticatedMember();
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM saved_places");
+		jdbcTemplate.update("DELETE FROM places WHERE ST_Y(location::geometry) < -70");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 거리 정렬은 PostGIS ST_Distance 결과를 그대로 따르므로 가까운 장소가 먼저 나온다. */
+	@Test
+	@DisplayName("진행 중인 여행이 있는 회원은 거리순으로 정렬된 장소 목록을 받는다")
+	void returnsNearbyPlacesOrderedByDistanceForMemberWithActiveTrip() throws Exception {
+		startTrip(member.memberId());
+		UUID farPlace = savePlace(PlaceCategory.HERITAGE, "먼 장소", ORIGIN_LATITUDE + 0.05, ORIGIN_LONGITUDE + 0.05);
+		UUID nearPlace = savePlace(PlaceCategory.HERITAGE, "가까운 장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+
+		mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude",
+				String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.items[0].placeId").value(nearPlace.toString()))
+				.andExpect(jsonPath("$.data.items[0].distanceMeters", greaterThan(-1)))
+				.andExpect(jsonPath("$.data.items[1].placeId").value(farPlace.toString()));
+	}
+
+	/** 장소 탐색은 진행 중인 여행이 있는 회원만 이용할 수 있다. */
+	@Test
+	@DisplayName("진행 중인 여행이 없으면 403을 받는다")
+	void returns403WhenMemberHasNoActiveTrip() throws Exception {
+		mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude",
+				String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.success").value(false))
+				.andExpect(jsonPath("$.data.code").value("ACTIVE_TRIP_REQUIRED"));
+	}
+
+	/** 인증되지 않은 요청은 장소 목록을 볼 수 없다. */
+	@Test
+	@DisplayName("인증하지 않으면 401을 받는다")
+	void returns401WhenUnauthenticated() throws Exception {
+		mockMvc.perform(get("/places").param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude",
+				String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** latitude·longitude는 필수 파라미터다. */
+	@Test
+	@DisplayName("좌표가 없으면 400을 받는다")
+	void returns400WhenCoordinatesMissing() throws Exception {
+		startTrip(member.memberId());
+
+		mockMvc.perform(placeRequest()).andExpect(status().isBadRequest()).andExpect(jsonPath("$.success").value(false))
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	/** size와 cursor는 신뢰 경계의 입력이므로 잘못된 값은 500이 아니라 400으로 거른다. */
+	@Test
+	@DisplayName("잘못된 size나 cursor는 400을 받는다")
+	void returns400WhenPagingParametersAreInvalid() throws Exception {
+		startTrip(member.memberId());
+
+		for (String size : new String[]{"0", "-1", "101"}) {
+			mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE))
+					.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("size", size))
+					.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+		}
+		for (String cursor : new String[]{"abc", "!!!", "MTIz"}) {
+			mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE))
+					.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("cursor", cursor))
+					.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	/** 알 수 없는 카테고리나 범위를 벗어난 좌표는 500이 아니라 400으로 거른다. */
+	@Test
+	@DisplayName("잘못된 카테고리나 좌표는 400을 받는다")
+	void returns400WhenCategoryOrCoordinatesAreInvalid() throws Exception {
+		startTrip(member.memberId());
+
+		mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE))
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("category", "BANANA"))
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+
+		mockMvc.perform(placeRequest().param("latitude", "abc").param("longitude", String.valueOf(ORIGIN_LONGITUDE)))
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+
+		mockMvc.perform(placeRequest().param("latitude", "91.0").param("longitude", String.valueOf(ORIGIN_LONGITUDE)))
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	/** category를 지정하면 해당 카테고리 장소만 반환한다. */
+	@Test
+	@DisplayName("카테고리로 필터링된 장소 목록을 받는다")
+	void returnsPlacesFilteredByCategory() throws Exception {
+		startTrip(member.memberId());
+		savePlace(PlaceCategory.HERITAGE, "유적지", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+		savePlace(PlaceCategory.CAFE, "카페", ORIGIN_LATITUDE + 0.002, ORIGIN_LONGITUDE + 0.002);
+
+		mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE))
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("category", "CAFE"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items.length()").value(1))
+				.andExpect(jsonPath("$.data.items[0].category").value("CAFE"));
+	}
+
+	/** size만큼 끊어 반환하고, 커서로 이어받으면 남은 장소가 중복 없이 나온다. */
+	@Test
+	@DisplayName("size만큼 페이지네이션된 결과와 다음 커서를 받는다")
+	void returnsPaginatedResultsWithNextCursor() throws Exception {
+		startTrip(member.memberId());
+		UUID first = savePlace(PlaceCategory.HERITAGE, "장소1", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+		UUID second = savePlace(PlaceCategory.HERITAGE, "장소2", ORIGIN_LATITUDE + 0.002, ORIGIN_LONGITUDE + 0.002);
+		UUID third = savePlace(PlaceCategory.HERITAGE, "장소3", ORIGIN_LATITUDE + 0.003, ORIGIN_LONGITUDE + 0.003);
+
+		MvcResult firstPage = mockMvc
+				.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE))
+						.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("size", "2"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items.length()").value(2))
+				.andExpect(jsonPath("$.data.items[0].placeId").value(first.toString()))
+				.andExpect(jsonPath("$.data.items[1].placeId").value(second.toString()))
+				.andExpect(jsonPath("$.data.page.hasNext").value(true))
+				.andExpect(jsonPath("$.data.page.nextCursor").isString()).andReturn();
+
+		String nextCursor = objectMapper.readTree(firstPage.getResponse().getContentAsString()).get("data").get("page")
+				.get("nextCursor").stringValue();
+
+		// 시드 마이그레이션이 넣어 둔 부여 장소도 뒤쪽에 함께 잡히므로, 커서 다음 페이지의 첫
+		// 항목이 남은 내 장소인지와 앞 페이지가 다시 나오지 않는지만 확인한다.
+		mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE))
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("size", "2").param("cursor", nextCursor))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items[0].placeId").value(third.toString()))
+				.andExpect(jsonPath("$.data.items[*].placeId").value(not(hasItem(first.toString()))))
+				.andExpect(jsonPath("$.data.items[*].placeId").value(not(hasItem(second.toString()))));
+	}
+
+	/** saved는 요청한 회원이 저장한 장소에서만 참이고, 다른 회원의 저장은 영향을 주지 않는다. */
+	@Test
+	@DisplayName("저장한 장소만 saved가 참으로 표시된다")
+	void marksOnlyPlacesSavedByRequestingMember() throws Exception {
+		startTrip(member.memberId());
+		UUID savedPlace = savePlace(PlaceCategory.HERITAGE, "저장한 장소", ORIGIN_LATITUDE + 0.001,
+				ORIGIN_LONGITUDE + 0.001);
+		UUID otherPlace = savePlace(PlaceCategory.HERITAGE, "저장 안 한 장소", ORIGIN_LATITUDE + 0.002,
+				ORIGIN_LONGITUDE + 0.002);
+		savePlaceForMember(member.memberId(), savedPlace);
+		savePlaceForMember(insertAuthenticatedMember().memberId(), otherPlace);
+
+		mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude",
+				String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items[0].placeId").value(savedPlace.toString()))
+				.andExpect(jsonPath("$.data.items[0].saved").value(true))
+				.andExpect(jsonPath("$.data.items[1].placeId").value(otherPlace.toString()))
+				.andExpect(jsonPath("$.data.items[1].saved").value(false));
+	}
+
+	/** 목록의 각 장소는 거리와 도보 시간을 함께 제공한다. */
+	@Test
+	@DisplayName("각 장소 응답에 거리와 도보 시간이 포함된다")
+	void includesDistanceAndWalkingMinutesInResponse() throws Exception {
+		startTrip(member.memberId());
+		savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+
+		mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude",
+				String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items[0].distanceMeters").exists())
+				.andExpect(jsonPath("$.data.items[0].walkingMinutes").exists());
+	}
+
+	private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder placeRequest() {
+		return get("/places").header("Authorization", "Bearer " + member.accessToken());
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private void savePlaceForMember(UUID memberId, UUID placeId) {
+		jdbcTemplate.update("INSERT INTO saved_places (member_id, place_id) VALUES (?, ?)", memberId, placeId);
+	}
+
+	private void startTrip(UUID memberId) {
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status) VALUES (?, ?, 'IN_PROGRESS')", UUID.randomUUID(),
+				memberId);
+	}
+
+	private UUID savePlace(PlaceCategory category, String name, double latitude, double longitude) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO places (id, category, name, location) VALUES (?, ?::place_category, ?, "
+						+ "ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography)",
+				id, category.name(), name, longitude, latitude);
+		return id;
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("storage.images.bucket", () -> "buyeoon-test-images");
+		registry.add("storage.images.region", () -> "ap-northeast-2");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}

--- a/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
@@ -108,6 +108,38 @@ class PlaceControllerIntegrationTests {
 				.andExpect(jsonPath("$.data.items[1].placeId").value(farPlace.toString()));
 	}
 
+	/**
+	 * 커서 다음 페이지의 동점 조건이 등호(=)면 재계산된 거리가 원래 값과 부동소수점 마지막 자리까지 일치하지 않는 경우 동점 그룹 나머지가
+	 * 통째로 누락된다. 좌표가 완전히 같은 두 장소로 동점을 만들어 id 가드(>=+id>)가 실제로 그 그룹을 넘기는지 확인한다.
+	 */
+	@Test
+	@DisplayName("같은 거리의 장소가 커서 경계에 걸쳐 있어도 누락되지 않는다")
+	void returnsTiedDistancePlacesAcrossCursorBoundary() throws Exception {
+		startTrip(member.memberId());
+		double tiedLatitude = ORIGIN_LATITUDE + 0.001;
+		double tiedLongitude = ORIGIN_LONGITUDE + 0.001;
+		UUID first = savePlace(PlaceCategory.HERITAGE, "동점1", tiedLatitude, tiedLongitude);
+		UUID second = savePlace(PlaceCategory.HERITAGE, "동점2", tiedLatitude, tiedLongitude);
+		UUID third = savePlace(PlaceCategory.HERITAGE, "동점3", tiedLatitude, tiedLongitude);
+
+		MvcResult firstPage = mockMvc
+				.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE))
+						.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("size", "1"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.page.hasNext").value(true)).andReturn();
+		String nextCursor = objectMapper.readTree(firstPage.getResponse().getContentAsString()).get("data").get("page")
+				.get("nextCursor").stringValue();
+
+		mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE))
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("size", "2").param("cursor", nextCursor))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items.length()").value(2));
+
+		mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE))
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("size", "10")).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items[*].placeId").value(hasItem(first.toString())))
+				.andExpect(jsonPath("$.data.items[*].placeId").value(hasItem(second.toString())))
+				.andExpect(jsonPath("$.data.items[*].placeId").value(hasItem(third.toString())));
+	}
+
 	/** 장소 탐색은 진행 중인 여행이 있는 회원만 이용할 수 있다. */
 	@Test
 	@DisplayName("진행 중인 여행이 없으면 403을 받는다")


### PR DESCRIPTION
## 개요

진행 중인 여행이 있는 회원이 현재 위치 기준으로 주변 장소를 거리순으로 조회

Closes #7
Parent Epic: #6

## 변경 사항

- **GET /places** 구현 — 카테고리 필터, 좌표 필수 검증, keyset 커서 페이지네이션(size 기본 20, 허용 1~100)
- PostGIS `ST_Distance` 기반 거리 계산과 도보 예상 시간(distanceMeters, walkingMinutes) 제공
- saved 필드를 `saved_places` 조회로 실제 계산 (페이지당 단일 쿼리, N+1 없음)
- 여행 도메인 공개 seam(`TripQueryService`)을 통해 진행 중인 여행 여부 검증

## 검증

- 통합 테스트(HTTP + PostgreSQL/PostGIS) 10개 통과
  - 거리순 정렬, 카테고리 필터, 커서 페이지네이션, saved 표시
- 실제 PostGIS 인스턴스에 부여 좌표(정림사지·부소산성 등)로 수동 호출해 거리·도보 시간 값 확인