### PR TITLE
feat: uc-05 여행 시작 구현

### DIFF
--- a/src/main/java/com/buyeoon/common/api/ErrorResponse.java
+++ b/src/main/java/com/buyeoon/common/api/ErrorResponse.java
@@ -35,7 +35,11 @@ public record ErrorResponse(boolean success, ErrorData data) {
 	}
 
 	public static ErrorResponse outsideBuyeo() {
-		return new ErrorResponse(false, new ErrorData("OUTSIDE_BUYEO", "부여 안에서만 군민증을 만들 수 있습니다."));
+		return new ErrorResponse(false, new ErrorData("OUTSIDE_BUYEO", "부여 안에서만 이용할 수 있습니다."));
+	}
+
+	public static ErrorResponse citizenCardNotIssued() {
+		return new ErrorResponse(false, new ErrorData("CITIZEN_CARD_NOT_ISSUED", "군민증을 먼저 발급해 주세요."));
 	}
 
 	public static ErrorResponse invalidStateTransition() {

--- a/src/main/java/com/buyeoon/trip/CitizenCardNotIssuedException.java
+++ b/src/main/java/com/buyeoon/trip/CitizenCardNotIssuedException.java
@@ -1,0 +1,4 @@
+package com.buyeoon.trip;
+
+public class CitizenCardNotIssuedException extends RuntimeException {
+}

--- a/src/main/java/com/buyeoon/trip/CitizenCardRepository.java
+++ b/src/main/java/com/buyeoon/trip/CitizenCardRepository.java
@@ -1,0 +1,11 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.member.entity.CitizenCardEntity;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** 여행 시작 서비스가 군민증 발급 여부를 확인하기 위한 trip 도메인 소유의 읽기 전용 리포지토리다. */
+public interface CitizenCardRepository extends JpaRepository<CitizenCardEntity, UUID> {
+
+	boolean existsByMemberId(UUID memberId);
+}

--- a/src/main/java/com/buyeoon/trip/IdempotencyRequestRepository.java
+++ b/src/main/java/com/buyeoon/trip/IdempotencyRequestRepository.java
@@ -1,0 +1,14 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.common.entity.IdempotencyRequestEntity;
+import com.buyeoon.common.entity.IdempotencyRequestId;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+public interface IdempotencyRequestRepository extends JpaRepository<IdempotencyRequestEntity, IdempotencyRequestId> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<IdempotencyRequestEntity> findById(IdempotencyRequestId id);
+}

--- a/src/main/java/com/buyeoon/trip/InvalidTripStartRequestException.java
+++ b/src/main/java/com/buyeoon/trip/InvalidTripStartRequestException.java
@@ -1,0 +1,4 @@
+package com.buyeoon.trip;
+
+public class InvalidTripStartRequestException extends RuntimeException {
+}

--- a/src/main/java/com/buyeoon/trip/MemberRepository.java
+++ b/src/main/java/com/buyeoon/trip/MemberRepository.java
@@ -1,0 +1,16 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.member.entity.MemberEntity;
+import com.buyeoon.member.entity.MemberStatus;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+/** 여행 시작 서비스가 회원 행을 잠그기 위한 trip 도메인 소유의 읽기 전용 리포지토리다. */
+public interface MemberRepository extends JpaRepository<MemberEntity, UUID> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<MemberEntity> findByIdAndStatus(UUID id, MemberStatus status);
+}

--- a/src/main/java/com/buyeoon/trip/TermRepository.java
+++ b/src/main/java/com/buyeoon/trip/TermRepository.java
@@ -1,0 +1,27 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.member.entity.TermEntity;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** 여행 시작 서비스가 필수 약관 동의 여부를 확인하기 위한 trip 도메인 소유의 읽기 전용 리포지토리다. */
+public interface TermRepository extends JpaRepository<TermEntity, UUID> {
+
+	@Query("""
+			SELECT count(currentTerm) = 0
+			FROM TermEntity currentTerm
+			WHERE currentTerm.required = true
+			  AND currentTerm.effectiveAt = (
+			      SELECT max(latest.effectiveAt) FROM TermEntity latest
+			      WHERE latest.type = currentTerm.type AND latest.required = true
+			        AND latest.effectiveAt <= function('clock_timestamp')
+			  )
+			  AND currentTerm.id NOT IN (
+			      SELECT consent.id.termId FROM TermConsentEntity consent
+			      WHERE consent.id.memberId = :memberId AND consent.agreed = true
+			  )
+			""")
+	boolean hasAgreedToCurrentRequiredTerms(@Param("memberId") UUID memberId);
+}

--- a/src/main/java/com/buyeoon/trip/TripController.java
+++ b/src/main/java/com/buyeoon/trip/TripController.java
@@ -1,0 +1,101 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.trip.TripStartService.LocationCommand;
+import com.buyeoon.trip.TripStartService.TripStartCommand;
+import com.buyeoon.trip.TripStartService.TripView;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import tools.jackson.databind.JsonNode;
+
+@RestController
+public class TripController {
+
+	private final TripStarter tripStart;
+
+	public TripController(TripStarter tripStart) {
+		this.tripStart = tripStart;
+	}
+
+	@PostMapping("/trips")
+	public ResponseEntity<SuccessResponse<TripView>> start(@AuthenticationPrincipal Jwt jwt,
+			@RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey,
+			@RequestBody JsonNode request) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		TripView trip = tripStart.start(memberId, idempotencyKey, parseRequest(request));
+		return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.of(trip));
+	}
+
+	private TripStartCommand parseRequest(JsonNode request) {
+		if (request == null || !request.isObject() || !hasOnlyProperties(request, Set.of("location"))) {
+			throw new InvalidTripStartRequestException();
+		}
+		return new TripStartCommand(location(request.get("location")));
+	}
+
+	private LocationCommand location(JsonNode node) {
+		Set<String> fields = Set.of("latitude", "longitude", "accuracyMeters", "capturedAt");
+		if (node == null || !node.isObject() || !hasOnlyOptionalProperties(node, fields, 3, 4)) {
+			throw new InvalidTripStartRequestException();
+		}
+		double latitude = finiteNumber(node.get("latitude"));
+		double longitude = finiteNumber(node.get("longitude"));
+		if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+			throw new InvalidTripStartRequestException();
+		}
+		Double accuracy = nullableAccuracy(node.get("accuracyMeters"));
+		OffsetDateTime capturedAt = dateTime(node.get("capturedAt"));
+		return new LocationCommand(latitude, longitude, accuracy, capturedAt);
+	}
+
+	private double finiteNumber(JsonNode node) {
+		if (node == null || !node.isNumber() || !Double.isFinite(node.doubleValue())) {
+			throw new InvalidTripStartRequestException();
+		}
+		return node.doubleValue();
+	}
+
+	private Double nullableAccuracy(JsonNode node) {
+		if (node == null || node.isNull()) {
+			return null;
+		}
+		double accuracy = finiteNumber(node);
+		if (accuracy < 0) {
+			throw new InvalidTripStartRequestException();
+		}
+		return accuracy;
+	}
+
+	private OffsetDateTime dateTime(JsonNode node) {
+		if (node == null || !node.isString()) {
+			throw new InvalidTripStartRequestException();
+		}
+		try {
+			return OffsetDateTime.parse(node.stringValue());
+		} catch (DateTimeParseException exception) {
+			throw new InvalidTripStartRequestException();
+		}
+	}
+
+	private boolean hasOnlyProperties(JsonNode node, Set<String> properties) {
+		return node.size() == properties.size()
+				&& node.properties().stream().allMatch(property -> properties.contains(property.getKey()));
+	}
+
+	private boolean hasOnlyOptionalProperties(JsonNode node, Set<String> properties, int minimum, int maximum) {
+		return node.size() >= minimum && node.size() <= maximum
+				&& node.properties().stream().allMatch(property -> properties.contains(property.getKey()))
+				&& node.has("latitude") && node.has("longitude") && node.has("capturedAt");
+	}
+}

--- a/src/main/java/com/buyeoon/trip/TripExceptionHandler.java
+++ b/src/main/java/com/buyeoon/trip/TripExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.common.api.ErrorResponse;
+import com.buyeoon.member.application.IdempotencyKeyReusedException;
+import com.buyeoon.member.application.InvalidStateTransitionException;
+import com.buyeoon.member.application.OutsideBuyeoException;
+import com.buyeoon.member.application.RequiredTermsNotAgreedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = TripController.class)
+public class TripExceptionHandler {
+
+	@ExceptionHandler({InvalidTripStartRequestException.class, HttpMessageNotReadableException.class})
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorResponse handleInvalidRequest() {
+		return ErrorResponse.invalidRequest();
+	}
+
+	@ExceptionHandler(RequiredTermsNotAgreedException.class)
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	public ErrorResponse handleRequiredTermsNotAgreed() {
+		return ErrorResponse.requiredTermsNotAgreed();
+	}
+
+	@ExceptionHandler(CitizenCardNotIssuedException.class)
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	public ErrorResponse handleCitizenCardNotIssued() {
+		return ErrorResponse.citizenCardNotIssued();
+	}
+
+	@ExceptionHandler(OutsideBuyeoException.class)
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	public ErrorResponse handleOutsideBuyeo() {
+		return ErrorResponse.outsideBuyeo();
+	}
+
+	@ExceptionHandler(InvalidStateTransitionException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ErrorResponse handleInvalidStateTransition() {
+		return ErrorResponse.invalidStateTransition();
+	}
+
+	@ExceptionHandler(IdempotencyKeyReusedException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ErrorResponse handleIdempotencyKeyReused() {
+		return ErrorResponse.idempotencyKeyReused();
+	}
+}

--- a/src/main/java/com/buyeoon/trip/TripRepository.java
+++ b/src/main/java/com/buyeoon/trip/TripRepository.java
@@ -2,11 +2,19 @@ package com.buyeoon.trip;
 
 import com.buyeoon.trip.entity.TripEntity;
 import com.buyeoon.trip.entity.TripStatus;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TripRepository extends JpaRepository<TripEntity, UUID> {
 
 	Optional<TripEntity> findByMemberIdAndStatus(UUID memberId, TripStatus status);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT t FROM TripEntity t WHERE t.memberId = :memberId AND t.status = :status")
+	Optional<TripEntity> lockByMemberIdAndStatus(@Param("memberId") UUID memberId, @Param("status") TripStatus status);
 }

--- a/src/main/java/com/buyeoon/trip/TripStartService.java
+++ b/src/main/java/com/buyeoon/trip/TripStartService.java
@@ -1,0 +1,219 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.common.entity.IdempotencyRequestEntity;
+import com.buyeoon.common.entity.IdempotencyRequestId;
+import com.buyeoon.common.location.BuyeoBoundary;
+import com.buyeoon.member.application.IdempotencyKeyReusedException;
+import com.buyeoon.member.application.InvalidStateTransitionException;
+import com.buyeoon.member.application.OutsideBuyeoException;
+import com.buyeoon.member.application.RequiredTermsNotAgreedException;
+import com.buyeoon.member.entity.MemberStatus;
+import com.buyeoon.trip.entity.TripEntity;
+import com.buyeoon.trip.entity.TripStatus;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.HexFormat;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.ObjectWriter;
+
+/** UC-05 여행 시작 커맨드 서비스다. */
+@Service
+public class TripStartService implements TripStarter {
+
+	private static final String OPERATION = "START_TRIP";
+	private static final Duration RETENTION = Duration.ofHours(24);
+	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+
+	private final JdbcOperations jdbcOperations;
+	private final TransactionTemplate transactions;
+	private final MemberRepository members;
+	private final TripRepository trips;
+	private final TermRepository terms;
+	private final CitizenCardRepository citizenCards;
+	private final IdempotencyRequestRepository idempotencyRequests;
+	private final BuyeoBoundary boundary;
+	private final ObjectReader objectReader;
+	private final ObjectWriter objectWriter;
+
+	public TripStartService(JdbcOperations jdbcOperations, PlatformTransactionManager transactionManager,
+			MemberRepository members, TripRepository trips, TermRepository terms, CitizenCardRepository citizenCards,
+			IdempotencyRequestRepository idempotencyRequests, BuyeoBoundary boundary, ObjectMapper objectMapper) {
+		this.jdbcOperations = jdbcOperations;
+		this.transactions = new TransactionTemplate(transactionManager);
+		this.members = members;
+		this.trips = trips;
+		this.terms = terms;
+		this.citizenCards = citizenCards;
+		this.idempotencyRequests = idempotencyRequests;
+		this.boundary = boundary;
+		this.objectReader = objectMapper.reader();
+		this.objectWriter = objectMapper.writer();
+	}
+
+	@Override
+	public TripView start(UUID memberId, String idempotencyKey, TripStartCommand command) {
+		validateIdempotencyKey(idempotencyKey);
+		if (!boundary.covers(command.location().latitude(), command.location().longitude())) {
+			throw new OutsideBuyeoException();
+		}
+		String requestHash = hash(command);
+		return Objects.requireNonNull(
+				transactions.execute(status -> startInTransaction(memberId, idempotencyKey, requestHash)),
+				"여행 시작 트랜잭션 결과가 없습니다.");
+	}
+
+	private TripView startInTransaction(UUID memberId, String idempotencyKey, String requestHash) {
+		lockMember(memberId);
+		Instant startedAt = clockTimestamp();
+
+		IdempotencyRequestId idempotencyId = new IdempotencyRequestId(memberId, idempotencyKey);
+		Optional<IdempotencyRequestEntity> existingRequest = idempotencyRequests.findById(idempotencyId);
+		if (existingRequest.isPresent()) {
+			IdempotencyRequestEntity request = existingRequest.get();
+			if (!request.getExpiresAt().isAfter(startedAt)) {
+				idempotencyRequests.delete(request);
+			} else {
+				return replay(request, requestHash);
+			}
+		}
+
+		if (!terms.hasAgreedToCurrentRequiredTerms(memberId)) {
+			throw new RequiredTermsNotAgreedException();
+		}
+		if (!citizenCards.existsByMemberId(memberId)) {
+			throw new CitizenCardNotIssuedException();
+		}
+		if (trips.lockByMemberIdAndStatus(memberId, TripStatus.IN_PROGRESS).isPresent()) {
+			throw new InvalidStateTransitionException();
+		}
+
+		TripEntity trip = trips.saveAndFlush(TripEntity.start(memberId));
+
+		TripView result = new TripView(trip.getId(), trip.getStatus(), trip.getStartedAt().atZone(ASIA_SEOUL), null,
+				null);
+		String responseBody = writeResponse(result);
+		IdempotencyRequestEntity idempotencyRequest = IdempotencyRequestEntity.create(memberId, idempotencyKey,
+				OPERATION, requestHash, startedAt.plus(RETENTION));
+		idempotencyRequest.complete(201, responseBody);
+		idempotencyRequests.save(idempotencyRequest);
+		return result;
+	}
+
+	private TripView replay(IdempotencyRequestEntity request, String requestHash) {
+		if (!OPERATION.equals(request.getOperation()) || !requestHash.equals(request.getRequestHash())) {
+			throw new IdempotencyKeyReusedException();
+		}
+		if (!Integer.valueOf(201).equals(request.getResponseStatus()) || request.getResponseBody() == null) {
+			throw new IllegalStateException("완료되지 않은 멱등성 요청이 남아 있습니다.");
+		}
+		return readResponse(request.getResponseBody());
+	}
+
+	private void lockMember(UUID memberId) {
+		members.findByIdAndStatus(memberId, MemberStatus.ACTIVE)
+				.orElseThrow(() -> new IllegalStateException("인증된 활성 회원을 찾을 수 없습니다."));
+	}
+
+	private Instant clockTimestamp() {
+		return Objects.requireNonNull(jdbcOperations.queryForObject("SELECT clock_timestamp()", Timestamp.class))
+				.toInstant();
+	}
+
+	private void validateIdempotencyKey(String idempotencyKey) {
+		if (idempotencyKey == null || idempotencyKey.length() < 8 || idempotencyKey.length() > 128) {
+			throw new InvalidTripStartRequestException();
+		}
+	}
+
+	private String hash(TripStartCommand command) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			update(digest, Double.toHexString(command.location().latitude()));
+			update(digest, Double.toHexString(command.location().longitude()));
+			update(digest,
+					command.location().accuracyMeters() == null
+							? "null"
+							: Double.toHexString(command.location().accuracyMeters()));
+			update(digest, command.location().capturedAt().toInstant().toString());
+			return HexFormat.of().formatHex(digest.digest());
+		} catch (NoSuchAlgorithmException exception) {
+			throw new IllegalStateException("SHA-256을 사용할 수 없습니다.", exception);
+		}
+	}
+
+	private void update(MessageDigest digest, String value) {
+		byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+		digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+		digest.update(bytes);
+	}
+
+	private String writeResponse(TripView result) {
+		try {
+			return objectWriter.writeValueAsString(SuccessResponse.of(result));
+		} catch (JacksonException exception) {
+			throw new IllegalStateException("여행 시작 응답을 저장할 수 없습니다.", exception);
+		}
+	}
+
+	private TripView readResponse(String responseBody) {
+		try {
+			JsonNode data = required(objectReader.readTree(responseBody), "data");
+			return new TripView(UUID.fromString(requiredText(data, "tripId")),
+					TripStatus.valueOf(requiredText(data, "status")),
+					ZonedDateTime.parse(requiredText(data, "startedAt")), nullableDateTime(data, "endedAt"),
+					nullableDateTime(data, "settledAt"));
+		} catch (JacksonException | IllegalArgumentException exception) {
+			throw new IllegalStateException("저장된 여행 시작 응답을 읽을 수 없습니다.", exception);
+		}
+	}
+
+	private ZonedDateTime nullableDateTime(JsonNode data, String field) {
+		JsonNode value = data.get(field);
+		return value == null || value.isNull() ? null : ZonedDateTime.parse(value.stringValue());
+	}
+
+	private JsonNode required(JsonNode node, String field) {
+		JsonNode value = node == null ? null : node.get(field);
+		if (value == null) {
+			throw new IllegalStateException("저장된 여행 시작 응답 필드가 누락되었습니다: " + field);
+		}
+		return value;
+	}
+
+	private String requiredText(JsonNode node, String field) {
+		JsonNode value = required(node, field);
+		if (!value.isString()) {
+			throw new IllegalStateException("저장된 여행 시작 응답 필드가 문자열이 아닙니다: " + field);
+		}
+		return value.stringValue();
+	}
+
+	public record TripStartCommand(LocationCommand location) {
+	}
+
+	public record LocationCommand(double latitude, double longitude, Double accuracyMeters, OffsetDateTime capturedAt) {
+	}
+
+	public record TripView(UUID tripId, TripStatus status, ZonedDateTime startedAt, ZonedDateTime endedAt,
+			ZonedDateTime settledAt) {
+	}
+}

--- a/src/main/java/com/buyeoon/trip/TripStarter.java
+++ b/src/main/java/com/buyeoon/trip/TripStarter.java
@@ -1,0 +1,10 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.trip.TripStartService.TripStartCommand;
+import com.buyeoon.trip.TripStartService.TripView;
+import java.util.UUID;
+
+public interface TripStarter {
+
+	TripView start(UUID memberId, String idempotencyKey, TripStartCommand command);
+}

--- a/src/test/java/com/buyeoon/trip/TripStartIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/TripStartIntegrationTests.java
@@ -1,0 +1,338 @@
+package com.buyeoon.trip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class TripStartIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM idempotency_requests");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM citizen_cards");
+		jdbcTemplate.update("DELETE FROM member_profiles");
+		jdbcTemplate.update("DELETE FROM term_consents");
+		jdbcTemplate.update("DELETE FROM terms");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+		jdbcTemplate.update("DELETE FROM card_themes");
+	}
+
+	/** 사전조건을 모두 충족한 회원은 여행을 IN_PROGRESS로 시작한다. */
+	@Test
+	@DisplayName("유효한 요청은 여행을 시작한다")
+	void validRequestStartsTrip() throws Exception {
+		AuthenticatedMember member = readyMember();
+
+		performStart(member, "start-trip-key-01", request(36.27, 126.91)).andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true)).andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+				.andExpect(jsonPath("$.data.startedAt").isString()).andExpect(jsonPath("$.data.endedAt").isEmpty())
+				.andExpect(jsonPath("$.data.settledAt").isEmpty());
+
+		assertThat(
+				jdbcTemplate.queryForObject("SELECT count(*) FROM trips WHERE member_id = ? AND status = 'IN_PROGRESS'",
+						Long.class, member.memberId()))
+				.isEqualTo(1L);
+	}
+
+	/** 필수 약관에 동의하지 않은 회원은 여행을 시작할 수 없다. */
+	@Test
+	@DisplayName("필수 약관 미동의는 여행 시작을 거부한다")
+	void requiredTermsMustBeAgreed() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		insertRequiredTerms();
+		insertCitizenCard(member.memberId());
+
+		performStart(member, "terms-trip-key", request(36.27, 126.91)).andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.data.code").value("REQUIRED_TERMS_NOT_AGREED"));
+		assertNoTrip(member.memberId());
+	}
+
+	/** 군민증을 발급받지 않은 회원은 여행을 시작할 수 없다. */
+	@Test
+	@DisplayName("군민증 미발급은 여행 시작을 거부한다")
+	void citizenCardMustBeIssued() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		agreeToCurrentRequiredTerms(member.memberId());
+
+		performStart(member, "card-trip-key", request(36.27, 126.91)).andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.data.code").value("CITIZEN_CARD_NOT_ISSUED"));
+		assertNoTrip(member.memberId());
+	}
+
+	/** 부여 경계는 포함하고 경계 밖 위치는 여행을 만들지 않는다. */
+	@Test
+	@DisplayName("부여 경계는 허용하고 외부 위치는 거부한다")
+	void boundaryIsIncludedAndOutsideIsRejected() throws Exception {
+		AuthenticatedMember outsideMember = readyMember();
+
+		performStart(outsideMember, "outside-trip-key", request(36.5, 127.2)).andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.data.code").value("OUTSIDE_BUYEO"));
+		assertNoTrip(outsideMember.memberId());
+
+		AuthenticatedMember boundaryMember = insertAuthenticatedMember();
+		agreeExistingRequiredTerms(boundaryMember.memberId());
+		insertCitizenCard(boundaryMember.memberId());
+		performStart(boundaryMember, "boundary-trip-key", request(36.2, 126.8)).andExpect(status().isCreated());
+	}
+
+	/** 이미 진행 중인 여행이 있으면 새 여행을 만들지 않는다. */
+	@Test
+	@DisplayName("진행 중인 여행이 있으면 중복 시작을 거부한다")
+	void duplicateInProgressTripIsRejected() throws Exception {
+		AuthenticatedMember member = readyMember();
+		performStart(member, "first-trip-key", request(36.27, 126.91)).andExpect(status().isCreated());
+
+		performStart(member, "second-trip-key", request(36.27, 126.91)).andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("INVALID_STATE_TRANSITION"));
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM trips WHERE member_id = ?", Long.class,
+				member.memberId())).isEqualTo(1L);
+	}
+
+	/** 같은 키와 같은 본문의 재요청은 최초 성공 응답을 그대로 반환한다. */
+	@Test
+	@DisplayName("동일한 멱등성 요청은 최초 응답을 재사용한다")
+	void sameIdempotentRequestReturnsFirstResponse() throws Exception {
+		AuthenticatedMember member = readyMember();
+		String key = "retry-trip-key";
+
+		String first = performStart(member, key, request(36.27, 126.91)).andExpect(status().isCreated()).andReturn()
+				.getResponse().getContentAsString();
+		String retried = performStart(member, key, request(36.27, 126.91)).andExpect(status().isCreated()).andReturn()
+				.getResponse().getContentAsString();
+
+		assertThat(retried).isEqualTo(first);
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM trips WHERE member_id = ?", Long.class,
+				member.memberId())).isEqualTo(1L);
+	}
+
+	/** 같은 키를 다른 요청 본문에 재사용하면 충돌을 반환한다. */
+	@Test
+	@DisplayName("멱등성 키를 다른 본문에 재사용하면 충돌한다")
+	void reusedKeyWithDifferentBodyConflicts() throws Exception {
+		AuthenticatedMember member = readyMember();
+		performStart(member, "conflict-trip-key", request(36.27, 126.91)).andExpect(status().isCreated());
+
+		performStart(member, "conflict-trip-key", request(36.2, 126.8)).andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("IDEMPOTENCY_KEY_REUSED"));
+	}
+
+	/** 동시에 도착한 같은 회원의 여행 시작 요청은 하나의 진행 중 여행만 만든다. */
+	@Test
+	@DisplayName("동시 시작 요청은 진행 중 여행을 하나만 생성한다")
+	void concurrentStartRequestsCreateOneInProgressTrip() throws Exception {
+		AuthenticatedMember member = readyMember();
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+
+		try {
+			Future<MvcResult> first = executor.submit(() -> concurrentStart(member, "concurrent-a", ready, start));
+			Future<MvcResult> second = executor.submit(() -> concurrentStart(member, "concurrent-b", ready, start));
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			MvcResult firstResult = first.get(10, TimeUnit.SECONDS);
+			MvcResult secondResult = second.get(10, TimeUnit.SECONDS);
+			int[] statuses = {firstResult.getResponse().getStatus(), secondResult.getResponse().getStatus()};
+			assertThat(statuses).containsExactlyInAnyOrder(201, 409);
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertThat(
+				jdbcTemplate.queryForObject("SELECT count(*) FROM trips WHERE member_id = ? AND status = 'IN_PROGRESS'",
+						Long.class, member.memberId()))
+				.isEqualTo(1L);
+	}
+
+	/** 여행 저장 중 DB 오류가 발생하면 여행과 멱등성 기록 모두 남지 않는다. */
+	@Test
+	@DisplayName("여행 저장 실패는 전체 트랜잭션을 롤백한다")
+	void storageFailureRollsBackTripAndIdempotency() {
+		AuthenticatedMember member = readyMember();
+		jdbcTemplate.execute("""
+				CREATE FUNCTION fail_trip() RETURNS trigger AS $$
+				BEGIN
+				    RAISE EXCEPTION 'forced trip failure';
+				END;
+				$$ LANGUAGE plpgsql
+				""");
+		jdbcTemplate.execute("""
+				CREATE TRIGGER fail_trip_trigger
+				BEFORE INSERT ON trips
+				FOR EACH ROW EXECUTE FUNCTION fail_trip()
+				""");
+
+		try {
+			assertThatThrownBy(() -> performStart(member, "rollback-trip-key", request(36.27, 126.91)).andReturn())
+					.isInstanceOf(Exception.class);
+			assertNoTrip(member.memberId());
+			assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM idempotency_requests WHERE member_id = ?",
+					Long.class, member.memberId())).isZero();
+		} finally {
+			jdbcTemplate.execute("DROP TRIGGER fail_trip_trigger ON trips");
+			jdbcTemplate.execute("DROP FUNCTION fail_trip()");
+		}
+	}
+
+	/** 인증되지 않은 요청은 여행 시작 계층에 도달하지 않는다. */
+	@Test
+	@DisplayName("여행 시작에는 유효한 인증 세션이 필요하다")
+	void authenticationIsRequired() throws Exception {
+		mockMvc.perform(post("/trips").header("Idempotency-Key", "unauth-trip-key")
+				.contentType(MediaType.APPLICATION_JSON).content(request(36.27, 126.91)))
+				.andExpect(status().isUnauthorized()).andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	private MvcResult concurrentStart(AuthenticatedMember member, String key, CountDownLatch ready,
+			CountDownLatch start) throws Exception {
+		ready.countDown();
+		if (!start.await(5, TimeUnit.SECONDS)) {
+			throw new IllegalStateException("동시 요청 시작 신호를 받지 못했습니다.");
+		}
+		return performStart(member, key, request(36.27, 126.91)).andReturn();
+	}
+
+	private ResultActions performStart(AuthenticatedMember member, String key, String body) throws Exception {
+		var request = post("/trips").header("Authorization", "Bearer " + member.accessToken())
+				.contentType(MediaType.APPLICATION_JSON).content(body);
+		if (key != null) {
+			request.header("Idempotency-Key", key);
+		}
+		return mockMvc.perform(request);
+	}
+
+	private AuthenticatedMember readyMember() {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		agreeToCurrentRequiredTerms(member.memberId());
+		insertCitizenCard(member.memberId());
+		return member;
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private void agreeToCurrentRequiredTerms(UUID memberId) {
+		insertRequiredTerms();
+		agreeExistingRequiredTerms(memberId);
+	}
+
+	private void agreeExistingRequiredTerms(UUID memberId) {
+		jdbcTemplate.update("""
+				INSERT INTO term_consents (member_id, term_id, agreed)
+				SELECT ?, id, true FROM terms WHERE required = true
+				""", memberId);
+	}
+
+	private void insertRequiredTerms() {
+		Instant effectiveAt = Instant.parse("2026-08-01T00:00:00Z");
+		insertTerm("SERVICE", effectiveAt);
+		insertTerm("PRIVACY", effectiveAt);
+	}
+
+	private void insertTerm(String type, Instant effectiveAt) {
+		jdbcTemplate.update("""
+				INSERT INTO terms (type, version, required, title, content, effective_at)
+				VALUES (?::term_type, '1.0', true, '테스트 약관', '테스트 본문', ?)
+				""", type, Timestamp.from(effectiveAt));
+	}
+
+	private void insertCitizenCard(UUID memberId) {
+		UUID themeId = UUID.randomUUID();
+		jdbcTemplate.update("""
+				INSERT INTO card_themes (id, name, image_key, sort_order)
+				VALUES (?, '백제', 'public/themes/baekje.webp', ?)
+				""", themeId, ThreadLocalRandom.current().nextInt(1, 30_000));
+		jdbcTemplate.update("""
+				INSERT INTO citizen_cards (member_id, theme_id, barcode_value)
+				VALUES (?, ?, ?)
+				""", memberId, themeId, UUID.randomUUID().toString());
+	}
+
+	private String request(double latitude, double longitude) {
+		return "{\"location\":{\"latitude\":" + latitude + ",\"longitude\":" + longitude
+				+ ",\"accuracyMeters\":5.5,\"capturedAt\":\"2026-08-12T15:30:00+09:00\"}}";
+	}
+
+	private void assertNoTrip(UUID memberId) {
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM trips WHERE member_id = ?", Long.class, memberId))
+				.isZero();
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("location.buyeo-boundary", () -> "classpath:boundaries/buyeo-test.geojson");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## 개요

로그인·필수 약관 동의·군민증 발급을 마친 회원이 부여 행정구역 안에서 POST /trips로 여행을 시작하는 기능

Closes #85

## 구현 내용

- POST /trips 컨트롤러 → 커맨드 서비스 → JPA 리포지토리까지 이어지는 수직 슬라이스
- 여행 생성과 멱등성 기록을 하나의 트랜잭션으로 확정 (`TransactionTemplate` 사용, 자기 호출로 인한 `@Transactional` 프록시 우회 문제 회피)
- trip 패키지에 읽기 전용 MemberRepository 신설
- ErrorResponse.outsideBuyeo() 메시지를 상황 무관 문구로 일반화(군민증 전용 문구였음), `CITIZEN_CARD_NOT_ISSUED` 에러 코드 신규 추가

## 테스트

- 정상 시작(201), 약관 미동의(403), 군민증 미발급(403), 부여 외부(403, 경계 포함 확인)
- 진행 중 여행 중복(409), 멱등성 키 재요청 replay(201 동일 응답), 멱등성 키 재사용 다른 본문(409)