### PR TITLE
feat: UC-12 저장한 장소 목록을 거리와 도보 시간 제공 (위치 기반)

### DIFF
--- a/src/main/java/com/buyeoon/place/api/PlaceController.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceController.java
@@ -56,14 +56,20 @@ public class PlaceController {
 
 	@GetMapping("/members/me/saved-places")
 	public SuccessResponse<PlaceListView> getSavedPlaces(@AuthenticationPrincipal Jwt jwt,
-			@RequestParam(required = false) String category, @RequestParam(required = false) String cursor,
+			@RequestParam(required = false) String category, @RequestParam(required = false) String latitude,
+			@RequestParam(required = false) String longitude, @RequestParam(required = false) String cursor,
 			@RequestParam(defaultValue = "20") int size) {
 		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
 		if (size < MIN_SIZE || size > MAX_SIZE) {
 			throw new InvalidPlaceRequestException();
 		}
-		return SuccessResponse.of(
-				placeQueryService.listSaved(memberId, parseCategory(category), parseSavedPlaceCursor(cursor), size));
+		if ((latitude == null) != (longitude == null)) {
+			throw new InvalidPlaceRequestException();
+		}
+		Double parsedLatitude = latitude == null ? null : latitude(latitude);
+		Double parsedLongitude = longitude == null ? null : longitude(longitude);
+		return SuccessResponse.of(placeQueryService.listSaved(memberId, parseCategory(category), parsedLatitude,
+				parsedLongitude, parseSavedPlaceCursor(cursor), size));
 	}
 
 	@GetMapping("/places/{placeId}")

--- a/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
@@ -51,12 +51,15 @@ public class PlaceQueryService {
 		return new PlaceListView(items, new PageInfoView(nextCursor, hasNext));
 	}
 
-	public PlaceListView listSaved(UUID memberId, PlaceCategory category, SavedPlaceCursor cursor, int size) {
-		List<SavedPlaceProjection> rows = findSavedRows(memberId, category, cursor, size);
+	public PlaceListView listSaved(UUID memberId, PlaceCategory category, Double latitude, Double longitude,
+			SavedPlaceCursor cursor, int size) {
+		List<SavedPlaceProjection> rows = findSavedRows(memberId, category, latitude, longitude, cursor, size);
 		boolean hasNext = rows.size() > size;
 		List<SavedPlaceProjection> page = hasNext ? rows.subList(0, size) : rows;
-		String nextCursor = hasNext ? new SavedPlaceCursor(page.getLast().savedAt(), page.getLast().place().getId()).encode() : null;
-		List<PlaceItemView> items = page.stream().map(row -> toView(row.place(), true)).toList();
+		String nextCursor = hasNext
+				? new SavedPlaceCursor(page.getLast().savedAt(), page.getLast().place().getId()).encode()
+				: null;
+		List<PlaceItemView> items = page.stream().map(this::toSavedView).toList();
 		return new PlaceListView(items, new PageInfoView(nextCursor, hasNext));
 	}
 
@@ -94,18 +97,41 @@ public class PlaceQueryService {
 						cursor.placeId(), pageRequest);
 	}
 
-	private List<SavedPlaceProjection> findSavedRows(UUID memberId, PlaceCategory category, SavedPlaceCursor cursor,
-			int size) {
+	private List<SavedPlaceProjection> findSavedRows(UUID memberId, PlaceCategory category, Double latitude,
+			Double longitude, SavedPlaceCursor cursor, int size) {
 		PageRequest pageRequest = PageRequest.of(0, size + 1);
+		boolean hasLocation = latitude != null;
 		if (cursor == null) {
+			if (!hasLocation) {
+				return category == null
+						? savedPlaceRepository.findFromStart(memberId, pageRequest)
+						: savedPlaceRepository.findFromStartByCategory(memberId, category, pageRequest);
+			}
 			return category == null
-					? savedPlaceRepository.findFromStart(memberId, pageRequest)
-					: savedPlaceRepository.findFromStartByCategory(memberId, category, pageRequest);
+					? savedPlaceRepository.findFromStartWithDistance(memberId, latitude, longitude, pageRequest)
+					: savedPlaceRepository.findFromStartByCategoryWithDistance(memberId, category, latitude, longitude,
+							pageRequest);
+		}
+		if (!hasLocation) {
+			return category == null
+					? savedPlaceRepository.findAfter(memberId, cursor.savedAt(), cursor.placeId(), pageRequest)
+					: savedPlaceRepository.findAfterByCategory(memberId, category, cursor.savedAt(), cursor.placeId(),
+							pageRequest);
 		}
 		return category == null
-				? savedPlaceRepository.findAfter(memberId, cursor.savedAt(), cursor.placeId(), pageRequest)
-				: savedPlaceRepository.findAfterByCategory(memberId, category, cursor.savedAt(), cursor.placeId(),
-						pageRequest);
+				? savedPlaceRepository.findAfterWithDistance(memberId, cursor.savedAt(), cursor.placeId(), latitude,
+						longitude, pageRequest)
+				: savedPlaceRepository.findAfterByCategoryWithDistance(memberId, category, cursor.savedAt(),
+						cursor.placeId(), latitude, longitude, pageRequest);
+	}
+
+	private PlaceItemView toSavedView(SavedPlaceProjection row) {
+		if (row.distanceMeters() == null) {
+			return toView(row.place(), true);
+		}
+		int distanceMeters = (int) Math.round(row.distanceMeters());
+		int walkingMinutes = (int) Math.ceil(row.distanceMeters() / WALKING_METERS_PER_MINUTE);
+		return toView(row.place(), distanceMeters, walkingMinutes, true);
 	}
 
 	private PlaceItemView toView(PlaceProjection row, Set<UUID> savedPlaceIds) {

--- a/src/main/java/com/buyeoon/place/repository/SavedPlaceProjection.java
+++ b/src/main/java/com/buyeoon/place/repository/SavedPlaceProjection.java
@@ -3,5 +3,9 @@ package com.buyeoon.place.repository;
 import com.buyeoon.place.entity.PlaceEntity;
 import java.time.Instant;
 
-public record SavedPlaceProjection(PlaceEntity place, Instant savedAt) {
+public record SavedPlaceProjection(PlaceEntity place, Instant savedAt, Double distanceMeters) {
+
+	public SavedPlaceProjection(PlaceEntity place, Instant savedAt) {
+		this(place, savedAt, null);
+	}
 }

--- a/src/main/java/com/buyeoon/place/repository/SavedPlaceRepository.java
+++ b/src/main/java/com/buyeoon/place/repository/SavedPlaceRepository.java
@@ -13,8 +13,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 /**
- * 카테고리 지정 여부와 커서 유무를 각각 다른 쿼리로 나눠 둔다. nullable 파라미터를 {@code IS NULL OR ...}로
- * 합치면 PostgreSQL이 파라미터 타입을 정하지 못해 실패한다.
+ * 카테고리 지정 여부, 커서 유무, 위치 전달 여부를 각각 다른 쿼리로 나눠 둔다. nullable 파라미터를
+ * {@code IS NULL OR ...}로 합치면 PostgreSQL이 파라미터 타입을 정하지 못해 실패한다. 위치가 있어도 정렬은 항상
+ * 저장 시각순이며 거리는 표시용으로만 SELECT에 추가된다.
  */
 public interface SavedPlaceRepository extends JpaRepository<SavedPlaceEntity, SavedPlaceId> {
 
@@ -76,4 +77,62 @@ public interface SavedPlaceRepository extends JpaRepository<SavedPlaceEntity, Sa
 	List<SavedPlaceProjection> findAfterByCategory(@Param("memberId") UUID memberId,
 			@Param("category") PlaceCategory category, @Param("savedAt") Instant savedAt,
 			@Param("placeId") UUID placeId, Pageable pageable);
+
+	@Query("""
+			SELECT new com.buyeoon.place.repository.SavedPlaceProjection(p, s.savedAt,
+			       ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
+			FROM SavedPlaceEntity s
+			JOIN PlaceEntity p ON p.id = s.id.placeId
+			WHERE s.id.memberId = :memberId
+			ORDER BY s.savedAt DESC, p.id ASC
+			""")
+	List<SavedPlaceProjection> findFromStartWithDistance(@Param("memberId") UUID memberId,
+			@Param("latitude") double latitude, @Param("longitude") double longitude, Pageable pageable);
+
+	@Query("""
+			SELECT new com.buyeoon.place.repository.SavedPlaceProjection(p, s.savedAt,
+			       ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
+			FROM SavedPlaceEntity s
+			JOIN PlaceEntity p ON p.id = s.id.placeId
+			WHERE s.id.memberId = :memberId
+			  AND p.category = :category
+			ORDER BY s.savedAt DESC, p.id ASC
+			""")
+	List<SavedPlaceProjection> findFromStartByCategoryWithDistance(@Param("memberId") UUID memberId,
+			@Param("category") PlaceCategory category, @Param("latitude") double latitude,
+			@Param("longitude") double longitude, Pageable pageable);
+
+	@Query("""
+			SELECT new com.buyeoon.place.repository.SavedPlaceProjection(p, s.savedAt,
+			       ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
+			FROM SavedPlaceEntity s
+			JOIN PlaceEntity p ON p.id = s.id.placeId
+			WHERE s.id.memberId = :memberId
+			  AND (s.savedAt < :savedAt
+			       OR (s.savedAt = :savedAt AND p.id > :placeId))
+			ORDER BY s.savedAt DESC, p.id ASC
+			""")
+	List<SavedPlaceProjection> findAfterWithDistance(@Param("memberId") UUID memberId,
+			@Param("savedAt") Instant savedAt, @Param("placeId") UUID placeId, @Param("latitude") double latitude,
+			@Param("longitude") double longitude, Pageable pageable);
+
+	@Query("""
+			SELECT new com.buyeoon.place.repository.SavedPlaceProjection(p, s.savedAt,
+			       ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
+			FROM SavedPlaceEntity s
+			JOIN PlaceEntity p ON p.id = s.id.placeId
+			WHERE s.id.memberId = :memberId
+			  AND p.category = :category
+			  AND (s.savedAt < :savedAt
+			       OR (s.savedAt = :savedAt AND p.id > :placeId))
+			ORDER BY s.savedAt DESC, p.id ASC
+			""")
+	List<SavedPlaceProjection> findAfterByCategoryWithDistance(@Param("memberId") UUID memberId,
+			@Param("category") PlaceCategory category, @Param("savedAt") Instant savedAt,
+			@Param("placeId") UUID placeId, @Param("latitude") double latitude, @Param("longitude") double longitude,
+			Pageable pageable);
 }

--- a/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
@@ -484,6 +484,80 @@ class PlaceControllerIntegrationTests {
 				.andExpect(jsonPath("$.data.items[0].placeId").value(cafe.toString()));
 	}
 
+	/**
+	 * 가까운 장소를 먼저, 먼 장소를 나중에 저장해 거리순과 저장 시각순 결과가 서로 반대로 나오게 한다. 정렬이 실수로 거리순으로 바뀌면 이
+	 * 테스트가 실패해야 한다.
+	 */
+	@Test
+	@DisplayName("위치와 함께 조회하면 distanceMeters와 walkingMinutes가 채워지고 정렬은 저장 시각순을 유지한다")
+	void returnsSavedPlacesWithDistanceWhenLocationProvidedButOrderStaysBySavedAt() throws Exception {
+		UUID near = savePlace(PlaceCategory.HERITAGE, "가깝지만 먼저 저장", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+		UUID far = savePlace(PlaceCategory.HERITAGE, "멀지만 나중 저장", ORIGIN_LATITUDE + 0.05, ORIGIN_LONGITUDE + 0.05);
+		Instant base = Instant.now();
+		savePlaceForMemberAt(member.memberId(), near, base);
+		savePlaceForMemberAt(member.memberId(), far, base.plusSeconds(60));
+
+		mockMvc.perform(savedPlacesRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude",
+				String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items[0].placeId").value(far.toString()))
+				.andExpect(jsonPath("$.data.items[1].placeId").value(near.toString()))
+				.andExpect(jsonPath("$.data.items[0].distanceMeters", greaterThan(-1)))
+				.andExpect(jsonPath("$.data.items[1].distanceMeters", greaterThan(-1)));
+	}
+
+	@Test
+	@DisplayName("위치와 category를 함께 전달하면 해당 분류만 거리·도보 시간과 함께 반환한다")
+	void returnsSavedPlacesFilteredByCategoryWithDistance() throws Exception {
+		UUID heritage = savePlace(PlaceCategory.HERITAGE, "유적지", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+		UUID cafe = savePlace(PlaceCategory.CAFE, "카페", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+		savePlaceForMember(member.memberId(), heritage);
+		savePlaceForMember(member.memberId(), cafe);
+
+		mockMvc.perform(
+				savedPlacesRequest().param("category", "CAFE").param("latitude", String.valueOf(ORIGIN_LATITUDE))
+						.param("longitude", String.valueOf(ORIGIN_LONGITUDE)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items.length()").value(1))
+				.andExpect(jsonPath("$.data.items[0].placeId").value(cafe.toString()))
+				.andExpect(jsonPath("$.data.items[0].distanceMeters", greaterThan(-1)));
+	}
+
+	@Test
+	@DisplayName("위치와 함께 커서로 다음 페이지를 요청해도 저장 시각순으로 이어진다")
+	void returnsNextPageOfSavedPlacesWithLocationOrderedBySavedAt() throws Exception {
+		UUID first = savePlace(PlaceCategory.HERITAGE, "장소1", ORIGIN_LATITUDE, ORIGIN_LONGITUDE);
+		UUID second = savePlace(PlaceCategory.HERITAGE, "장소2", ORIGIN_LATITUDE, ORIGIN_LONGITUDE);
+		UUID third = savePlace(PlaceCategory.HERITAGE, "장소3", ORIGIN_LATITUDE, ORIGIN_LONGITUDE);
+		Instant base = Instant.now();
+		savePlaceForMemberAt(member.memberId(), first, base);
+		savePlaceForMemberAt(member.memberId(), second, base.plusSeconds(60));
+		savePlaceForMemberAt(member.memberId(), third, base.plusSeconds(120));
+
+		MvcResult firstPage = mockMvc
+				.perform(savedPlacesRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE))
+						.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("size", "2"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items.length()").value(2))
+				.andExpect(jsonPath("$.data.page.hasNext").value(true)).andReturn();
+		String cursor = objectMapper.readTree(firstPage.getResponse().getContentAsString()).path("data").path("page")
+				.path("nextCursor").asString();
+
+		mockMvc.perform(savedPlacesRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE))
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("size", "2").param("cursor", cursor))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items.length()").value(1))
+				.andExpect(jsonPath("$.data.items[0].placeId").value(first.toString()))
+				.andExpect(jsonPath("$.data.items[0].distanceMeters", greaterThan(-1)))
+				.andExpect(jsonPath("$.data.page.hasNext").value(false));
+	}
+
+	@Test
+	@DisplayName("latitude/longitude 중 하나만 전달되면 400을 반환한다")
+	void returns400WhenOnlyOneCoordinateProvidedForSavedPlaces() throws Exception {
+		mockMvc.perform(savedPlacesRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE)))
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+
+		mockMvc.perform(savedPlacesRequest().param("longitude", String.valueOf(ORIGIN_LONGITUDE)))
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
 	@Test
 	@DisplayName("저장한 장소가 없으면 빈 배열과 hasNext:false를 반환한다")
 	void returnsEmptyListWhenNoSavedPlaces() throws Exception {


### PR DESCRIPTION
## Summary
- UC-12 Sub-issue #92: `GET /members/me/saved-places`에 위치 기반 거리, 도보 시간 제공 기능 추가
- 정렬은 동일하게 저장 시각 내림차순 고정 — 위치는 거리·도보 시간 계산에만 사용 

## Test plan
- [x] 위치와 함께 호출하면 distanceMeters/walkingMinutes가 채워진다
- [x] 위치를 전달해도 정렬 순서는 저장 시각 내림차순으로 유지된다
- [x] category와 위치를 함께 전달하면 해당 분류만 거리·도보 시간과 함께 반환한다
- [x] 위치와 함께 커서로 다음 페이지를 요청해도 저장 시각순으로 정상 이어진다
- [x] latitude/longitude 중 하나만 전달되면 400을 반환한다

Closes #92 