### PR TITLE
feat: UC-06 500m 주변 미션 목록 조회 구현

### DIFF
--- a/src/main/java/com/buyeoon/common/api/ErrorResponse.java
+++ b/src/main/java/com/buyeoon/common/api/ErrorResponse.java
@@ -54,6 +54,10 @@ public record ErrorResponse(boolean success, ErrorData data) {
 		return new ErrorResponse(false, new ErrorData("ACTIVE_TRIP_REQUIRED", "진행 중인 여행이 있어야 이용할 수 있습니다."));
 	}
 
+	public static ErrorResponse tripNotInProgress() {
+		return new ErrorResponse(false, new ErrorData("TRIP_NOT_IN_PROGRESS", "진행 중인 여행에서만 요청할 수 있습니다."));
+	}
+
 	public record ErrorData(String code, String message) {
 	}
 }

--- a/src/main/java/com/buyeoon/mission/api/InvalidMissionRequestException.java
+++ b/src/main/java/com/buyeoon/mission/api/InvalidMissionRequestException.java
@@ -1,0 +1,4 @@
+package com.buyeoon.mission.api;
+
+public class InvalidMissionRequestException extends RuntimeException {
+}

--- a/src/main/java/com/buyeoon/mission/api/MissionController.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionController.java
@@ -1,0 +1,58 @@
+package com.buyeoon.mission.api;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.mission.application.MissionQueryService;
+import com.buyeoon.mission.application.MissionQueryService.MissionListView;
+import java.util.Objects;
+import java.util.UUID;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MissionController {
+
+	private final MissionQueryService missionQueryService;
+
+	public MissionController(MissionQueryService missionQueryService) {
+		this.missionQueryService = missionQueryService;
+	}
+
+	@GetMapping("/missions/nearby")
+	public SuccessResponse<MissionListView> getNearbyMissions(@AuthenticationPrincipal Jwt jwt,
+			@RequestParam String latitude, @RequestParam String longitude, @RequestParam UUID tripId) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		return SuccessResponse
+				.of(missionQueryService.listNearby(memberId, tripId, latitude(latitude), longitude(longitude)));
+	}
+
+	private double latitude(String value) {
+		double latitude = coordinate(value);
+		if (latitude < -90 || latitude > 90) {
+			throw new InvalidMissionRequestException();
+		}
+		return latitude;
+	}
+
+	private double longitude(String value) {
+		double longitude = coordinate(value);
+		if (longitude < -180 || longitude > 180) {
+			throw new InvalidMissionRequestException();
+		}
+		return longitude;
+	}
+
+	private double coordinate(String value) {
+		try {
+			double coordinate = Double.parseDouble(value);
+			if (!Double.isFinite(coordinate)) {
+				throw new InvalidMissionRequestException();
+			}
+			return coordinate;
+		} catch (NumberFormatException exception) {
+			throw new InvalidMissionRequestException();
+		}
+	}
+}

--- a/src/main/java/com/buyeoon/mission/api/MissionExceptionHandler.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.buyeoon.mission.api;
+
+import com.buyeoon.common.api.ErrorResponse;
+import com.buyeoon.mission.application.TripNotFoundException;
+import com.buyeoon.mission.application.TripNotInProgressException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice(assignableTypes = MissionController.class)
+public class MissionExceptionHandler {
+
+	@ExceptionHandler({InvalidMissionRequestException.class, MissingServletRequestParameterException.class,
+			MethodArgumentTypeMismatchException.class})
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorResponse handleInvalidRequest() {
+		return ErrorResponse.invalidRequest();
+	}
+
+	@ExceptionHandler(TripNotFoundException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public ErrorResponse handleTripNotFound() {
+		return ErrorResponse.resourceNotFound();
+	}
+
+	@ExceptionHandler(TripNotInProgressException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ErrorResponse handleTripNotInProgress() {
+		return ErrorResponse.tripNotInProgress();
+	}
+}

--- a/src/main/java/com/buyeoon/mission/application/MissionAvailability.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionAvailability.java
@@ -1,0 +1,5 @@
+package com.buyeoon.mission.application;
+
+public enum MissionAvailability {
+	LOCKED, AVAILABLE, EXHAUSTED, COMPLETED
+}

--- a/src/main/java/com/buyeoon/mission/application/MissionQueryService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionQueryService.java
@@ -1,0 +1,80 @@
+package com.buyeoon.mission.application;
+
+import com.buyeoon.mission.entity.MissionEntity;
+import com.buyeoon.mission.entity.MissionParticipationEntity;
+import com.buyeoon.mission.entity.MissionStatus;
+import com.buyeoon.mission.entity.MissionType;
+import com.buyeoon.mission.repository.MissionQueryRepository;
+import com.buyeoon.mission.repository.NearbyMissionProjection;
+import com.buyeoon.place.entity.PlaceEntity;
+import com.buyeoon.trip.TripQueryService;
+import com.buyeoon.trip.entity.TripStatus;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MissionQueryService {
+
+	private static final int PARTICIPATION_RADIUS_METERS = 100;
+
+	private final MissionQueryRepository missionQueryRepository;
+	private final TripQueryService tripQueryService;
+
+	public MissionQueryService(MissionQueryRepository missionQueryRepository, TripQueryService tripQueryService) {
+		this.missionQueryRepository = missionQueryRepository;
+		this.tripQueryService = tripQueryService;
+	}
+
+	public MissionListView listNearby(UUID memberId, UUID tripId, double latitude, double longitude) {
+		TripStatus status = tripQueryService.findOwnedTripStatus(memberId, tripId)
+				.orElseThrow(TripNotFoundException::new);
+		if (status != TripStatus.IN_PROGRESS) {
+			throw new TripNotInProgressException();
+		}
+
+		List<MissionItemView> items = missionQueryRepository.findNearby(tripId, latitude, longitude).stream()
+				.map(row -> toView(tripId, row)).toList();
+		return new MissionListView(items);
+	}
+
+	private MissionItemView toView(UUID tripId, NearbyMissionProjection row) {
+		MissionEntity mission = row.mission();
+		PlaceEntity place = row.place();
+		MissionParticipationEntity participation = row.participation();
+
+		MissionStatus persistedStatus = participation == null ? MissionStatus.AVAILABLE : participation.getStatus();
+		int attemptCount = participation == null ? 0 : participation.getAttemptCount();
+		boolean withinParticipationRadius = row.distanceMeters() <= PARTICIPATION_RADIUS_METERS;
+
+		MissionAvailability availability = switch (persistedStatus) {
+			case COMPLETED -> MissionAvailability.COMPLETED;
+			case EXHAUSTED -> MissionAvailability.EXHAUSTED;
+			case AVAILABLE -> withinParticipationRadius ? MissionAvailability.AVAILABLE : MissionAvailability.LOCKED;
+		};
+
+		Integer maxAttempts = mission.getMaxAttempts();
+		Integer remainingAttempts = maxAttempts == null
+				? null
+				: (persistedStatus == MissionStatus.AVAILABLE ? maxAttempts - attemptCount : 0);
+
+		int distanceMeters = (int) Math.round(row.distanceMeters());
+
+		return new MissionItemView(mission.getId(), tripId, place.getId(), place.getName(), place.getLocation().getY(),
+				place.getLocation().getX(), distanceMeters, mission.getType(), mission.getTitle(),
+				mission.getRewardPoints(), availability, PARTICIPATION_RADIUS_METERS, remainingAttempts);
+	}
+
+	public record MissionListView(List<MissionItemView> items) {
+		public MissionListView {
+			items = List.copyOf(items);
+		}
+	}
+
+	public record MissionItemView(UUID missionId, UUID tripId, UUID placeId, String placeName, double latitude,
+			double longitude, int distanceMeters, MissionType type, String title, int rewardPoints,
+			MissionAvailability availability, int participationRadiusMeters, Integer remainingAttempts) {
+	}
+}

--- a/src/main/java/com/buyeoon/mission/application/TripNotFoundException.java
+++ b/src/main/java/com/buyeoon/mission/application/TripNotFoundException.java
@@ -1,0 +1,8 @@
+package com.buyeoon.mission.application;
+
+public class TripNotFoundException extends RuntimeException {
+
+	public TripNotFoundException() {
+		super("존재하지 않거나 본인 소유가 아닌 여행입니다.");
+	}
+}

--- a/src/main/java/com/buyeoon/mission/application/TripNotInProgressException.java
+++ b/src/main/java/com/buyeoon/mission/application/TripNotInProgressException.java
@@ -1,0 +1,8 @@
+package com.buyeoon.mission.application;
+
+public class TripNotInProgressException extends RuntimeException {
+
+	public TripNotInProgressException() {
+		super("진행 중인 여행에서만 요청할 수 있습니다.");
+	}
+}

--- a/src/main/java/com/buyeoon/mission/repository/MissionQueryRepository.java
+++ b/src/main/java/com/buyeoon/mission/repository/MissionQueryRepository.java
@@ -1,0 +1,31 @@
+package com.buyeoon.mission.repository;
+
+import com.buyeoon.mission.entity.MissionEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 미션 위치는 연결된 {@code places.location}을 사용한다(ADR-002). 미션과 장소는 별도 도메인 테이블이지만 매핑된
+ * 연관관계가 없으므로 JPQL ad-hoc join으로 연결한다.
+ */
+public interface MissionQueryRepository extends JpaRepository<MissionEntity, UUID> {
+
+	@Query("""
+			SELECT new com.buyeoon.mission.repository.NearbyMissionProjection(m, p,
+			       ST_Distance(p.location,
+			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)),
+			       participation)
+			FROM MissionEntity m
+			JOIN PlaceEntity p ON p.id = m.placeId
+			LEFT JOIN MissionParticipationEntity participation
+			    ON participation.missionId = m.id AND participation.tripId = :tripId
+			WHERE ST_Distance(p.location,
+			          ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)) <= 500
+			ORDER BY 3 ASC, m.id ASC
+			""")
+	List<NearbyMissionProjection> findNearby(@Param("tripId") UUID tripId, @Param("latitude") double latitude,
+			@Param("longitude") double longitude);
+}

--- a/src/main/java/com/buyeoon/mission/repository/NearbyMissionProjection.java
+++ b/src/main/java/com/buyeoon/mission/repository/NearbyMissionProjection.java
@@ -1,0 +1,12 @@
+package com.buyeoon.mission.repository;
+
+import com.buyeoon.mission.entity.MissionEntity;
+import com.buyeoon.mission.entity.MissionParticipationEntity;
+import com.buyeoon.place.entity.PlaceEntity;
+
+public record NearbyMissionProjection(
+		MissionEntity mission,
+		PlaceEntity place,
+		double distanceMeters,
+		MissionParticipationEntity participation) {
+}

--- a/src/main/java/com/buyeoon/trip/TripQueryService.java
+++ b/src/main/java/com/buyeoon/trip/TripQueryService.java
@@ -1,6 +1,8 @@
 package com.buyeoon.trip;
 
+import com.buyeoon.trip.entity.TripEntity;
 import com.buyeoon.trip.entity.TripStatus;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,5 +20,10 @@ public class TripQueryService {
 
 	public boolean hasActiveTrip(UUID memberId) {
 		return tripRepository.findByMemberIdAndStatus(memberId, TripStatus.IN_PROGRESS).isPresent();
+	}
+
+	/** 요청 회원이 소유한 여행의 현재 상태를 조회한다. 소유한 여행이 없으면 빈 값을 반환한다. */
+	public Optional<TripStatus> findOwnedTripStatus(UUID memberId, UUID tripId) {
+		return tripRepository.findByIdAndMemberId(tripId, memberId).map(TripEntity::getStatus);
 	}
 }

--- a/src/main/java/com/buyeoon/trip/TripRepository.java
+++ b/src/main/java/com/buyeoon/trip/TripRepository.java
@@ -14,6 +14,8 @@ public interface TripRepository extends JpaRepository<TripEntity, UUID> {
 
 	Optional<TripEntity> findByMemberIdAndStatus(UUID memberId, TripStatus status);
 
+	Optional<TripEntity> findByIdAndMemberId(UUID id, UUID memberId);
+
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT t FROM TripEntity t WHERE t.memberId = :memberId AND t.status = :status")
 	Optional<TripEntity> lockByMemberIdAndStatus(@Param("memberId") UUID memberId, @Param("status") TripStatus status);

--- a/src/test/java/com/buyeoon/mission/MissionControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionControllerIntegrationTests.java
@@ -1,0 +1,432 @@
+package com.buyeoon.mission;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class MissionControllerIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	// 시드 마이그레이션이 부여 지역에 장소·미션 예시 데이터를 채워두므로, 격리를 위해 남극 인근 좌표를
+	// 기준으로 테스트 데이터를 배치한다.
+	private static final double ORIGIN_LATITUDE = -75.0;
+	private static final double ORIGIN_LONGITUDE = 0.0;
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private org.springframework.test.web.servlet.MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	private AuthenticatedMember member;
+
+	@BeforeEach
+	void setUpMember() {
+		member = insertAuthenticatedMember();
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update(
+				"DELETE FROM missions WHERE place_id IN (SELECT id FROM places WHERE ST_Y(location::geometry) < -70)");
+		jdbcTemplate.update("DELETE FROM places WHERE ST_Y(location::geometry) < -70");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 진행 중인 여행으로 요청하면 500m 이내 OX·객관식·사진 인증 미션을 모두 받는다. */
+	@Test
+	@DisplayName("진행 중인 여행이 있으면 500m 이내 모든 유형의 미션을 200으로 받는다")
+	void returns200WithAllMissionTypesWithin500m() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID placeA = insertPlace("장소1", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE);
+		UUID placeB = insertPlace("장소2", ORIGIN_LATITUDE + 0.002, ORIGIN_LONGITUDE);
+		UUID placeC = insertPlace("장소3", ORIGIN_LATITUDE + 0.003, ORIGIN_LONGITUDE);
+		insertOxMission(placeA, "OX 미션", 100, null, true);
+		insertMultipleChoiceMission(placeB, "객관식 미션", 100, null);
+		insertPhotoMission(placeC, "사진 미션", 150);
+
+		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.items.length()").value(3)).andExpect(jsonPath("$.data.items[*].type")
+						.value(org.hamcrest.Matchers.containsInAnyOrder("OX", "MULTIPLE_CHOICE", "PHOTO")));
+	}
+
+	/** 500m 직전 미션은 포함되고 직후 미션은 제외된다. */
+	@Test
+	@DisplayName("500m 경계 안쪽 미션은 포함되고 바깥쪽 미션은 제외된다")
+	void includesMissionJustInsideAndExcludesJustBeyond500m() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID insidePlace = insertProjectedPlace("경계 안쪽", 499.9);
+		UUID outsidePlace = insertProjectedPlace("경계 바깥", 500.1);
+		UUID insideMission = insertOxMission(insidePlace, "안쪽 미션", 100, null, true);
+		insertOxMission(outsidePlace, "바깥 미션", 100, null, true);
+
+		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items.length()").value(1))
+				.andExpect(jsonPath("$.data.items[0].missionId").value(insideMission.toString()));
+	}
+
+	/** 실제 거리가 같으면 missionId 오름차순으로 안정 정렬된다. */
+	@Test
+	@DisplayName("같은 거리의 미션은 missionId 오름차순으로 정렬된다")
+	void ordersByDistanceThenMissionIdWhenTied() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertPlace("공통 장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE);
+		insertOxMission(place, "미션A", 100, null, true);
+		insertOxMission(place, "미션B", 100, null, true);
+		// Postgres uuid는 바이트 단위 비교라 java.util.UUID#compareTo(부호 있는 long 비교)와 순서가
+		// 다를 수 있으므로 DB에서 실제 정렬 순서를 그대로 가져온다.
+		List<UUID> expectedOrder = jdbcTemplate.queryForList("SELECT id FROM missions WHERE place_id = ? ORDER BY id",
+				UUID.class, place);
+
+		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items.length()").value(2))
+				.andExpect(jsonPath("$.data.items[0].missionId").value(expectedOrder.get(0).toString()))
+				.andExpect(jsonPath("$.data.items[1].missionId").value(expectedOrder.get(1).toString()));
+	}
+
+	/** 같은 장소에 연결된 여러 미션은 각각 반환된다. */
+	@Test
+	@DisplayName("같은 장소의 여러 미션은 각각 반환된다")
+	void returnsEachMissionSeparatelyForSamePlace() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertPlace("문화재", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE);
+		insertOxMission(place, "OX", 100, null, true);
+		insertMultipleChoiceMission(place, "객관식", 100, null);
+
+		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items.length()").value(2));
+	}
+
+	/** 500m 안에 미션이 없으면 빈 목록을 정상 반환한다. */
+	@Test
+	@DisplayName("주변에 미션이 없으면 빈 목록을 받는다")
+	void returnsEmptyListWhenNoMissionsNearby() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+
+		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk()).andExpect(jsonPath("$.data.items").isArray())
+				.andExpect(jsonPath("$.data.items.length()").value(0));
+	}
+
+	/** 목록 항목은 OpenAPI Mission 스키마의 식별자, 유형, 제목, 장소명·좌표, 거리, 보상, 상태, 참여 반경을 포함한다. */
+	@Test
+	@DisplayName("목록 항목에 필요한 모든 필드가 포함된다")
+	void includesAllRequiredFieldsInResponse() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("부소산성", 50);
+		UUID missionId = insertOxMission(place, "OX 퀴즈", 100, null, true);
+
+		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items[0].missionId").value(missionId.toString()))
+				.andExpect(jsonPath("$.data.items[0].tripId").value(tripId.toString()))
+				.andExpect(jsonPath("$.data.items[0].placeId").value(place.toString()))
+				.andExpect(jsonPath("$.data.items[0].placeName").value("부소산성"))
+				.andExpect(jsonPath("$.data.items[0].latitude").exists())
+				.andExpect(jsonPath("$.data.items[0].longitude").exists())
+				.andExpect(jsonPath("$.data.items[0].distanceMeters").exists())
+				.andExpect(jsonPath("$.data.items[0].type").value("OX"))
+				.andExpect(jsonPath("$.data.items[0].title").value("OX 퀴즈"))
+				.andExpect(jsonPath("$.data.items[0].rewardPoints").value(100))
+				.andExpect(jsonPath("$.data.items[0].availability").value("AVAILABLE"))
+				.andExpect(jsonPath("$.data.items[0].participationRadiusMeters").value(100))
+				.andExpect(jsonPath("$.data.items[0].remainingAttempts").isEmpty());
+	}
+
+	/** 참여 기록이 없는 미션은 100m 이내면 AVAILABLE, 초과면 LOCKED이며 100m 경계는 AVAILABLE이다. */
+	@Test
+	@DisplayName("참여 기록이 없으면 100m 이내는 AVAILABLE, 초과는 LOCKED로 표시된다")
+	void marksAvailableWithinParticipationRadiusAndLockedBeyond() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID availablePlace = insertProjectedPlace("참여 가능", 99.9);
+		UUID lockedPlace = insertProjectedPlace("잠김", 100.1);
+		UUID availableMission = insertOxMission(availablePlace, "참여 가능 미션", 100, null, true);
+		UUID lockedMission = insertOxMission(lockedPlace, "잠긴 미션", 100, null, true);
+
+		MvcResult result = mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk()).andReturn();
+		assertThat(itemFor(result, availableMission).get("availability").stringValue()).isEqualTo("AVAILABLE");
+		assertThat(itemFor(result, lockedMission).get("availability").stringValue()).isEqualTo("LOCKED");
+	}
+
+	/** 완료·기회 소진 기록은 현재 위치와 무관하게 유지된다. */
+	@Test
+	@DisplayName("완료·기회 소진 상태는 위치와 관계없이 유지된다")
+	void completedAndExhaustedOverrideLocationBasedAvailability() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID farPlace = insertProjectedPlace("먼 장소", 490);
+		UUID completedMission = insertOxMission(farPlace, "완료 미션", 100, null, true);
+		UUID exhaustedMission = insertOxMission(farPlace, "소진 미션", 100, 1, true);
+		insertParticipation(tripId, completedMission, "COMPLETED", 1);
+		insertParticipation(tripId, exhaustedMission, "EXHAUSTED", 1);
+
+		MvcResult result = mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk()).andReturn();
+		assertThat(itemFor(result, completedMission).get("availability").stringValue()).isEqualTo("COMPLETED");
+		assertThat(itemFor(result, exhaustedMission).get("availability").stringValue()).isEqualTo("EXHAUSTED");
+	}
+
+	/** 도전 가능한 스페셜 퀴즈의 남은 횟수는 최대 횟수에서 사용 횟수를 뺀 값이다. */
+	@Test
+	@DisplayName("도전 가능한 스페셜 퀴즈는 남은 횟수를 최대 횟수에서 사용 횟수를 뺀 값으로 받는다")
+	void computesRemainingAttemptsForChallengeableSpecialQuiz() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertPlace("스페셜 퀴즈 장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE);
+		UUID missionId = insertOxMission(place, "스페셜 퀴즈", 100, 3, true);
+		insertParticipation(tripId, missionId, "AVAILABLE", 1);
+
+		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items[0].remainingAttempts").value(2));
+	}
+
+	/** 완료 또는 기회 소진된 스페셜 퀴즈의 남은 횟수는 0이다. */
+	@Test
+	@DisplayName("완료·소진된 스페셜 퀴즈의 남은 횟수는 0이다")
+	void remainingAttemptsIsZeroForCompletedOrExhaustedSpecialQuiz() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertPlace("스페셜 퀴즈 장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE);
+		UUID missionId = insertOxMission(place, "스페셜 퀴즈", 100, 3, true);
+		insertParticipation(tripId, missionId, "EXHAUSTED", 3);
+
+		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items[0].remainingAttempts").value(0));
+	}
+
+	/** 일반 퀴즈와 사진 인증 미션의 남은 도전 횟수는 항상 null이다. */
+	@Test
+	@DisplayName("일반 퀴즈와 사진 미션의 남은 횟수는 null이다")
+	void remainingAttemptsIsNullForNormalQuizAndPhotoMission() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertPlace("장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE);
+		UUID normalQuiz = insertOxMission(place, "일반 퀴즈", 100, null, true);
+		UUID photoMission = insertPhotoMission(place, "사진 미션", 100);
+		insertParticipation(tripId, normalQuiz, "COMPLETED", 1);
+
+		MvcResult result = mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk()).andReturn();
+		assertThat(itemFor(result, normalQuiz).get("remainingAttempts").isNull()).isTrue();
+		assertThat(itemFor(result, photoMission).get("remainingAttempts").isNull()).isTrue();
+	}
+
+	/** 조회는 참여 행을 생성하거나 기존 DB 상태를 바꾸지 않는다. */
+	@Test
+	@DisplayName("반복 조회 전후 mission_participations를 포함한 DB 상태가 동일하다")
+	void repeatedRequestsDoNotChangeDbState() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertPlace("장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE);
+		insertOxMission(place, "OX", 100, null, true);
+
+		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk());
+		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk());
+
+		Integer participationCount = jdbcTemplate
+				.queryForObject("SELECT COUNT(*) FROM mission_participations WHERE trip_id = ?", Integer.class, tripId);
+		assertThat(participationCount).isZero();
+	}
+
+	/** 좌표나 tripId 형식이 잘못되면 400을 받는다. */
+	@Test
+	@DisplayName("좌표나 tripId 형식이 잘못되면 400을 받는다")
+	void returns400WhenCoordinatesOrTripIdAreInvalid() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+
+		mockMvc.perform(get("/missions/nearby").header("Authorization", "Bearer " + member.accessToken())
+				.param("latitude", "abc").param("longitude", String.valueOf(ORIGIN_LONGITUDE))
+				.param("tripId", tripId.toString())).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+
+		mockMvc.perform(get("/missions/nearby").header("Authorization", "Bearer " + member.accessToken())
+				.param("latitude", "91.0").param("longitude", String.valueOf(ORIGIN_LONGITUDE))
+				.param("tripId", tripId.toString())).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+
+		mockMvc.perform(get("/missions/nearby").header("Authorization", "Bearer " + member.accessToken())
+				.param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude", String.valueOf(ORIGIN_LONGITUDE))
+				.param("tripId", "not-a-uuid")).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+
+		mockMvc.perform(get("/missions/nearby").header("Authorization", "Bearer " + member.accessToken())
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("tripId", tripId.toString()))
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	/** 인증되지 않은 요청은 401을 받는다. */
+	@Test
+	@DisplayName("인증하지 않으면 401을 받는다")
+	void returns401WhenUnauthenticated() throws Exception {
+		mockMvc.perform(get("/missions/nearby").param("latitude", String.valueOf(ORIGIN_LATITUDE))
+				.param("longitude", String.valueOf(ORIGIN_LONGITUDE)).param("tripId", UUID.randomUUID().toString()))
+				.andExpect(status().isUnauthorized()).andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** 존재하지 않거나 다른 회원의 여행은 존재 여부를 구분하지 않고 404를 받는다. */
+	@Test
+	@DisplayName("본인 소유가 아니거나 존재하지 않는 여행은 404를 받는다")
+	void returns404WhenTripIsNotOwnedOrMissing() throws Exception {
+		mockMvc.perform(nearbyRequest(UUID.randomUUID())).andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+
+		AuthenticatedMember other = insertAuthenticatedMember();
+		UUID otherTripId = startTrip(other.memberId());
+		mockMvc.perform(nearbyRequest(otherTripId)).andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 본인 여행이지만 종료·정산 상태면 409를 받는다. */
+	@Test
+	@DisplayName("본인 여행이 진행 중이 아니면 409를 받는다")
+	void returns409WhenOwnTripIsNotInProgress() throws Exception {
+		UUID endedTripId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status, ended_at) VALUES (?, ?, 'ENDED', now())",
+				endedTripId, member.memberId());
+		mockMvc.perform(nearbyRequest(endedTripId)).andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("TRIP_NOT_IN_PROGRESS"));
+
+		UUID settledTripId = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO trips (id, member_id, status, ended_at, settled_at) VALUES (?, ?, 'SETTLED', now(), now())",
+				settledTripId, member.memberId());
+		mockMvc.perform(nearbyRequest(settledTripId)).andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("TRIP_NOT_IN_PROGRESS"));
+	}
+
+	private JsonNode itemFor(MvcResult result, UUID missionId) throws Exception {
+		JsonNode items = objectMapper.readTree(result.getResponse().getContentAsString()).get("data").get("items");
+		for (JsonNode item : items) {
+			if (item.get("missionId").stringValue().equals(missionId.toString())) {
+				return item;
+			}
+		}
+		throw new AssertionError("응답에서 미션을 찾을 수 없습니다: " + missionId);
+	}
+
+	private MockHttpServletRequestBuilder nearbyRequest(UUID tripId) {
+		return get("/missions/nearby").header("Authorization", "Bearer " + member.accessToken())
+				.param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude", String.valueOf(ORIGIN_LONGITUDE))
+				.param("tripId", tripId.toString());
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private UUID startTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status) VALUES (?, ?, 'IN_PROGRESS')", tripId, memberId);
+		return tripId;
+	}
+
+	private UUID insertPlace(String name, double latitude, double longitude) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate
+				.update("INSERT INTO places (id, category, name, location) VALUES (?, 'HERITAGE'::place_category, ?, "
+						+ "ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography)", id, name, longitude, latitude);
+		return id;
+	}
+
+	/**
+	 * 원점에서 지정한 거리(m)만큼 떨어진 지점에 장소를 만든다. 삽입과 조회가 같은 PostGIS geodesic 계산을 쓰므로 왕복 오차가
+	 * 없다.
+	 */
+	private UUID insertProjectedPlace(String name, double distanceMeters) {
+		Map<String, Object> point = jdbcTemplate.queryForMap(
+				"SELECT ST_Y(pt::geometry) AS lat, ST_X(pt::geometry) AS lon FROM "
+						+ "(SELECT ST_Project(ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?, 0) AS pt) t",
+				ORIGIN_LONGITUDE, ORIGIN_LATITUDE, distanceMeters);
+		return insertPlace(name, ((Number) point.get("lat")).doubleValue(), ((Number) point.get("lon")).doubleValue());
+	}
+
+	private UUID insertOxMission(UUID placeId, String title, int rewardPoints, Integer maxAttempts,
+			boolean correctAnswer) {
+		return insertMission(placeId, "OX", title, rewardPoints, maxAttempts, correctAnswer);
+	}
+
+	private UUID insertMultipleChoiceMission(UUID placeId, String title, int rewardPoints, Integer maxAttempts) {
+		return insertMission(placeId, "MULTIPLE_CHOICE", title, rewardPoints, maxAttempts, null);
+	}
+
+	private UUID insertPhotoMission(UUID placeId, String title, int rewardPoints) {
+		return insertMission(placeId, "PHOTO", title, rewardPoints, null, null);
+	}
+
+	private UUID insertMission(UUID placeId, String type, String title, int rewardPoints, Integer maxAttempts,
+			Boolean oxCorrectAnswer) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO missions (id, place_id, type, title, description, reward_points, max_attempts, "
+						+ "ox_correct_answer) VALUES (?, ?, ?::mission_type, ?, '설명', ?, ?, ?)",
+				id, placeId, type, title, rewardPoints, maxAttempts, oxCorrectAnswer);
+		return id;
+	}
+
+	private void insertParticipation(UUID tripId, UUID missionId, String status, int attemptCount) {
+		Timestamp completedAt = "COMPLETED".equals(status) ? Timestamp.from(Instant.now()) : null;
+		jdbcTemplate.update(
+				"INSERT INTO mission_participations (id, trip_id, mission_id, status, attempt_count, completed_at) "
+						+ "VALUES (?, ?, ?, ?::mission_status, ?, ?)",
+				UUID.randomUUID(), tripId, missionId, status, attemptCount, completedAt);
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## Summary
- `GET /missions/nearby`를 OpenAPI 계약대로 구현해, 인증된 활성 회원이 자신의 진행 중 여행 반경 500m 이내 OX·객관식·사진 인증 미션을 지도 마커용 정보(거리·보상·표시 상태·참여 반경·남은 도전 횟수)와 함께 조회할 수 있게 했다.
- 미션 위치는 ADR-002에 따라 연결된 `places.location`을 JPQL ad-hoc join으로 참조해 PostGIS `ST_Distance`로 판정하며, 완료·기회 소진은 위치와 무관하게 우선하고 나머지는 100m 참여 반경 기준으로 AVAILABLE/LOCKED를 계산한다.
- 여행 소유권·진행 상태 확인을 위해 `TripQueryService`에 `findOwnedTripStatus` seam을 추가하고, 공용 `ErrorResponse`에 `TRIP_NOT_IN_PROGRESS`(409) 팩토리를 추가했다.

## Test plan
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh`
- [x] `./scripts/test/test.sh` (전체 테스트, 신규 `MissionControllerIntegrationTests` 16건 포함)
- [x] `./scripts/test/docker-build.sh`
- [x] `code-review` 스킬로 Standards/Spec 리뷰 완료 (차단 문제 없음)

Closes #3