### PR TITLE
feat: 진행 중인 trip일때 member 장소 상세 조회

### DIFF
--- a/src/main/java/com/buyeoon/place/api/PlaceController.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceController.java
@@ -3,6 +3,7 @@ package com.buyeoon.place.api;
 import com.buyeoon.common.api.SuccessResponse;
 import com.buyeoon.place.application.PlaceCursor;
 import com.buyeoon.place.application.PlaceQueryService;
+import com.buyeoon.place.application.PlaceQueryService.PlaceItemView;
 import com.buyeoon.place.application.PlaceQueryService.PlaceListView;
 import com.buyeoon.place.entity.PlaceCategory;
 import java.util.Objects;
@@ -10,6 +11,7 @@ import java.util.UUID;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,6 +38,13 @@ public class PlaceController {
 		}
 		return SuccessResponse.of(placeQueryService.list(memberId, parseCategory(category), latitude(latitude),
 				longitude(longitude), parseCursor(cursor), size));
+	}
+
+	@GetMapping("/places/{placeId}")
+	public SuccessResponse<PlaceItemView> getPlace(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID placeId,
+			@RequestParam String latitude, @RequestParam String longitude) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		return SuccessResponse.of(placeQueryService.get(memberId, placeId, latitude(latitude), longitude(longitude)));
 	}
 
 	private PlaceCategory parseCategory(String category) {

--- a/src/main/java/com/buyeoon/place/api/PlaceExceptionHandler.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceExceptionHandler.java
@@ -2,6 +2,7 @@ package com.buyeoon.place.api;
 
 import com.buyeoon.common.api.ErrorResponse;
 import com.buyeoon.place.application.ActiveTripRequiredException;
+import com.buyeoon.place.application.PlaceNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -23,5 +24,11 @@ public class PlaceExceptionHandler {
 	@ResponseStatus(HttpStatus.FORBIDDEN)
 	public ErrorResponse handleActiveTripRequired() {
 		return ErrorResponse.activeTripRequired();
+	}
+
+	@ExceptionHandler(PlaceNotFoundException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public ErrorResponse handleNotFound() {
+		return ErrorResponse.resourceNotFound();
 	}
 }

--- a/src/main/java/com/buyeoon/place/application/PlaceNotFoundException.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceNotFoundException.java
@@ -1,0 +1,4 @@
+package com.buyeoon.place.application;
+
+public class PlaceNotFoundException extends RuntimeException {
+}

--- a/src/main/java/com/buyeoon/place/application/PlaceNotFoundException.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceNotFoundException.java
@@ -1,4 +1,8 @@
 package com.buyeoon.place.application;
 
 public class PlaceNotFoundException extends RuntimeException {
+
+	public PlaceNotFoundException() {
+		super("존재하지 않는 장소입니다.");
+	}
 }

--- a/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
@@ -57,8 +57,8 @@ public class PlaceQueryService {
 
 		PlaceProjection row = placeQueryRepository.findByIdWithDistance(placeId, latitude, longitude)
 				.orElseThrow(PlaceNotFoundException::new);
-		Set<UUID> savedPlaceIds = Set.copyOf(savedPlaceRepository.findSavedPlaceIds(memberId, List.of(placeId)));
-		return toView(row, savedPlaceIds);
+		boolean saved = savedPlaceRepository.existsByMemberIdAndPlaceId(memberId, placeId);
+		return toView(row, saved);
 	}
 
 	private Set<UUID> findSavedPlaceIds(UUID memberId, List<PlaceProjection> page) {
@@ -85,6 +85,10 @@ public class PlaceQueryService {
 	}
 
 	private PlaceItemView toView(PlaceProjection row, Set<UUID> savedPlaceIds) {
+		return toView(row, savedPlaceIds.contains(row.place().getId()));
+	}
+
+	private PlaceItemView toView(PlaceProjection row, boolean saved) {
 		PlaceEntity place = row.place();
 		int distanceMeters = (int) Math.round(row.distanceMeters());
 		int walkingMinutes = (int) Math.ceil(row.distanceMeters() / WALKING_METERS_PER_MINUTE);
@@ -92,7 +96,7 @@ public class PlaceQueryService {
 
 		return new PlaceItemView(place.getId(), place.getCategory(), place.getName(), place.getSummary(),
 				place.getDescription(), place.getAddress(), imageUrl, place.getLocation().getY(),
-				place.getLocation().getX(), distanceMeters, walkingMinutes, savedPlaceIds.contains(place.getId()));
+				place.getLocation().getX(), distanceMeters, walkingMinutes, saved);
 	}
 
 	public record PlaceListView(List<PlaceItemView> items, PageInfoView page) {

--- a/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
@@ -50,6 +50,17 @@ public class PlaceQueryService {
 		return new PlaceListView(items, new PageInfoView(nextCursor, hasNext));
 	}
 
+	public PlaceItemView get(UUID memberId, UUID placeId, double latitude, double longitude) {
+		if (!tripQueryService.hasActiveTrip(memberId)) {
+			throw new ActiveTripRequiredException();
+		}
+
+		PlaceProjection row = placeQueryRepository.findByIdWithDistance(placeId, latitude, longitude)
+				.orElseThrow(PlaceNotFoundException::new);
+		Set<UUID> savedPlaceIds = Set.copyOf(savedPlaceRepository.findSavedPlaceIds(memberId, List.of(placeId)));
+		return toView(row, savedPlaceIds);
+	}
+
 	private Set<UUID> findSavedPlaceIds(UUID memberId, List<PlaceProjection> page) {
 		if (page.isEmpty()) {
 			return Set.of();

--- a/src/main/java/com/buyeoon/place/repository/PlaceQueryRepository.java
+++ b/src/main/java/com/buyeoon/place/repository/PlaceQueryRepository.java
@@ -3,6 +3,7 @@ package com.buyeoon.place.repository;
 import com.buyeoon.place.entity.PlaceCategory;
 import com.buyeoon.place.entity.PlaceEntity;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -71,4 +72,14 @@ public interface PlaceQueryRepository extends JpaRepository<PlaceEntity, UUID> {
 	List<PlaceProjection> findAfterByCategory(@Param("category") PlaceCategory category,
 			@Param("latitude") double latitude, @Param("longitude") double longitude,
 			@Param("distanceMeters") double distanceMeters, @Param("placeId") UUID placeId, Pageable pageable);
+
+	@Query("""
+			SELECT new com.buyeoon.place.repository.PlaceProjection(p,
+			       ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
+			FROM PlaceEntity p
+			WHERE p.id = :placeId
+			""")
+	Optional<PlaceProjection> findByIdWithDistance(@Param("placeId") UUID placeId, @Param("latitude") double latitude,
+			@Param("longitude") double longitude);
 }

--- a/src/main/java/com/buyeoon/place/repository/SavedPlaceRepository.java
+++ b/src/main/java/com/buyeoon/place/repository/SavedPlaceRepository.java
@@ -19,4 +19,8 @@ public interface SavedPlaceRepository extends JpaRepository<SavedPlaceEntity, Sa
 			  AND s.id.placeId IN :placeIds
 			""")
 	List<UUID> findSavedPlaceIds(@Param("memberId") UUID memberId, @Param("placeIds") Collection<UUID> placeIds);
+
+	default boolean existsByMemberIdAndPlaceId(UUID memberId, UUID placeId) {
+		return existsById(new SavedPlaceId(memberId, placeId));
+	}
 }

--- a/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
@@ -281,8 +281,74 @@ class PlaceControllerIntegrationTests {
 				.andExpect(jsonPath("$.data.items[0].walkingMinutes").exists());
 	}
 
+	/** 진행 중인 여행이 있는 회원은 존재하는 장소의 상세를 받는다. */
+	@Test
+	@DisplayName("유효한 위치·진행 중 여행으로 요청하면 200과 함께 장소 상세를 받는다")
+	void returnsPlaceDetailForMemberWithActiveTrip() throws Exception {
+		startTrip(member.memberId());
+		UUID placeId = savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+
+		mockMvc.perform(placeDetailRequest(placeId).param("latitude", String.valueOf(ORIGIN_LATITUDE))
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.placeId").value(placeId.toString()))
+				.andExpect(jsonPath("$.data.name").value("장소")).andExpect(jsonPath("$.data.category").value("HERITAGE"))
+				.andExpect(jsonPath("$.data.distanceMeters").exists())
+				.andExpect(jsonPath("$.data.walkingMinutes").exists());
+	}
+
+	/** 장소 탐색은 진행 중인 여행이 있는 회원만 이용할 수 있다. */
+	@Test
+	@DisplayName("장소 상세 조회는 진행 중인 여행이 없으면 403을 받는다")
+	void returns403ForPlaceDetailWhenMemberHasNoActiveTrip() throws Exception {
+		UUID placeId = savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+
+		mockMvc.perform(placeDetailRequest(placeId).param("latitude", String.valueOf(ORIGIN_LATITUDE))
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.data.code").value("ACTIVE_TRIP_REQUIRED"));
+	}
+
+	/** 인증되지 않은 요청은 장소 상세를 볼 수 없다. */
+	@Test
+	@DisplayName("장소 상세 조회는 인증하지 않으면 401을 받는다")
+	void returns401ForPlaceDetailWhenUnauthenticated() throws Exception {
+		UUID placeId = UUID.randomUUID();
+
+		mockMvc.perform(get("/places/" + placeId).param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude",
+				String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** latitude·longitude는 장소 상세 조회에서도 필수 파라미터다. */
+	@Test
+	@DisplayName("장소 상세 조회는 좌표가 없으면 400을 받는다")
+	void returns400ForPlaceDetailWhenCoordinatesMissing() throws Exception {
+		startTrip(member.memberId());
+		UUID placeId = savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+
+		mockMvc.perform(placeDetailRequest(placeId)).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	/** 존재하지 않는 placeId는 404를 받는다. */
+	@Test
+	@DisplayName("존재하지 않는 placeId면 404를 받는다")
+	void returns404WhenPlaceDoesNotExist() throws Exception {
+		startTrip(member.memberId());
+		UUID placeId = UUID.randomUUID();
+
+		mockMvc.perform(placeDetailRequest(placeId).param("latitude", String.valueOf(ORIGIN_LATITUDE))
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
 	private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder placeRequest() {
 		return get("/places").header("Authorization", "Bearer " + member.accessToken());
+	}
+
+	private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder placeDetailRequest(
+			UUID placeId) {
+		return get("/places/" + placeId).header("Authorization", "Bearer " + member.accessToken());
 	}
 
 	private AuthenticatedMember insertAuthenticatedMember() {

--- a/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
@@ -294,7 +294,21 @@ class PlaceControllerIntegrationTests {
 				.andExpect(jsonPath("$.data.placeId").value(placeId.toString()))
 				.andExpect(jsonPath("$.data.name").value("장소")).andExpect(jsonPath("$.data.category").value("HERITAGE"))
 				.andExpect(jsonPath("$.data.distanceMeters").exists())
-				.andExpect(jsonPath("$.data.walkingMinutes").exists());
+				.andExpect(jsonPath("$.data.walkingMinutes").exists())
+				.andExpect(jsonPath("$.data.saved").value(false));
+	}
+
+	/** 요청 회원이 저장한 장소는 saved가 참으로 표시된다. */
+	@Test
+	@DisplayName("저장한 장소의 상세 조회는 saved가 true를 받는다")
+	void returnsSavedTrueForPlaceSavedByRequestingMember() throws Exception {
+		startTrip(member.memberId());
+		UUID placeId = savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+		savePlaceForMember(member.memberId(), placeId);
+
+		mockMvc.perform(placeDetailRequest(placeId).param("latitude", String.valueOf(ORIGIN_LATITUDE))
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.saved").value(true));
 	}
 
 	/** 장소 탐색은 진행 중인 여행이 있는 회원만 이용할 수 있다. */


### PR DESCRIPTION
## 개요

진행 중인 여행이 있는 회원이 특정 장소를 조회

Closes #8
Parent Epic: #6

## 변경 사항

- **GET /places/{placeId}** 구현 — 좌표 필수 검증, 진행 중 여행 검증은 #7과 동일한 공개 seam(`TripQueryService`) 재사용
- PostGIS `ST_Distance` 기반 거리 계산과 도보 예상 시간(distanceMeters, walkingMinutes)은 #7의 계산 로직 재사용
- saved 필드는 요청 회원의 저장 여부를 `saved_places` 조회로 계산
- 존재하지 않는 placeId는 404(RESOURCE_NOT_FOUND) 반환

## 검증

- 통합 테스트(HTTP + PostgreSQL/PostGIS) 5개 통과
  - 정상 조회(200), 여행 없음(403), 미인증(401), 좌표 누락(400), 존재하지 않는 장소(404)
- 실제 로컬 스택(docker compose)에 부여 좌표로 수동 호출해 200/401/400/404 응답 확인