### PR TITLE
Feat/uc 13 saved places delete

### DIFF
--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -469,8 +469,6 @@ paths:
           $ref: '#/components/responses/EmptySuccess'
         '401':
           $ref: '#/components/responses/Unauthorized'
-        '404':
-          $ref: '#/components/responses/NotFound'
   /missions/nearby:
     get:
       tags: [Missions]

--- a/src/main/java/com/buyeoon/place/api/PlaceController.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceController.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.UUID;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -38,6 +39,14 @@ public class PlaceController {
 			@PathVariable UUID placeId) {
 		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
 		placeCommandService.savePlace(memberId, placeId);
+		return SuccessResponse.of(Map.of());
+	}
+
+	@DeleteMapping("/members/me/saved-places/{placeId}")
+	public SuccessResponse<Map<String, Object>> deleteSavedPlace(@AuthenticationPrincipal Jwt jwt,
+			@PathVariable UUID placeId) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		placeCommandService.deleteSavedPlace(memberId, placeId);
 		return SuccessResponse.of(Map.of());
 	}
 

--- a/src/main/java/com/buyeoon/place/application/PlaceCommandService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceCommandService.java
@@ -1,6 +1,7 @@
 package com.buyeoon.place.application;
 
 import com.buyeoon.place.entity.SavedPlaceEntity;
+import com.buyeoon.place.entity.SavedPlaceId;
 import com.buyeoon.place.repository.PlaceQueryRepository;
 import com.buyeoon.place.repository.SavedPlaceRepository;
 import com.buyeoon.trip.TripQueryService;
@@ -37,5 +38,10 @@ public class PlaceCommandService {
 		} catch (DataIntegrityViolationException alreadySaved) {
 			// 회원-장소 유니크 제약 위반은 이미 저장된 상태라는 뜻이므로 성공으로 흡수한다.
 		}
+	}
+
+	@Transactional
+	public void deleteSavedPlace(UUID memberId, UUID placeId) {
+		savedPlaceRepository.deleteById(new SavedPlaceId(memberId, placeId));
 	}
 }

--- a/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -366,6 +367,110 @@ class PlaceControllerIntegrationTests {
 
 	private int saveStatus(UUID placeId) throws Exception {
 		return mockMvc.perform(savePlaceRequest(placeId)).andReturn().getResponse().getStatus();
+	}
+
+	/** 저장한 장소를 삭제하면 200을 반환하고 저장 관계가 제거된다. */
+	@Test
+	@DisplayName("저장한 장소를 삭제하면 200과 함께 저장 관계가 제거된다")
+	void deletesSavedPlaceAndReturns200() throws Exception {
+		UUID placeId = savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE, ORIGIN_LONGITUDE);
+		savePlaceForMember(member.memberId(), placeId);
+
+		mockMvc.perform(deleteSavedPlaceRequest(placeId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+
+		assertSavedPlaceCount(member.memberId(), placeId, 0);
+	}
+
+	/** 저장하지 않은 장소를 삭제해도 이미 목표 상태이므로 200을 반환한다(멱등). */
+	@Test
+	@DisplayName("저장하지 않은 장소를 삭제해도 200을 반환한다")
+	void deletingUnsavedPlaceStaysIdempotent() throws Exception {
+		UUID placeId = savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE, ORIGIN_LONGITUDE);
+
+		mockMvc.perform(deleteSavedPlaceRequest(placeId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+	}
+
+	/** 저장한 장소를 삭제해도 장소 자체와 방문 기록은 유지된다. */
+	@Test
+	@DisplayName("저장한 장소를 삭제해도 장소 데이터는 유지된다")
+	void deletingSavedPlaceKeepsPlaceData() throws Exception {
+		UUID placeId = savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE, ORIGIN_LONGITUDE);
+		savePlaceForMember(member.memberId(), placeId);
+
+		mockMvc.perform(deleteSavedPlaceRequest(placeId)).andExpect(status().isOk());
+
+		Integer placeCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM places WHERE id = ?", Integer.class,
+				placeId);
+		assertThat(placeCount).isEqualTo(1);
+	}
+
+	/** 진행 중인 여행이 없는 회원도 삭제할 수 있다(403 없음). */
+	@Test
+	@DisplayName("진행 중인 여행이 없어도 삭제 요청은 200을 받는다")
+	void deletesSavedPlaceWithoutActiveTrip() throws Exception {
+		UUID placeId = savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE, ORIGIN_LONGITUDE);
+		savePlaceForMember(member.memberId(), placeId);
+
+		mockMvc.perform(deleteSavedPlaceRequest(placeId)).andExpect(status().isOk());
+	}
+
+	/** 다른 회원이 저장한 장소를 삭제 요청해도 요청자 자신의 저장 관계만 대상이 된다. */
+	@Test
+	@DisplayName("다른 회원의 저장 관계는 삭제되지 않는다")
+	void deletingSavedPlaceDoesNotAffectOtherMembers() throws Exception {
+		UUID placeId = savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE, ORIGIN_LONGITUDE);
+		AuthenticatedMember otherMember = insertAuthenticatedMember();
+		savePlaceForMember(otherMember.memberId(), placeId);
+
+		mockMvc.perform(deleteSavedPlaceRequest(placeId)).andExpect(status().isOk());
+
+		assertSavedPlaceCount(otherMember.memberId(), placeId, 1);
+	}
+
+	/** 같은 장소에 대한 저장과 삭제가 동시에 요청되면 나중에 확정된 요청의 상태를 따른다. */
+	@Test
+	@DisplayName("동시 저장·삭제 요청 후 저장 관계 존재 여부는 둘 중 하나로 일관된다")
+	void concurrentSaveAndDeleteRequestsBothSucceedWithConsistentFinalState() throws Exception {
+		startTrip(member.memberId());
+		UUID placeId = savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE, ORIGIN_LONGITUDE);
+		savePlaceForMember(member.memberId(), placeId);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			List<Future<Integer>> results = executor
+					.invokeAll(List.of(() -> saveStatus(placeId), () -> deleteStatus(placeId)));
+			for (Future<Integer> result : results) {
+				assertThat(result.get()).isEqualTo(200);
+			}
+		} finally {
+			executor.shutdown();
+		}
+
+		Integer count = jdbcTemplate.queryForObject(
+				"SELECT COUNT(*) FROM saved_places WHERE member_id = ? AND place_id = ?", Integer.class,
+				member.memberId(), placeId);
+		assertThat(count).isIn(0, 1);
+	}
+
+	/** 로그인하지 않은 삭제 요청은 401을 반환한다. */
+	@Test
+	@DisplayName("인증하지 않으면 삭제 요청은 401을 받는다")
+	void returns401WhenDeletingUnauthenticated() throws Exception {
+		UUID placeId = savePlace(PlaceCategory.HERITAGE, "장소", ORIGIN_LATITUDE, ORIGIN_LONGITUDE);
+
+		mockMvc.perform(delete("/members/me/saved-places/{placeId}", placeId)).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	private int deleteStatus(UUID placeId) throws Exception {
+		return mockMvc.perform(deleteSavedPlaceRequest(placeId)).andReturn().getResponse().getStatus();
+	}
+
+	private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder deleteSavedPlaceRequest(
+			UUID placeId) {
+		return delete("/members/me/saved-places/{placeId}", placeId).header("Authorization",
+				"Bearer " + member.accessToken());
 	}
 
 	private void assertSavedPlaceCount(UUID memberId, UUID placeId, int expectedCount) {


### PR DESCRIPTION
## Summary
- `DELETE /members/me/saved-places/{placeId}` 엔드포인트 추가
- `PlaceCommandService.deleteSavedPlace`는 사전 조회 없이 `savedPlaceRepository.deleteById`만 호출 — Spring Data JPA 4.1.0에서 대상 없는 삭제도 예외 없이 반환됨을 확인하고 별도 예외 처리를 생략함
- 활성 여행 여부 확인 없음(진행 중 여행과 무관하게 삭제 가능), 소유권은 JWT memberId + 복합키로 구조적 보장

## Test plan
- [x] 저장한 장소 삭제 → 200 + `saved_places` 행 제거
- [x] 저장하지 않은 장소 삭제 → 200 (멱등)

Closes #96