### PR TITLE
feat: UC-09 사진 인증 업로드와 제출

### DIFF
--- a/src/main/java/com/buyeoon/common/api/ErrorResponse.java
+++ b/src/main/java/com/buyeoon/common/api/ErrorResponse.java
@@ -62,6 +62,10 @@ public record ErrorResponse(boolean success, ErrorData data) {
 		return new ErrorResponse(false, new ErrorData("LOCATION_VERIFICATION_FAILED", "위치 인증에 실패했습니다."));
 	}
 
+	public static ErrorResponse payloadTooLarge() {
+		return new ErrorResponse(false, new ErrorData("PAYLOAD_TOO_LARGE", "서버에 설정된 최대 업로드 크기를 초과했습니다."));
+	}
+
 	public record ErrorData(String code, String message) {
 	}
 }

--- a/src/main/java/com/buyeoon/common/storage/MissionPhotoObjectStore.java
+++ b/src/main/java/com/buyeoon/common/storage/MissionPhotoObjectStore.java
@@ -1,0 +1,22 @@
+package com.buyeoon.common.storage;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * 사진 인증 미션에서 실제로 업로드된 S3 객체의 실체를 확인하는 seam이다. 테스트는 실제 AWS 호출 없이 이 인터페이스를 대체해
+ * 소유자·크기·Content-Type의 일치·불일치와 존재하지 않는 객체를 조합해 검증한다.
+ */
+public interface MissionPhotoObjectStore {
+
+	Optional<MissionPhotoObject> head(String objectKey);
+
+	/**
+	 * {@code contentType}·{@code fileSizeBytes}는 실제 업로드된 객체의 값이고,
+	 * {@code declaredContentType}·{@code declaredFileSizeBytes}는 Presigned URL 발급
+	 * 요청에서 서명된 메타데이터로 남긴 값이다.
+	 */
+	record MissionPhotoObject(UUID ownerId, String contentType, long fileSizeBytes, String declaredContentType,
+			long declaredFileSizeBytes) {
+	}
+}

--- a/src/main/java/com/buyeoon/common/storage/MissionPhotoUploadPresigner.java
+++ b/src/main/java/com/buyeoon/common/storage/MissionPhotoUploadPresigner.java
@@ -1,0 +1,20 @@
+package com.buyeoon.common.storage;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 사진 인증 미션의 S3 Presigned PUT URL 발급 seam이다. 테스트는 실제 AWS 호출 없이 이 인터페이스를 대체한다.
+ */
+public interface MissionPhotoUploadPresigner {
+
+	MissionPhotoUploadTarget presign(String objectKey, UUID memberId, String contentType, long fileSizeBytes);
+
+	record MissionPhotoUploadTarget(String uploadUrl, Map<String, String> headers, Instant expiresAt) {
+
+		public MissionPhotoUploadTarget {
+			headers = Map.copyOf(headers);
+		}
+	}
+}

--- a/src/main/java/com/buyeoon/common/storage/S3MissionPhotoObjectStore.java
+++ b/src/main/java/com/buyeoon/common/storage/S3MissionPhotoObjectStore.java
@@ -1,0 +1,61 @@
+package com.buyeoon.common.storage;
+
+import jakarta.annotation.PreDestroy;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+@Service
+public class S3MissionPhotoObjectStore implements MissionPhotoObjectStore {
+
+	private static final String OWNER_METADATA_KEY = "member-id";
+	private static final String DECLARED_FILE_SIZE_METADATA_KEY = "declared-file-size-bytes";
+	private static final String DECLARED_CONTENT_TYPE_METADATA_KEY = "declared-content-type";
+
+	private final String bucket;
+	private final S3Client s3Client;
+
+	public S3MissionPhotoObjectStore(@Value("${storage.images.bucket:}") String bucket,
+			@Value("${storage.images.region:ap-northeast-2}") String region) {
+		this.bucket = bucket;
+		this.s3Client = S3Client.builder().region(Region.of(region)).build();
+	}
+
+	@Override
+	public Optional<MissionPhotoObject> head(String objectKey) {
+		if (bucket.isBlank()) {
+			throw new IllegalStateException("IMAGE_BUCKET 설정이 필요합니다.");
+		}
+		try {
+			HeadObjectResponse response = s3Client
+					.headObject(HeadObjectRequest.builder().bucket(bucket).key(objectKey).build());
+			Map<String, String> metadata = response.metadata();
+			String ownerId = metadata.get(OWNER_METADATA_KEY);
+			String declaredContentType = metadata.get(DECLARED_CONTENT_TYPE_METADATA_KEY);
+			String declaredFileSizeBytes = metadata.get(DECLARED_FILE_SIZE_METADATA_KEY);
+			if (ownerId == null || declaredFileSizeBytes == null) {
+				// 발급 경로를 거치지 않아 서명된 메타데이터가 없는 객체다. 존재하지 않는 것과 동일하게 취급한다.
+				return Optional.empty();
+			}
+			return Optional.of(new MissionPhotoObject(UUID.fromString(ownerId), response.contentType(),
+					response.contentLength(), declaredContentType, Long.parseLong(declaredFileSizeBytes)));
+		} catch (NoSuchKeyException exception) {
+			return Optional.empty();
+		} catch (IllegalArgumentException exception) {
+			// 손상된 메타데이터(UUID·숫자 형식 오류)다. 존재하지 않는 것과 동일하게 취급한다.
+			return Optional.empty();
+		}
+	}
+
+	@PreDestroy
+	void close() {
+		s3Client.close();
+	}
+}

--- a/src/main/java/com/buyeoon/common/storage/S3MissionPhotoUploadPresigner.java
+++ b/src/main/java/com/buyeoon/common/storage/S3MissionPhotoUploadPresigner.java
@@ -1,0 +1,60 @@
+package com.buyeoon.common.storage;
+
+import jakarta.annotation.PreDestroy;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Service
+public class S3MissionPhotoUploadPresigner implements MissionPhotoUploadPresigner {
+
+	private static final Duration VALIDITY = Duration.ofMinutes(10);
+	private static final String OWNER_METADATA_KEY = "member-id";
+	private static final String DECLARED_FILE_SIZE_METADATA_KEY = "declared-file-size-bytes";
+	private static final String DECLARED_CONTENT_TYPE_METADATA_KEY = "declared-content-type";
+
+	private final String bucket;
+	private final S3Presigner presigner;
+
+	public S3MissionPhotoUploadPresigner(@Value("${storage.images.bucket:}") String bucket,
+			@Value("${storage.images.region:ap-northeast-2}") String region) {
+		this.bucket = bucket;
+		this.presigner = S3Presigner.builder().region(Region.of(region)).build();
+	}
+
+	@Override
+	public MissionPhotoUploadTarget presign(String objectKey, UUID memberId, String contentType, long fileSizeBytes) {
+		if (bucket.isBlank()) {
+			throw new IllegalStateException("IMAGE_BUCKET 설정이 필요합니다.");
+		}
+		if (!objectKey.startsWith("private/")) {
+			throw new IllegalArgumentException("비공개 이미지 객체 키가 아닙니다.");
+		}
+		Map<String, String> metadata = new LinkedHashMap<>();
+		metadata.put(OWNER_METADATA_KEY, memberId.toString());
+		metadata.put(DECLARED_FILE_SIZE_METADATA_KEY, Long.toString(fileSizeBytes));
+		metadata.put(DECLARED_CONTENT_TYPE_METADATA_KEY, contentType);
+		PutObjectRequest putObjectRequest = PutObjectRequest.builder().bucket(bucket).key(objectKey)
+				.contentType(contentType).metadata(metadata).build();
+		var presigned = presigner.presignPutObject(PutObjectPresignRequest.builder().signatureDuration(VALIDITY)
+				.putObjectRequest(putObjectRequest).build());
+
+		Map<String, String> headers = new LinkedHashMap<>();
+		headers.put("Content-Type", contentType);
+		metadata.forEach((key, value) -> headers.put("x-amz-meta-" + key, value));
+		return new MissionPhotoUploadTarget(presigned.url().toExternalForm(), headers, Instant.now().plus(VALIDITY));
+	}
+
+	@PreDestroy
+	void close() {
+		presigner.close();
+	}
+}

--- a/src/main/java/com/buyeoon/mission/api/MissionController.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionController.java
@@ -1,6 +1,9 @@
 package com.buyeoon.mission.api;
 
 import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.mission.application.MissionPhotoUploadUrlService;
+import com.buyeoon.mission.application.MissionPhotoUploadUrlService.MissionPhotoUploadUrlCommand;
+import com.buyeoon.mission.application.MissionPhotoUploadUrlService.MissionPhotoUploadUrlView;
 import com.buyeoon.mission.application.MissionQueryService;
 import com.buyeoon.mission.application.MissionQueryService.MissionListView;
 import com.buyeoon.mission.application.MissionSubmissionService;
@@ -14,6 +17,8 @@ import java.time.format.DateTimeParseException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,14 +33,18 @@ import tools.jackson.databind.JsonNode;
 @RestController
 public class MissionController {
 
+	private static final Set<String> ALLOWED_PHOTO_CONTENT_TYPES = Set.of("image/jpeg", "image/png", "image/webp");
+
 	private final MissionQueryService missionQueryService;
 	private final MissionSubmissionService missionSubmissionService;
+	private final MissionPhotoUploadUrlService missionPhotoUploadUrlService;
 
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
-	public MissionController(MissionQueryService missionQueryService,
-			MissionSubmissionService missionSubmissionService) {
+	public MissionController(MissionQueryService missionQueryService, MissionSubmissionService missionSubmissionService,
+			MissionPhotoUploadUrlService missionPhotoUploadUrlService) {
 		this.missionQueryService = missionQueryService;
 		this.missionSubmissionService = missionSubmissionService;
+		this.missionPhotoUploadUrlService = missionPhotoUploadUrlService;
 	}
 
 	@GetMapping("/missions/nearby")
@@ -64,22 +73,77 @@ public class MissionController {
 		return SuccessResponse.of(missionSubmissionService.submit(memberId, missionId, idempotencyKey, command));
 	}
 
+	@PostMapping("/mission-photos/presigned-url")
+	public ResponseEntity<SuccessResponse<MissionPhotoUploadUrlView>> createMissionPhotoUploadUrl(
+			@AuthenticationPrincipal Jwt jwt,
+			@RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey,
+			@RequestBody JsonNode request) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		MissionPhotoUploadUrlCommand command = parsePhotoUploadUrlRequest(request);
+		MissionPhotoUploadUrlView view = missionPhotoUploadUrlService.createUploadUrl(memberId, idempotencyKey,
+				command);
+		return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.of(view));
+	}
+
+	private MissionPhotoUploadUrlCommand parsePhotoUploadUrlRequest(JsonNode request) {
+		Set<String> fields = Set.of("tripId", "missionId", "fileName", "contentType", "fileSizeBytes");
+		if (request == null || !request.isObject() || !hasOnlyProperties(request, fields)) {
+			throw new InvalidMissionRequestException();
+		}
+		UUID tripId = uuid(request.get("tripId"));
+		UUID missionId = uuid(request.get("missionId"));
+		String fileName = fileName(request.get("fileName"));
+		String contentType = photoContentType(request.get("contentType"));
+		long fileSizeBytes = fileSizeBytes(request.get("fileSizeBytes"));
+		return new MissionPhotoUploadUrlCommand(tripId, missionId, fileName, contentType, fileSizeBytes);
+	}
+
+	private String fileName(JsonNode node) {
+		String value = text(node);
+		if (value.isEmpty() || value.length() > 255) {
+			throw new InvalidMissionRequestException();
+		}
+		return value;
+	}
+
+	private String photoContentType(JsonNode node) {
+		String value = text(node);
+		if (!ALLOWED_PHOTO_CONTENT_TYPES.contains(value)) {
+			throw new InvalidMissionRequestException();
+		}
+		return value;
+	}
+
+	private long fileSizeBytes(JsonNode node) {
+		if (node == null || !node.isNumber()) {
+			throw new InvalidMissionRequestException();
+		}
+		long value = node.longValue();
+		if (value < 1) {
+			throw new InvalidMissionRequestException();
+		}
+		return value;
+	}
+
 	private MissionSubmissionCommand parseSubmission(JsonNode request) {
 		if (request == null || !request.isObject()) {
 			throw new InvalidMissionRequestException();
 		}
 		MissionType type = missionType(request.get("type"));
-		Set<String> fields = type == MissionType.MULTIPLE_CHOICE
-				? Set.of("tripId", "type", "choiceId", "location")
-				: Set.of("tripId", "type", "oxAnswer", "location");
+		Set<String> fields = switch (type) {
+			case MULTIPLE_CHOICE -> Set.of("tripId", "type", "choiceId", "location");
+			case OX -> Set.of("tripId", "type", "oxAnswer", "location");
+			case PHOTO -> Set.of("tripId", "type", "photoId", "location");
+		};
 		if (!hasOnlyProperties(request, fields)) {
 			throw new InvalidMissionRequestException();
 		}
 		UUID tripId = uuid(request.get("tripId"));
 		String choiceId = type == MissionType.MULTIPLE_CHOICE ? text(request.get("choiceId")) : null;
 		Boolean oxAnswer = type == MissionType.OX ? bool(request.get("oxAnswer")) : null;
+		UUID photoId = type == MissionType.PHOTO ? uuid(request.get("photoId")) : null;
 		LocationCommand location = location(request.get("location"));
-		return new MissionSubmissionCommand(tripId, type, choiceId, oxAnswer, location);
+		return new MissionSubmissionCommand(tripId, type, choiceId, oxAnswer, photoId, location);
 	}
 
 	private MissionType missionType(JsonNode node) {
@@ -89,6 +153,7 @@ public class MissionController {
 		return switch (node.stringValue()) {
 			case "MULTIPLE_CHOICE" -> MissionType.MULTIPLE_CHOICE;
 			case "OX" -> MissionType.OX;
+			case "PHOTO" -> MissionType.PHOTO;
 			default -> throw new InvalidMissionRequestException();
 		};
 	}

--- a/src/main/java/com/buyeoon/mission/api/MissionExceptionHandler.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionExceptionHandler.java
@@ -5,6 +5,8 @@ import com.buyeoon.member.application.IdempotencyKeyReusedException;
 import com.buyeoon.member.application.InvalidStateTransitionException;
 import com.buyeoon.mission.application.InvalidMissionSubmissionException;
 import com.buyeoon.mission.application.MissionNotFoundException;
+import com.buyeoon.mission.application.MissionPhotoNotFoundException;
+import com.buyeoon.mission.application.MissionPhotoTooLargeException;
 import com.buyeoon.mission.application.OutsideParticipationRadiusException;
 import com.buyeoon.mission.application.TripNotFoundException;
 import com.buyeoon.mission.application.TripNotInProgressException;
@@ -27,10 +29,17 @@ public class MissionExceptionHandler {
 		return ErrorResponse.invalidRequest();
 	}
 
-	@ExceptionHandler({TripNotFoundException.class, MissionNotFoundException.class})
+	@ExceptionHandler({TripNotFoundException.class, MissionNotFoundException.class,
+			MissionPhotoNotFoundException.class})
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	public ErrorResponse handleResourceNotFound() {
 		return ErrorResponse.resourceNotFound();
+	}
+
+	@ExceptionHandler(MissionPhotoTooLargeException.class)
+	@ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+	public ErrorResponse handlePayloadTooLarge() {
+		return ErrorResponse.payloadTooLarge();
 	}
 
 	@ExceptionHandler(OutsideParticipationRadiusException.class)

--- a/src/main/java/com/buyeoon/mission/application/MissionPhotoNotFoundException.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionPhotoNotFoundException.java
@@ -1,0 +1,8 @@
+package com.buyeoon.mission.application;
+
+public class MissionPhotoNotFoundException extends RuntimeException {
+
+	public MissionPhotoNotFoundException() {
+		super("존재하지 않거나 본인이 발급받지 않은 사진입니다.");
+	}
+}

--- a/src/main/java/com/buyeoon/mission/application/MissionPhotoObjectKeys.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionPhotoObjectKeys.java
@@ -1,0 +1,14 @@
+package com.buyeoon.mission.application;
+
+import java.util.UUID;
+
+/** 발급 시점과 제출 시점이 같은 S3 객체 키를 유도할 수 있도록 계산 규칙을 한 곳에 둔다. */
+final class MissionPhotoObjectKeys {
+
+	private MissionPhotoObjectKeys() {
+	}
+
+	static String key(UUID tripId, UUID missionId, UUID photoId) {
+		return "private/missions/" + tripId + "/" + missionId + "/" + photoId;
+	}
+}

--- a/src/main/java/com/buyeoon/mission/application/MissionPhotoTooLargeException.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionPhotoTooLargeException.java
@@ -1,0 +1,8 @@
+package com.buyeoon.mission.application;
+
+public class MissionPhotoTooLargeException extends RuntimeException {
+
+	public MissionPhotoTooLargeException() {
+		super("서버에 설정된 최대 업로드 크기를 초과했습니다.");
+	}
+}

--- a/src/main/java/com/buyeoon/mission/application/MissionPhotoUploadUrlService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionPhotoUploadUrlService.java
@@ -1,0 +1,221 @@
+package com.buyeoon.mission.application;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.common.entity.IdempotencyRequestEntity;
+import com.buyeoon.common.entity.IdempotencyRequestId;
+import com.buyeoon.common.storage.MissionPhotoUploadPresigner;
+import com.buyeoon.common.storage.MissionPhotoUploadPresigner.MissionPhotoUploadTarget;
+import com.buyeoon.member.application.IdempotencyKeyReusedException;
+import com.buyeoon.mission.entity.MissionEntity;
+import com.buyeoon.mission.entity.MissionType;
+import com.buyeoon.mission.repository.MissionIdempotencyRequestRepository;
+import com.buyeoon.mission.repository.MissionQueryRepository;
+import com.buyeoon.trip.TripQueryService;
+import com.buyeoon.trip.entity.TripStatus;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.ObjectWriter;
+
+/** UC-09 사진 인증 업로드용 Presigned URL 발급 커맨드 서비스다. */
+@Service
+public class MissionPhotoUploadUrlService {
+
+	private static final String OPERATION = "CREATE_MISSION_PHOTO_UPLOAD_URL";
+	private static final Duration RETENTION = Duration.ofHours(24);
+	private static final int SUCCESS_STATUS = 201;
+
+	private final JdbcOperations jdbcOperations;
+	private final TransactionTemplate transactions;
+	private final TripQueryService tripQueryService;
+	private final MissionQueryRepository missionQueryRepository;
+	private final MissionIdempotencyRequestRepository idempotencyRequests;
+	private final MissionPhotoUploadPresigner presigner;
+	private final long maxFileSizeBytes;
+	private final ObjectReader objectReader;
+	private final ObjectWriter objectWriter;
+
+	public MissionPhotoUploadUrlService(JdbcOperations jdbcOperations, PlatformTransactionManager transactionManager,
+			TripQueryService tripQueryService, MissionQueryRepository missionQueryRepository,
+			MissionIdempotencyRequestRepository idempotencyRequests, MissionPhotoUploadPresigner presigner,
+			@Value("${storage.images.max-upload-bytes:10485760}") long maxFileSizeBytes, ObjectMapper objectMapper) {
+		this.jdbcOperations = jdbcOperations;
+		this.transactions = new TransactionTemplate(transactionManager);
+		this.tripQueryService = tripQueryService;
+		this.missionQueryRepository = missionQueryRepository;
+		this.idempotencyRequests = idempotencyRequests;
+		this.presigner = presigner;
+		this.maxFileSizeBytes = maxFileSizeBytes;
+		this.objectReader = objectMapper.reader();
+		this.objectWriter = objectMapper.writer();
+	}
+
+	public MissionPhotoUploadUrlView createUploadUrl(UUID memberId, String idempotencyKey,
+			MissionPhotoUploadUrlCommand command) {
+		validateIdempotencyKey(idempotencyKey);
+		String requestHash = hash(command);
+		return Objects.requireNonNull(
+				transactions.execute(status -> createInTransaction(memberId, idempotencyKey, requestHash, command)),
+				"사진 업로드 URL 발급 트랜잭션 결과가 없습니다.");
+	}
+
+	private MissionPhotoUploadUrlView createInTransaction(UUID memberId, String idempotencyKey, String requestHash,
+			MissionPhotoUploadUrlCommand command) {
+		TripStatus tripStatus = tripQueryService.findOwnedTripStatus(memberId, command.tripId())
+				.orElseThrow(TripNotFoundException::new);
+		if (tripStatus != TripStatus.IN_PROGRESS) {
+			throw new TripNotInProgressException();
+		}
+
+		MissionEntity mission = missionQueryRepository.findById(command.missionId())
+				.orElseThrow(MissionNotFoundException::new);
+		if (mission.getType() != MissionType.PHOTO) {
+			throw new InvalidMissionSubmissionException();
+		}
+
+		Instant occurredAt = clockTimestamp();
+		IdempotencyRequestId idempotencyId = new IdempotencyRequestId(memberId, idempotencyKey);
+		Optional<IdempotencyRequestEntity> existingRequest = idempotencyRequests.findById(idempotencyId);
+		if (existingRequest.isPresent()) {
+			IdempotencyRequestEntity request = existingRequest.get();
+			if (!request.getExpiresAt().isAfter(occurredAt)) {
+				idempotencyRequests.delete(request);
+			} else {
+				return replay(request, requestHash);
+			}
+		}
+
+		if (command.fileSizeBytes() > maxFileSizeBytes) {
+			throw new MissionPhotoTooLargeException();
+		}
+
+		UUID photoId = UUID.randomUUID();
+		String objectKey = MissionPhotoObjectKeys.key(command.tripId(), command.missionId(), photoId);
+		MissionPhotoUploadTarget target = presigner.presign(objectKey, memberId, command.contentType(),
+				command.fileSizeBytes());
+
+		MissionPhotoUploadUrlView result = new MissionPhotoUploadUrlView(photoId, target.uploadUrl(), "PUT",
+				target.headers(), 200, target.expiresAt());
+
+		String responseBody = writeResponse(result);
+		IdempotencyRequestEntity idempotencyRequest = IdempotencyRequestEntity.create(memberId, idempotencyKey,
+				OPERATION, requestHash, occurredAt.plus(RETENTION));
+		idempotencyRequest.complete(SUCCESS_STATUS, responseBody);
+		idempotencyRequests.save(idempotencyRequest);
+		return result;
+	}
+
+	private MissionPhotoUploadUrlView replay(IdempotencyRequestEntity request, String requestHash) {
+		if (!OPERATION.equals(request.getOperation()) || !requestHash.equals(request.getRequestHash())) {
+			throw new IdempotencyKeyReusedException();
+		}
+		if (!Integer.valueOf(SUCCESS_STATUS).equals(request.getResponseStatus()) || request.getResponseBody() == null) {
+			throw new IllegalStateException("완료되지 않은 멱등성 요청이 남아 있습니다.");
+		}
+		return readResponse(request.getResponseBody());
+	}
+
+	private Instant clockTimestamp() {
+		return Objects.requireNonNull(jdbcOperations.queryForObject("SELECT clock_timestamp()", Timestamp.class))
+				.toInstant();
+	}
+
+	private void validateIdempotencyKey(String idempotencyKey) {
+		if (idempotencyKey == null || idempotencyKey.length() < 8 || idempotencyKey.length() > 128) {
+			throw new InvalidMissionSubmissionException();
+		}
+	}
+
+	private String hash(MissionPhotoUploadUrlCommand command) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			update(digest, command.tripId().toString());
+			update(digest, command.missionId().toString());
+			update(digest, command.fileName());
+			update(digest, command.contentType());
+			update(digest, Long.toString(command.fileSizeBytes()));
+			return HexFormat.of().formatHex(digest.digest());
+		} catch (NoSuchAlgorithmException exception) {
+			throw new IllegalStateException("SHA-256을 사용할 수 없습니다.", exception);
+		}
+	}
+
+	private void update(MessageDigest digest, String value) {
+		byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+		digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+		digest.update(bytes);
+	}
+
+	private String writeResponse(MissionPhotoUploadUrlView result) {
+		try {
+			return objectWriter.writeValueAsString(SuccessResponse.of(result));
+		} catch (JacksonException exception) {
+			throw new IllegalStateException("사진 업로드 URL 발급 응답을 저장할 수 없습니다.", exception);
+		}
+	}
+
+	private MissionPhotoUploadUrlView readResponse(String responseBody) {
+		try {
+			JsonNode data = required(objectReader.readTree(responseBody), "data");
+			Map<String, String> headers = new LinkedHashMap<>();
+			required(data, "headers").properties()
+					.forEach(property -> headers.put(property.getKey(), property.getValue().stringValue()));
+			return new MissionPhotoUploadUrlView(UUID.fromString(requiredText(data, "photoId")),
+					requiredText(data, "uploadUrl"), requiredText(data, "method"), headers,
+					requiredInt(data, "successStatus"), Instant.parse(requiredText(data, "expiresAt")));
+		} catch (JacksonException | IllegalArgumentException exception) {
+			throw new IllegalStateException("저장된 사진 업로드 URL 발급 응답을 읽을 수 없습니다.", exception);
+		}
+	}
+
+	private JsonNode required(JsonNode node, String field) {
+		JsonNode value = node == null ? null : node.get(field);
+		if (value == null) {
+			throw new IllegalStateException("저장된 사진 업로드 URL 발급 응답 필드가 누락되었습니다: " + field);
+		}
+		return value;
+	}
+
+	private String requiredText(JsonNode node, String field) {
+		JsonNode value = required(node, field);
+		if (!value.isString()) {
+			throw new IllegalStateException("저장된 사진 업로드 URL 발급 응답 필드가 문자열이 아닙니다: " + field);
+		}
+		return value.stringValue();
+	}
+
+	private int requiredInt(JsonNode node, String field) {
+		return required(node, field).intValue();
+	}
+
+	public record MissionPhotoUploadUrlCommand(UUID tripId, UUID missionId, String fileName, String contentType,
+			long fileSizeBytes) {
+	}
+
+	public record MissionPhotoUploadUrlView(UUID photoId, String uploadUrl, String method, Map<String, String> headers,
+			int successStatus, Instant expiresAt) {
+
+		public MissionPhotoUploadUrlView {
+			headers = Map.copyOf(headers);
+		}
+	}
+}

--- a/src/main/java/com/buyeoon/mission/application/MissionSubmissionService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionSubmissionService.java
@@ -3,17 +3,21 @@ package com.buyeoon.mission.application;
 import com.buyeoon.common.api.SuccessResponse;
 import com.buyeoon.common.entity.IdempotencyRequestEntity;
 import com.buyeoon.common.entity.IdempotencyRequestId;
+import com.buyeoon.common.storage.MissionPhotoObjectStore;
+import com.buyeoon.common.storage.MissionPhotoObjectStore.MissionPhotoObject;
 import com.buyeoon.member.application.IdempotencyKeyReusedException;
 import com.buyeoon.member.application.InvalidStateTransitionException;
 import com.buyeoon.mission.entity.MissionChoiceEntity;
 import com.buyeoon.mission.entity.MissionEntity;
 import com.buyeoon.mission.entity.MissionParticipationEntity;
+import com.buyeoon.mission.entity.MissionPhotoEntity;
 import com.buyeoon.mission.entity.MissionStatus;
 import com.buyeoon.mission.entity.MissionSubmissionEntity;
 import com.buyeoon.mission.entity.MissionType;
 import com.buyeoon.mission.repository.MissionChoiceRepository;
 import com.buyeoon.mission.repository.MissionIdempotencyRequestRepository;
 import com.buyeoon.mission.repository.MissionParticipationRepository;
+import com.buyeoon.mission.repository.MissionPhotoRepository;
 import com.buyeoon.mission.repository.MissionPlaceDistanceProjection;
 import com.buyeoon.mission.repository.MissionQueryRepository;
 import com.buyeoon.mission.repository.MissionSubmissionRepository;
@@ -35,6 +39,7 @@ import java.time.OffsetDateTime;
 import java.util.HexFormat;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcOperations;
@@ -54,6 +59,7 @@ public class MissionSubmissionService {
 	private static final String OPERATION = "SUBMIT_MISSION";
 	private static final Duration RETENTION = Duration.ofHours(24);
 	private static final int PARTICIPATION_RADIUS_METERS = 100;
+	private static final Set<String> ALLOWED_PHOTO_CONTENT_TYPES = Set.of("image/jpeg", "image/png", "image/webp");
 
 	private final JdbcOperations jdbcOperations;
 	private final TransactionTemplate transactions;
@@ -62,6 +68,8 @@ public class MissionSubmissionService {
 	private final MissionChoiceRepository missionChoiceRepository;
 	private final MissionParticipationRepository missionParticipations;
 	private final MissionSubmissionRepository missionSubmissions;
+	private final MissionPhotoRepository missionPhotos;
+	private final MissionPhotoObjectStore missionPhotoObjectStore;
 	private final MissionIdempotencyRequestRepository idempotencyRequests;
 	private final VisitRecordService visitRecordService;
 	private final PointRewardService pointRewardService;
@@ -73,7 +81,8 @@ public class MissionSubmissionService {
 	public MissionSubmissionService(JdbcOperations jdbcOperations, PlatformTransactionManager transactionManager,
 			TripQueryService tripQueryService, MissionQueryRepository missionQueryRepository,
 			MissionChoiceRepository missionChoiceRepository, MissionParticipationRepository missionParticipations,
-			MissionSubmissionRepository missionSubmissions, MissionIdempotencyRequestRepository idempotencyRequests,
+			MissionSubmissionRepository missionSubmissions, MissionPhotoRepository missionPhotos,
+			MissionPhotoObjectStore missionPhotoObjectStore, MissionIdempotencyRequestRepository idempotencyRequests,
 			VisitRecordService visitRecordService, PointRewardService pointRewardService,
 			ApplicationEventPublisher events, ObjectMapper objectMapper) {
 		this.jdbcOperations = jdbcOperations;
@@ -83,6 +92,8 @@ public class MissionSubmissionService {
 		this.missionChoiceRepository = missionChoiceRepository;
 		this.missionParticipations = missionParticipations;
 		this.missionSubmissions = missionSubmissions;
+		this.missionPhotos = missionPhotos;
+		this.missionPhotoObjectStore = missionPhotoObjectStore;
 		this.idempotencyRequests = idempotencyRequests;
 		this.visitRecordService = visitRecordService;
 		this.pointRewardService = pointRewardService;
@@ -141,9 +152,12 @@ public class MissionSubmissionService {
 			throw new OutsideParticipationRadiusException();
 		}
 
+		UUID photoRecordId = command.type() == MissionType.PHOTO
+				? verifyAndRecordPhoto(memberId, command.tripId(), missionId, command.photoId())
+				: null;
 		boolean correct = determineCorrectness(command, mission, missionId);
 		participation.recordAttempt(correct, mission.getMaxAttempts(), occurredAt);
-		missionSubmissions.save(toSubmissionEntity(participation.getId(), command, correct));
+		missionSubmissions.save(toSubmissionEntity(participation.getId(), command, correct, photoRecordId));
 
 		int rewardPoints = 0;
 		long pointBalance = pointRewardService.currentBalance(memberId);
@@ -181,8 +195,29 @@ public class MissionSubmissionService {
 		return switch (command.type()) {
 			case MULTIPLE_CHOICE -> isCorrectChoice(missionId, command.choiceId());
 			case OX -> command.oxAnswer() != null && command.oxAnswer().equals(mission.getOxCorrectAnswer());
-			case PHOTO -> throw new InvalidMissionSubmissionException();
+			case PHOTO -> true;
 		};
+	}
+
+	/** 발급 요청 정보(소유자·크기·Content-Type)와 실제 업로드된 S3 객체를 대조하고, 통과하면 사진 기록을 생성한다. */
+	private UUID verifyAndRecordPhoto(UUID memberId, UUID tripId, UUID missionId, UUID photoId) {
+		if (photoId == null) {
+			throw new InvalidMissionSubmissionException();
+		}
+		String objectKey = MissionPhotoObjectKeys.key(tripId, missionId, photoId);
+		MissionPhotoObject object = missionPhotoObjectStore.head(objectKey)
+				.orElseThrow(MissionPhotoNotFoundException::new);
+		if (!object.ownerId().equals(memberId)) {
+			throw new MissionPhotoNotFoundException();
+		}
+		if (object.fileSizeBytes() != object.declaredFileSizeBytes()
+				|| !object.contentType().equals(object.declaredContentType())
+				|| !ALLOWED_PHOTO_CONTENT_TYPES.contains(object.contentType())) {
+			throw new InvalidMissionSubmissionException();
+		}
+		MissionPhotoEntity photo = missionPhotos.save(MissionPhotoEntity.create(memberId, tripId, missionId, objectKey,
+				object.contentType(), object.fileSizeBytes()));
+		return photo.getId();
 	}
 
 	private boolean isCorrectChoice(UUID missionId, String choiceId) {
@@ -202,12 +237,12 @@ public class MissionSubmissionService {
 	}
 
 	private MissionSubmissionEntity toSubmissionEntity(UUID participationId, MissionSubmissionCommand command,
-			boolean correct) {
+			boolean correct, UUID photoRecordId) {
 		return switch (command.type()) {
 			case MULTIPLE_CHOICE ->
 				MissionSubmissionEntity.multipleChoice(participationId, parseChoiceId(command.choiceId()), correct);
 			case OX -> MissionSubmissionEntity.ox(participationId, command.oxAnswer(), correct);
-			case PHOTO -> throw new InvalidMissionSubmissionException();
+			case PHOTO -> MissionSubmissionEntity.photo(participationId, photoRecordId);
 		};
 	}
 
@@ -247,6 +282,7 @@ public class MissionSubmissionService {
 			update(digest, command.type().name());
 			update(digest, command.choiceId() == null ? "null" : command.choiceId());
 			update(digest, command.oxAnswer() == null ? "null" : command.oxAnswer().toString());
+			update(digest, command.photoId() == null ? "null" : command.photoId().toString());
 			update(digest, Double.toHexString(command.location().latitude()));
 			update(digest, Double.toHexString(command.location().longitude()));
 			update(digest,
@@ -325,7 +361,7 @@ public class MissionSubmissionService {
 	}
 
 	public record MissionSubmissionCommand(UUID tripId, MissionType type, String choiceId, Boolean oxAnswer,
-			LocationCommand location) {
+			UUID photoId, LocationCommand location) {
 	}
 
 	public record LocationCommand(double latitude, double longitude, Double accuracyMeters, OffsetDateTime capturedAt) {

--- a/src/main/java/com/buyeoon/mission/repository/MissionPhotoRepository.java
+++ b/src/main/java/com/buyeoon/mission/repository/MissionPhotoRepository.java
@@ -1,0 +1,8 @@
+package com.buyeoon.mission.repository;
+
+import com.buyeoon.mission.entity.MissionPhotoEntity;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionPhotoRepository extends JpaRepository<MissionPhotoEntity, UUID> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,6 +30,7 @@ social.apple.read-timeout=${APPLE_READ_TIMEOUT:3s}
 
 storage.images.bucket=${IMAGE_BUCKET:}
 storage.images.region=${AWS_REGION:ap-northeast-2}
+storage.images.max-upload-bytes=${MISSION_PHOTO_MAX_UPLOAD_BYTES:10485760}
 location.buyeo-boundary=${BUYEO_BOUNDARY:classpath:boundaries/buyeo-44760.geojson}
 
 member.purge.batch-size=${MEMBER_PURGE_BATCH_SIZE:100}

--- a/src/test/java/com/buyeoon/mission/MissionPhotoSubmissionIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionPhotoSubmissionIntegrationTests.java
@@ -1,0 +1,500 @@
+package com.buyeoon.mission;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.common.storage.MissionPhotoObjectStore;
+import com.buyeoon.common.storage.MissionPhotoObjectStore.MissionPhotoObject;
+import com.buyeoon.common.storage.MissionPhotoUploadPresigner;
+import com.buyeoon.common.storage.MissionPhotoUploadPresigner.MissionPhotoUploadTarget;
+import com.buyeoon.member.auth.AccessTokenService;
+import com.buyeoon.mission.application.MissionCompleted;
+import com.buyeoon.trip.VisitRecorded;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/** UC-09 사진 인증 업로드 URL 발급과 사진 제출을 검증한다. S3 연동은 테스트 대역으로 대체한다. */
+@SpringBootTest(properties = "storage.images.max-upload-bytes=1000000")
+@AutoConfigureMockMvc
+@RecordApplicationEvents
+@Testcontainers
+class MissionPhotoSubmissionIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	// 시드 마이그레이션이 부여 지역에 장소·미션 예시 데이터를 채워두므로, 격리를 위해 남극 인근 좌표를
+	// 기준으로 테스트 데이터를 배치한다.
+	private static final double ORIGIN_LATITUDE = -75.0;
+	private static final double ORIGIN_LONGITUDE = 0.0;
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@Autowired
+	private ApplicationEvents applicationEvents;
+
+	@MockitoBean
+	private MissionPhotoUploadPresigner photoUploadPresigner;
+
+	@MockitoBean
+	private MissionPhotoObjectStore photoObjectStore;
+
+	private AuthenticatedMember member;
+
+	@BeforeEach
+	void setUpMember() {
+		member = insertAuthenticatedMember();
+		when(photoUploadPresigner.presign(anyString(), any(), anyString(), anyLong()))
+				.thenReturn(new MissionPhotoUploadTarget("https://example-bucket.s3.amazonaws.com/upload",
+						Map.of("Content-Type", "image/jpeg"), Instant.now().plusSeconds(600)));
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM idempotency_requests");
+		jdbcTemplate.update("DELETE FROM point_transactions");
+		jdbcTemplate.update("DELETE FROM visit_records");
+		jdbcTemplate.update("DELETE FROM mission_submissions");
+		jdbcTemplate.update("DELETE FROM mission_photos");
+		jdbcTemplate.update("DELETE FROM mission_participations");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update(
+				"DELETE FROM missions WHERE place_id IN (SELECT id FROM places WHERE ST_Y(location::geometry) < -70)");
+		jdbcTemplate.update("DELETE FROM places WHERE ST_Y(location::geometry) < -70");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/**
+	 * 소유 트립·PHOTO 유형 미션이면 photoId, uploadUrl, method, headers, successStatus,
+	 * expiresAt을 201로 받는다.
+	 */
+	@Test
+	@DisplayName("사진 미션 발급 요청은 201과 업로드 대상을 받고 mission_photos row를 만들지 않는다")
+	void issuesUploadUrlWithoutCreatingMissionPhotoRow() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+
+		mockMvc.perform(presignRequest(tripId, missionId, "issue-key")).andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true)).andExpect(jsonPath("$.data.photoId").isNotEmpty())
+				.andExpect(jsonPath("$.data.uploadUrl").value("https://example-bucket.s3.amazonaws.com/upload"))
+				.andExpect(jsonPath("$.data.method").value("PUT"))
+				.andExpect(jsonPath("$.data.headers.Content-Type").value("image/jpeg"))
+				.andExpect(jsonPath("$.data.successStatus").value(200))
+				.andExpect(jsonPath("$.data.expiresAt").isNotEmpty());
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM mission_photos", Integer.class)).isZero();
+	}
+
+	/** PHOTO가 아닌 미션에 대한 발급 요청은 400을 받는다. */
+	@Test
+	@DisplayName("PHOTO가 아닌 미션에 발급을 요청하면 400을 받는다")
+	void returns400WhenMissionIsNotPhotoType() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("OX 장소", 50);
+		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
+
+		mockMvc.perform(presignRequest(tripId, missionId, "not-photo-key")).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	/** 존재하지 않거나 본인 소유가 아닌 여행은 404를 받는다. */
+	@Test
+	@DisplayName("본인 소유가 아니거나 존재하지 않는 여행으로 발급을 요청하면 404를 받는다")
+	void returns404WhenTripIsNotOwnedOrMissing() throws Exception {
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+
+		mockMvc.perform(presignRequest(UUID.randomUUID(), missionId, "missing-trip-key"))
+				.andExpect(status().isNotFound()).andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 진행 중이 아닌 본인 여행은 409를 받는다. */
+	@Test
+	@DisplayName("진행 중이 아닌 본인 여행으로 발급을 요청하면 409를 받는다")
+	void returns409WhenOwnTripIsNotInProgress() throws Exception {
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+		UUID endedTripId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status, ended_at) VALUES (?, ?, 'ENDED', now())",
+				endedTripId, member.memberId());
+
+		mockMvc.perform(presignRequest(endedTripId, missionId, "ended-trip-key")).andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("TRIP_NOT_IN_PROGRESS"));
+	}
+
+	/** 서버에 설정된 최대 업로드 크기를 초과하면 413을 받는다. */
+	@Test
+	@DisplayName("설정된 최대 크기를 초과하면 413을 받는다")
+	void returns413WhenFileSizeExceedsConfiguredMax() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+
+		mockMvc.perform(presignRequestBody(tripId, missionId, "too-large-key",
+				fileSizeRequestJson(tripId, missionId, 2_000_000))).andExpect(status().isPayloadTooLarge())
+				.andExpect(jsonPath("$.data.code").value("PAYLOAD_TOO_LARGE"));
+	}
+
+	/** 같은 키와 같은 본문의 재요청은 최초 응답을 그대로 재사용한다. */
+	@Test
+	@DisplayName("발급 요청도 동일한 멱등성 키·본문 재요청은 최초 응답을 재사용한다")
+	void presignReplaysFirstResponseForSameIdempotentRequest() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+
+		String first = mockMvc.perform(presignRequest(tripId, missionId, "replay-key")).andExpect(status().isCreated())
+				.andReturn().getResponse().getContentAsString();
+		String retried = mockMvc.perform(presignRequest(tripId, missionId, "replay-key"))
+				.andExpect(status().isCreated()).andReturn().getResponse().getContentAsString();
+
+		assertThat(retried).isEqualTo(first);
+	}
+
+	/** 같은 키를 다른 본문에 재사용하면 409를 받는다. */
+	@Test
+	@DisplayName("발급 요청도 멱등성 키를 다른 본문에 재사용하면 409를 받는다")
+	void presignReusedKeyWithDifferentBodyConflicts() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID otherPlace = insertProjectedPlace("다른 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+		UUID otherMissionId = insertPhotoMission(otherPlace, "다른 사진 미션", 150);
+
+		mockMvc.perform(presignRequest(tripId, missionId, "conflict-key")).andExpect(status().isCreated());
+		mockMvc.perform(presignRequest(tripId, otherMissionId, "conflict-key")).andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("IDEMPOTENCY_KEY_REUSED"));
+	}
+
+	/** 인증되지 않은 발급 요청은 401을 받는다. */
+	@Test
+	@DisplayName("인증하지 않고 발급을 요청하면 401을 받는다")
+	void returns401WhenPresignRequestIsUnauthenticated() throws Exception {
+		mockMvc.perform(post("/mission-photos/presigned-url").header("Idempotency-Key", "unauth-key")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(fileSizeRequestJson(UUID.randomUUID(), UUID.randomUUID(), 100)))
+				.andExpect(status().isUnauthorized()).andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** 소유자·크기·Content-Type이 모두 일치하는 사진 제출은 판정 없이 완료 처리되고 보상·방문 기록을 받는다. */
+	@Test
+	@DisplayName("검증에 성공한 사진 제출은 완료 처리되고 보상·방문 기록을 받는다")
+	void verifiedPhotoSubmissionCompletesMissionAndGrantsRewardAndVisit() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+		UUID photoId = UUID.randomUUID();
+		stubMatchingPhoto(tripId, missionId, photoId, member.memberId(), "image/jpeg", 1024);
+
+		mockMvc.perform(submit(missionId, "photo-complete", photoRequest(tripId, photoId))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.completed").value(true))
+				.andExpect(jsonPath("$.data.rewardPoints").value(150))
+				.andExpect(jsonPath("$.data.visitRecorded").value(true));
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT status FROM mission_participations WHERE trip_id = ? AND mission_id = ?", String.class, tripId,
+				missionId)).isEqualTo("COMPLETED");
+		assertThat(
+				jdbcTemplate.queryForObject("SELECT count(*) FROM mission_photos WHERE trip_id = ? AND mission_id = ?",
+						Integer.class, tripId, missionId))
+				.isEqualTo(1);
+		assertThat(applicationEvents.stream(MissionCompleted.class)).hasSize(1);
+		assertThat(applicationEvents.stream(VisitRecorded.class)).hasSize(1);
+	}
+
+	/** 존재하지 않는 photoId로 제출하면 404를 받는다. */
+	@Test
+	@DisplayName("존재하지 않는 photoId로 제출하면 404를 받는다")
+	void returns404WhenPhotoObjectDoesNotExist() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+		when(photoObjectStore.head(anyString())).thenReturn(Optional.empty());
+
+		mockMvc.perform(submit(missionId, "photo-missing", photoRequest(tripId, UUID.randomUUID())))
+				.andExpect(status().isNotFound()).andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM mission_participations WHERE trip_id = ?",
+				Integer.class, tripId)).isZero();
+	}
+
+	/** 다른 회원이 발급받은 photoId로 제출하면 404를 받는다. */
+	@Test
+	@DisplayName("다른 회원의 photoId로 제출하면 404를 받는다")
+	void returns404WhenPhotoOwnedByAnotherMember() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+		UUID photoId = UUID.randomUUID();
+		stubMatchingPhoto(tripId, missionId, photoId, UUID.randomUUID(), "image/jpeg", 1024);
+
+		mockMvc.perform(submit(missionId, "photo-other-owner", photoRequest(tripId, photoId)))
+				.andExpect(status().isNotFound()).andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 실제 크기가 발급 요청과 다르면 400을 받고 상태를 바꾸지 않는다. */
+	@Test
+	@DisplayName("실제 크기가 발급 요청과 다르면 400을 받고 상태를 바꾸지 않는다")
+	void returns400WhenFileSizeMismatches() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+		UUID photoId = UUID.randomUUID();
+		when(photoObjectStore.head(anyString())).thenReturn(
+				Optional.of(new MissionPhotoObject(member.memberId(), "image/jpeg", 2048, "image/jpeg", 1024)));
+
+		mockMvc.perform(submit(missionId, "photo-size-mismatch", photoRequest(tripId, photoId)))
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM mission_photos WHERE trip_id = ?", Integer.class,
+				tripId)).isZero();
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM mission_participations WHERE trip_id = ?",
+				Integer.class, tripId)).isZero();
+	}
+
+	/** Content-Type이 발급 요청과 다르면 400을 받는다. */
+	@Test
+	@DisplayName("Content-Type이 발급 요청과 다르면 400을 받는다")
+	void returns400WhenContentTypeMismatches() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+		UUID photoId = UUID.randomUUID();
+		when(photoObjectStore.head(anyString())).thenReturn(
+				Optional.of(new MissionPhotoObject(member.memberId(), "image/png", 1024, "image/jpeg", 1024)));
+
+		mockMvc.perform(submit(missionId, "photo-type-mismatch", photoRequest(tripId, photoId)))
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	/** 이미 완료된 사진 미션에 같은 photoId로 다시 제출하면 409를 받는다. */
+	@Test
+	@DisplayName("완료된 사진 미션에 재제출하면 409를 받는다")
+	void resubmittingCompletedPhotoMissionReturns409() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+		UUID photoId = UUID.randomUUID();
+		stubMatchingPhoto(tripId, missionId, photoId, member.memberId(), "image/jpeg", 1024);
+		mockMvc.perform(submit(missionId, "photo-first", photoRequest(tripId, photoId))).andExpect(status().isOk());
+
+		mockMvc.perform(submit(missionId, "photo-second", photoRequest(tripId, photoId)))
+				.andExpect(status().isConflict()).andExpect(jsonPath("$.data.code").value("INVALID_STATE_TRANSITION"));
+	}
+
+	/** 반올림 전 실제 거리가 100m를 초과하면 403을 받고 상태를 바꾸지 않는다. */
+	@Test
+	@DisplayName("100m를 초과한 사진 제출은 403을 받고 상태를 바꾸지 않는다")
+	void returns403WhenBeyondParticipationRadius() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("먼 사진 장소", 100.1);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+		UUID photoId = UUID.randomUUID();
+		stubMatchingPhoto(tripId, missionId, photoId, member.memberId(), "image/jpeg", 1024);
+
+		mockMvc.perform(submit(missionId, "photo-too-far", photoRequest(tripId, photoId)))
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.data.code").value("LOCATION_VERIFICATION_FAILED"));
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM mission_participations WHERE trip_id = ?",
+				Integer.class, tripId)).isZero();
+	}
+
+	/** 같은 키와 같은 본문의 제출 재요청은 최초 응답을 재사용하고 부작용을 반복하지 않는다. */
+	@Test
+	@DisplayName("사진 제출도 동일한 멱등성 요청은 최초 응답을 재사용한다")
+	void sameIdempotentPhotoSubmissionReplaysFirstResponse() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
+		UUID photoId = UUID.randomUUID();
+		stubMatchingPhoto(tripId, missionId, photoId, member.memberId(), "image/jpeg", 1024);
+		String body = photoRequest(tripId, photoId);
+
+		String first = mockMvc.perform(submit(missionId, "photo-retry", body)).andExpect(status().isOk()).andReturn()
+				.getResponse().getContentAsString();
+		String retried = mockMvc.perform(submit(missionId, "photo-retry", body)).andExpect(status().isOk()).andReturn()
+				.getResponse().getContentAsString();
+
+		assertThat(retried).isEqualTo(first);
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM mission_photos WHERE trip_id = ?", Integer.class,
+				tripId)).isEqualTo(1);
+	}
+
+	/** 같은 문화재의 다른 사진 미션을 완료해도 방문 기록은 한 번만 생성된다. */
+	@Test
+	@DisplayName("같은 문화재의 다른 사진 미션을 완료해도 방문 기록은 한 번만 생성된다")
+	void completingAnotherPhotoMissionForSamePlaceDoesNotDuplicateVisit() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("공통 장소", 50);
+		UUID firstMission = insertPhotoMission(place, "사진 미션1", 100);
+		UUID secondMission = insertPhotoMission(place, "사진 미션2", 100);
+		UUID firstPhotoId = UUID.randomUUID();
+		UUID secondPhotoId = UUID.randomUUID();
+		stubMatchingPhoto(tripId, firstMission, firstPhotoId, member.memberId(), "image/jpeg", 1024);
+		stubMatchingPhoto(tripId, secondMission, secondPhotoId, member.memberId(), "image/jpeg", 1024);
+
+		mockMvc.perform(submit(firstMission, "visit-first", photoRequest(tripId, firstPhotoId)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.visitRecorded").value(true));
+		mockMvc.perform(submit(secondMission, "visit-second", photoRequest(tripId, secondPhotoId)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.visitRecorded").value(false));
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM visit_records WHERE trip_id = ? AND place_id = ?",
+				Integer.class, tripId, place)).isEqualTo(1);
+	}
+
+	private void stubMatchingPhoto(UUID tripId, UUID missionId, UUID photoId, UUID ownerId, String contentType,
+			long fileSizeBytes) {
+		String objectKey = "private/missions/" + tripId + "/" + missionId + "/" + photoId;
+		when(photoObjectStore.head(objectKey)).thenReturn(
+				Optional.of(new MissionPhotoObject(ownerId, contentType, fileSizeBytes, contentType, fileSizeBytes)));
+	}
+
+	private MockHttpServletRequestBuilder submit(UUID missionId, String idempotencyKey, String body) {
+		return post("/missions/{missionId}/submissions", missionId)
+				.header("Authorization", "Bearer " + member.accessToken()).header("Idempotency-Key", idempotencyKey)
+				.contentType(MediaType.APPLICATION_JSON).content(body);
+	}
+
+	private String photoRequest(UUID tripId, UUID photoId) {
+		return "{\"tripId\":\"" + tripId + "\",\"type\":\"PHOTO\",\"photoId\":\"" + photoId + "\",\"location\":"
+				+ locationJson() + "}";
+	}
+
+	private String locationJson() {
+		return "{\"latitude\":" + ORIGIN_LATITUDE + ",\"longitude\":" + ORIGIN_LONGITUDE
+				+ ",\"accuracyMeters\":5.5,\"capturedAt\":\"2026-08-12T15:30:00+09:00\"}";
+	}
+
+	private MockHttpServletRequestBuilder presignRequest(UUID tripId, UUID missionId, String idempotencyKey) {
+		return presignRequestBody(tripId, missionId, idempotencyKey, fileSizeRequestJson(tripId, missionId, 1024));
+	}
+
+	private MockHttpServletRequestBuilder presignRequestBody(UUID tripId, UUID missionId, String idempotencyKey,
+			String body) {
+		return post("/mission-photos/presigned-url").header("Authorization", "Bearer " + member.accessToken())
+				.header("Idempotency-Key", idempotencyKey).contentType(MediaType.APPLICATION_JSON).content(body);
+	}
+
+	private String fileSizeRequestJson(UUID tripId, UUID missionId, long fileSizeBytes) {
+		return "{\"tripId\":\"" + tripId + "\",\"missionId\":\"" + missionId
+				+ "\",\"fileName\":\"photo.jpg\",\"contentType\":\"image/jpeg\",\"fileSizeBytes\":" + fileSizeBytes
+				+ "}";
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private UUID startTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status) VALUES (?, ?, 'IN_PROGRESS')", tripId, memberId);
+		return tripId;
+	}
+
+	private UUID insertPlace(String name, double latitude, double longitude) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate
+				.update("INSERT INTO places (id, category, name, location) VALUES (?, 'HERITAGE'::place_category, ?, "
+						+ "ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography)", id, name, longitude, latitude);
+		return id;
+	}
+
+	/**
+	 * 원점에서 지정한 거리(m)만큼 떨어진 지점에 장소를 만든다. 삽입과 조회가 같은 PostGIS geodesic 계산을 쓰므로 왕복 오차가
+	 * 없다.
+	 */
+	private UUID insertProjectedPlace(String name, double distanceMeters) {
+		Map<String, Object> point = jdbcTemplate.queryForMap(
+				"SELECT ST_Y(pt::geometry) AS lat, ST_X(pt::geometry) AS lon FROM "
+						+ "(SELECT ST_Project(ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?, 0) AS pt) t",
+				ORIGIN_LONGITUDE, ORIGIN_LATITUDE, distanceMeters);
+		return insertPlace(name, ((Number) point.get("lat")).doubleValue(), ((Number) point.get("lon")).doubleValue());
+	}
+
+	private UUID insertOxMission(UUID placeId, String title, int rewardPoints, Integer maxAttempts,
+			boolean correctAnswer) {
+		return insertMission(placeId, "OX", title, rewardPoints, maxAttempts, correctAnswer);
+	}
+
+	private UUID insertPhotoMission(UUID placeId, String title, int rewardPoints) {
+		return insertMission(placeId, "PHOTO", title, rewardPoints, null, null);
+	}
+
+	private UUID insertMission(UUID placeId, String type, String title, int rewardPoints, Integer maxAttempts,
+			Boolean oxCorrectAnswer) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO missions (id, place_id, type, title, description, reward_points, max_attempts, "
+						+ "ox_correct_answer) VALUES (?, ?, ?::mission_type, ?, '설명', ?, ?, ?)",
+				id, placeId, type, title, rewardPoints, maxAttempts, oxCorrectAnswer);
+		return id;
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## Summary
- `POST /mission-photos/presigned-url`을 구현한다. 여행 소유권·`IN_PROGRESS` 상태와 대상 미션의 `PHOTO` 유형을 검증하고 `photoId`를 애플리케이션에서 미리 생성한다. 발급 시점에는 `mission_photos` row를 생성하지 않는다.
- `POST /missions/{missionId}/submissions`의 `PHOTO` 유형을 구현한다. presign 시 S3 객체 메타데이터에 서명해 남긴 소유자·선언된 크기·Content-Type을 제출 시점에 실제 업로드된 S3 객체와 대조한다.
- 검증에 성공하면 `mission_photos` row를 생성하고 #103의 완료 처리 파이프라인(참여 상태 전이, 방문 기록, 포인트 지급, 이벤트 발행)을 그대로 호출해 판정 없이 즉시 완료 처리한다.
- S3 연동은 `MissionPhotoUploadPresigner`·`MissionPhotoObjectStore` 인터페이스로 분리해 테스트에서 실제 AWS 호출 없이 대체한다.

Closes #104

## Test plan
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh` (checkstyle, spotbugs, check)
- [x] `./scripts/test/test.sh` — mission 도메인 32개 포함 전체 스위트 통과
- [x] `docker compose build` — 이미지 빌드 성공
- [ ] `docker-build.sh` 헬스체크 — 실제 Supabase 자격 증명이 필요해 로컬 샌드박스에서는 끝까지 확인하지 못함
- [x] 인수 조건 9개 모두 `MissionPhotoSubmissionIntegrationTests`(17개)로 커버: 발급 응답 형식/`mission_photos` 미생성, `PHOTO`가 아닌 미션 400, 검증 성공 시 완료 처리, 불일치·존재하지 않는 객체 400/404, 재제출 409, 100m 초과 403, 두 endpoint의 멱등성, 같은 문화재 방문 기록 중복 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017is3HybCvLhw2HBYEWisxS