### PR TITLE
feat: UC-16 포인트 잔액 요약 조회 구현

### DIFF
--- a/src/main/java/com/buyeoon/point/api/PointController.java
+++ b/src/main/java/com/buyeoon/point/api/PointController.java
@@ -1,0 +1,28 @@
+package com.buyeoon.point.api;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.point.application.PointSummaryService;
+import com.buyeoon.point.application.PointSummaryService.PointSummaryView;
+import java.util.Objects;
+import java.util.UUID;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** 로그인 회원의 포인트 잔액 요약 조회를 담당하는 컨트롤러다. */
+@RestController
+public class PointController {
+
+	private final PointSummaryService pointSummaryService;
+
+	public PointController(PointSummaryService pointSummaryService) {
+		this.pointSummaryService = pointSummaryService;
+	}
+
+	@GetMapping("/members/me/points")
+	public SuccessResponse<PointSummaryView> getMyPointSummary(@AuthenticationPrincipal Jwt jwt) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		return SuccessResponse.of(pointSummaryService.getSummary(memberId));
+	}
+}

--- a/src/main/java/com/buyeoon/point/application/PointSummaryService.java
+++ b/src/main/java/com/buyeoon/point/application/PointSummaryService.java
@@ -1,0 +1,54 @@
+package com.buyeoon.point.application;
+
+import com.buyeoon.point.entity.PointSettlementEntity;
+import com.buyeoon.point.entity.PointTransactionType;
+import com.buyeoon.point.entity.SettlementChoice;
+import com.buyeoon.point.repository.PointSettlementQueryRepository;
+import com.buyeoon.point.repository.PointTransactionRepository;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 회원의 포인트 잔액 요약(잔액, 누적 적립, 만료 예정)을 조회하는 point 도메인의 공개 seam이다. */
+@Service
+@Transactional(readOnly = true)
+public class PointSummaryService {
+
+	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+
+	private final PointTransactionRepository pointTransactionRepository;
+	private final PointSettlementQueryRepository pointSettlementQueryRepository;
+
+	public PointSummaryService(PointTransactionRepository pointTransactionRepository,
+			PointSettlementQueryRepository pointSettlementQueryRepository) {
+		this.pointTransactionRepository = pointTransactionRepository;
+		this.pointSettlementQueryRepository = pointSettlementQueryRepository;
+	}
+
+	/** 잔액, `EARN` 누적 합계, 만료 시각 오름차순 만료 예정 목록을 조회한다. */
+	public PointSummaryView getSummary(UUID memberId) {
+		long balance = pointTransactionRepository.sumAmountByMemberId(memberId);
+		long cumulativeEarned = pointTransactionRepository.sumAmountByMemberIdAndType(memberId,
+				PointTransactionType.EARN);
+		List<PointExpirationView> expirations = pointSettlementQueryRepository
+				.findActiveCarryOversByMemberId(memberId, SettlementChoice.CARRY_OVER).stream()
+				.map(this::toExpirationView).toList();
+		return new PointSummaryView(balance, cumulativeEarned, expirations);
+	}
+
+	private PointExpirationView toExpirationView(PointSettlementEntity settlement) {
+		return new PointExpirationView(settlement.getSettledPoints(), settlement.getExpiresAt().atZone(ASIA_SEOUL));
+	}
+
+	public record PointSummaryView(long balance, long cumulativeEarned, List<PointExpirationView> expirations) {
+		public PointSummaryView {
+			expirations = List.copyOf(expirations);
+		}
+	}
+
+	public record PointExpirationView(long points, ZonedDateTime expiresAt) {
+	}
+}

--- a/src/main/java/com/buyeoon/point/repository/PointSettlementQueryRepository.java
+++ b/src/main/java/com/buyeoon/point/repository/PointSettlementQueryRepository.java
@@ -1,0 +1,28 @@
+package com.buyeoon.point.repository;
+
+import com.buyeoon.point.entity.PointSettlementEntity;
+import com.buyeoon.point.entity.SettlementChoice;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 정산의 소유 회원을 확인하기 위해 trip 도메인의 {@code TripEntity}를 ad-hoc join으로 참조한다(미션 도메인의
+ * {@code MissionQueryRepository}와 동일한 조회 전용 패턴).
+ */
+public interface PointSettlementQueryRepository extends JpaRepository<PointSettlementEntity, UUID> {
+
+	/** 회원이 `다음에 이어서 쓰기`로 이월했고 아직 만료되지 않은 정산을 만료 시각 오름차순으로 조회한다. */
+	@Query("""
+			SELECT s FROM PointSettlementEntity s
+			JOIN TripEntity t ON t.id = s.tripId
+			WHERE t.memberId = :memberId
+			  AND s.choice = :choice
+			  AND s.expiresAt > CURRENT_TIMESTAMP
+			ORDER BY s.expiresAt ASC
+			""")
+	List<PointSettlementEntity> findActiveCarryOversByMemberId(@Param("memberId") UUID memberId,
+			@Param("choice") SettlementChoice choice);
+}

--- a/src/main/java/com/buyeoon/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/buyeoon/point/repository/PointTransactionRepository.java
@@ -1,0 +1,21 @@
+package com.buyeoon.point.repository;
+
+import com.buyeoon.point.entity.PointTransactionEntity;
+import com.buyeoon.point.entity.PointTransactionType;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** 회원의 포인트 잔액·누적 적립 합계를 계산하는 조회 전용 repository다. */
+public interface PointTransactionRepository extends JpaRepository<PointTransactionEntity, UUID> {
+
+	/** 회원의 포인트 잔액(전체 내역 amount 합계)을 계산한다. 내역이 없으면 0을 반환한다. */
+	@Query("SELECT COALESCE(SUM(t.amount), 0) FROM PointTransactionEntity t WHERE t.memberId = :memberId")
+	long sumAmountByMemberId(@Param("memberId") UUID memberId);
+
+	/** 회원의 특정 유형 포인트 내역 amount 합계를 계산한다. 내역이 없으면 0을 반환한다. */
+	@Query("SELECT COALESCE(SUM(t.amount), 0) FROM PointTransactionEntity t "
+			+ "WHERE t.memberId = :memberId AND t.type = :type")
+	long sumAmountByMemberIdAndType(@Param("memberId") UUID memberId, @Param("type") PointTransactionType type);
+}

--- a/src/test/java/com/buyeoon/point/PointSummaryIntegrationTests.java
+++ b/src/test/java/com/buyeoon/point/PointSummaryIntegrationTests.java
@@ -1,0 +1,193 @@
+package com.buyeoon.point;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class PointSummaryIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private org.springframework.test.web.servlet.MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	private AuthenticatedMember member;
+
+	@BeforeEach
+	void setUpMember() {
+		member = insertAuthenticatedMember();
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM point_settlements");
+		jdbcTemplate.update("DELETE FROM point_transactions");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 잔액은 전체 내역 amount 합계이고, 누적 적립은 EARN 내역 amount 합계다. */
+	@Test
+	@DisplayName("잔액은 전체 내역 합계, 누적 적립은 EARN 내역 합계로 반환된다")
+	void returnsBalanceAndCumulativeEarnedFromTransactions() throws Exception {
+		insertTransaction(member.memberId(), "EARN", 100, "미션 보상");
+		insertTransaction(member.memberId(), "EARN", 50, "미션 보상");
+		insertTransaction(member.memberId(), "LEAVE_TO_BUYEO", -30, "정산");
+
+		mockMvc.perform(pointsRequest()).andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.balance").value(120))
+				.andExpect(jsonPath("$.data.cumulativeEarned").value(150));
+	}
+
+	/** 포인트 내역이 없으면 잔액과 누적 적립은 0, 만료 예정은 빈 목록이다. */
+	@Test
+	@DisplayName("내역이 없으면 balance 0, cumulativeEarned 0, expirations 빈 배열을 받는다")
+	void returnsZeroAndEmptyExpirationsWhenNoTransactions() throws Exception {
+		mockMvc.perform(pointsRequest()).andExpect(status().isOk()).andExpect(jsonPath("$.data.balance").value(0))
+				.andExpect(jsonPath("$.data.cumulativeEarned").value(0))
+				.andExpect(jsonPath("$.data.expirations").isArray())
+				.andExpect(jsonPath("$.data.expirations.length()").value(0));
+	}
+
+	/** 만료 예정은 CARRY_OVER 정산 중 만료 시각이 미래인 항목만 만료 시각 오름차순으로 반환한다. */
+	@Test
+	@DisplayName("만료 예정은 미래 CARRY_OVER 정산만 만료 시각 오름차순으로 반환한다")
+	void returnsFutureCarryOverExpirationsInAscendingOrder() throws Exception {
+		Instant soon = Instant.now().plus(10, ChronoUnit.DAYS);
+		Instant later = Instant.now().plus(20, ChronoUnit.DAYS);
+		Instant past = Instant.now().minus(1, ChronoUnit.DAYS);
+
+		UUID laterTrip = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(laterTrip, 200, later);
+		UUID soonTrip = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(soonTrip, 100, soon);
+		UUID pastTrip = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(pastTrip, 999, past);
+		UUID leaveTrip = insertSettledTrip(member.memberId());
+		insertLeaveToBuyeoSettlement(leaveTrip, 300);
+
+		mockMvc.perform(pointsRequest()).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.expirations.length()").value(2))
+				.andExpect(jsonPath("$.data.expirations[0].points").value(100))
+				.andExpect(jsonPath("$.data.expirations[1].points").value(200));
+	}
+
+	/** 다른 회원의 내역과 정산은 조회 결과에 포함되지 않는다. */
+	@Test
+	@DisplayName("다른 회원의 포인트 내역과 정산은 포함되지 않는다")
+	void excludesOtherMembersData() throws Exception {
+		AuthenticatedMember other = insertAuthenticatedMember();
+		insertTransaction(other.memberId(), "EARN", 1000, "다른 회원 적립");
+		UUID otherTrip = insertSettledTrip(other.memberId());
+		insertCarryOverSettlement(otherTrip, 500, Instant.now().plus(5, ChronoUnit.DAYS));
+
+		mockMvc.perform(pointsRequest()).andExpect(status().isOk()).andExpect(jsonPath("$.data.balance").value(0))
+				.andExpect(jsonPath("$.data.cumulativeEarned").value(0))
+				.andExpect(jsonPath("$.data.expirations.length()").value(0));
+	}
+
+	/** 인증하지 않으면 401을 받는다. */
+	@Test
+	@DisplayName("인증하지 않으면 401을 받는다")
+	void returns401WhenUnauthenticated() throws Exception {
+		mockMvc.perform(get("/members/me/points")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	private MockHttpServletRequestBuilder pointsRequest() {
+		return get("/members/me/points").header("Authorization", "Bearer " + member.accessToken());
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private void insertTransaction(UUID memberId, String type, long amount, String description) {
+		jdbcTemplate.update(
+				"INSERT INTO point_transactions (id, member_id, type, amount, description) "
+						+ "VALUES (?, ?, ?::point_transaction_type, ?, ?)",
+				UUID.randomUUID(), memberId, type, amount, description);
+	}
+
+	/** 정산 대상 여행. 여러 여행을 같은 회원에 만들기 위해 진행 중 상태 대신 정산 완료 상태로 만든다. */
+	private UUID insertSettledTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO trips (id, member_id, status, ended_at, settled_at) VALUES (?, ?, 'SETTLED', now(), now())",
+				tripId, memberId);
+		return tripId;
+	}
+
+	private void insertCarryOverSettlement(UUID tripId, long settledPoints, Instant expiresAt) {
+		Instant settledAt = expiresAt.minus(240, ChronoUnit.HOURS);
+		jdbcTemplate.update(
+				"INSERT INTO point_settlements (id, trip_id, choice, settled_points, expires_at, settled_at) "
+						+ "VALUES (?, ?, 'CARRY_OVER', ?, ?, ?)",
+				UUID.randomUUID(), tripId, settledPoints, Timestamp.from(expiresAt), Timestamp.from(settledAt));
+	}
+
+	private void insertLeaveToBuyeoSettlement(UUID tripId, long settledPoints) {
+		jdbcTemplate.update("INSERT INTO point_settlements (id, trip_id, choice, settled_points, expires_at) "
+				+ "VALUES (?, ?, 'LEAVE_TO_BUYEO', ?, NULL)", UUID.randomUUID(), tripId, settledPoints);
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## Summary
- `GET /members/me/points`에서 잔액(`balance`), 누적 적립(`cumulativeEarned`), 만료 예정(`expirations`)을 반환하는 point 도메인의 조회 경로(Repository·Service·Controller)를 신규 작성했다.
- 잔액은 회원 포인트 내역 전체 `amount` 합계, 누적 적립은 `EARN` 내역 `amount` 합계로 계산한다.
- 만료 예정은 `다음에 이어서 쓰기`(`CARRY_OVER`)로 정산했고 아직 만료되지 않은 항목만 만료 시각 오름차순으로 반환한다.

Closes #106

## Test plan
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh`
- [x] `./scripts/test/test.sh` (Testcontainers PostgreSQL/PostGIS + 전체 Flyway + 실제 JWT 인증 통합 테스트 포함)
- [x] `./scripts/test/docker-build.sh`
- [x] `PointSummaryIntegrationTests`: 잔액/누적 적립 합계, 빈 내역, 만료 예정 오름차순·미래만 필터링, 다른 회원 데이터 격리, 미인증 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBTGn2St8gKX2BFb1iv4rG