### PR TITLE
feat: UC-16 포인트 내역 목록 조회 구현

### DIFF
--- a/src/main/java/com/buyeoon/point/api/InvalidPointRequestException.java
+++ b/src/main/java/com/buyeoon/point/api/InvalidPointRequestException.java
@@ -1,0 +1,4 @@
+package com.buyeoon.point.api;
+
+public class InvalidPointRequestException extends RuntimeException {
+}

--- a/src/main/java/com/buyeoon/point/api/PointController.java
+++ b/src/main/java/com/buyeoon/point/api/PointController.java
@@ -3,26 +3,71 @@ package com.buyeoon.point.api;
 import com.buyeoon.common.api.SuccessResponse;
 import com.buyeoon.point.application.PointSummaryService;
 import com.buyeoon.point.application.PointSummaryService.PointSummaryView;
+import com.buyeoon.point.application.PointTransactionCursor;
+import com.buyeoon.point.application.PointTransactionQueryService;
+import com.buyeoon.point.application.PointTransactionQueryService.PointTransactionListView;
 import java.util.Objects;
 import java.util.UUID;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** 로그인 회원의 포인트 잔액 요약 조회를 담당하는 컨트롤러다. */
+/** 로그인 회원의 포인트 잔액 요약과 내역 조회를 담당하는 컨트롤러다. */
 @RestController
 public class PointController {
 
-	private final PointSummaryService pointSummaryService;
+	private static final int DEFAULT_SIZE = 20;
+	private static final int MIN_SIZE = 1;
+	private static final int MAX_SIZE = 100;
 
-	public PointController(PointSummaryService pointSummaryService) {
+	private final PointSummaryService pointSummaryService;
+	private final PointTransactionQueryService pointTransactionQueryService;
+
+	public PointController(PointSummaryService pointSummaryService,
+			PointTransactionQueryService pointTransactionQueryService) {
 		this.pointSummaryService = pointSummaryService;
+		this.pointTransactionQueryService = pointTransactionQueryService;
 	}
 
 	@GetMapping("/members/me/points")
 	public SuccessResponse<PointSummaryView> getMyPointSummary(@AuthenticationPrincipal Jwt jwt) {
 		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
 		return SuccessResponse.of(pointSummaryService.getSummary(memberId));
+	}
+
+	@GetMapping("/members/me/point-transactions")
+	public SuccessResponse<PointTransactionListView> getMyPointTransactions(@AuthenticationPrincipal Jwt jwt,
+			@RequestParam(required = false) String cursor, @RequestParam(required = false) String size) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		return SuccessResponse.of(pointTransactionQueryService.list(memberId, parseCursor(cursor), parseSize(size)));
+	}
+
+	private PointTransactionCursor parseCursor(String cursor) {
+		if (cursor == null) {
+			return null;
+		}
+		try {
+			return PointTransactionCursor.decode(cursor);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidPointRequestException();
+		}
+	}
+
+	private int parseSize(String size) {
+		if (size == null) {
+			return DEFAULT_SIZE;
+		}
+		int value;
+		try {
+			value = Integer.parseInt(size);
+		} catch (NumberFormatException exception) {
+			throw new InvalidPointRequestException();
+		}
+		if (value < MIN_SIZE || value > MAX_SIZE) {
+			throw new InvalidPointRequestException();
+		}
+		return value;
 	}
 }

--- a/src/main/java/com/buyeoon/point/api/PointExceptionHandler.java
+++ b/src/main/java/com/buyeoon/point/api/PointExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.buyeoon.point.api;
+
+import com.buyeoon.common.api.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(assignableTypes = PointController.class)
+public class PointExceptionHandler {
+
+	@ExceptionHandler(InvalidPointRequestException.class)
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	public ErrorResponse handleInvalidRequest() {
+		return ErrorResponse.invalidRequest();
+	}
+}

--- a/src/main/java/com/buyeoon/point/application/PointTransactionCursor.java
+++ b/src/main/java/com/buyeoon/point/application/PointTransactionCursor.java
@@ -1,0 +1,31 @@
+package com.buyeoon.point.application;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.UUID;
+
+/** 포인트 내역 목록 페이지네이션 커서(발생 시각, 내역 ID)를 인코딩·디코딩한다. */
+public record PointTransactionCursor(Instant occurredAt, UUID transactionId) {
+
+	public static PointTransactionCursor decode(String value) {
+		try {
+			String decoded = new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
+			int separatorIndex = decoded.indexOf('_');
+			long epochMicros = Long.parseLong(decoded.substring(0, separatorIndex));
+			UUID transactionId = UUID.fromString(decoded.substring(separatorIndex + 1));
+			Instant occurredAt = Instant.ofEpochSecond(Math.floorDiv(epochMicros, 1_000_000L),
+					Math.floorMod(epochMicros, 1_000_000L) * 1_000L);
+			return new PointTransactionCursor(occurredAt, transactionId);
+		} catch (RuntimeException exception) {
+			throw new IllegalArgumentException("잘못된 커서입니다.", exception);
+		}
+	}
+
+	public String encode() {
+		long epochMicros = Math.addExact(Math.multiplyExact(occurredAt.getEpochSecond(), 1_000_000L),
+				occurredAt.getNano() / 1_000L);
+		String raw = epochMicros + "_" + transactionId;
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+	}
+}

--- a/src/main/java/com/buyeoon/point/application/PointTransactionQueryService.java
+++ b/src/main/java/com/buyeoon/point/application/PointTransactionQueryService.java
@@ -1,0 +1,58 @@
+package com.buyeoon.point.application;
+
+import com.buyeoon.point.entity.PointTransactionType;
+import com.buyeoon.point.repository.PointTransactionRepository;
+import com.buyeoon.point.repository.PointTransactionRow;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 회원의 포인트 내역을 발생 시각 최신순으로 커서 페이지네이션 조회하는 point 도메인의 공개 seam이다. */
+@Service
+@Transactional(readOnly = true)
+public class PointTransactionQueryService {
+
+	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+
+	private final PointTransactionRepository pointTransactionRepository;
+
+	public PointTransactionQueryService(PointTransactionRepository pointTransactionRepository) {
+		this.pointTransactionRepository = pointTransactionRepository;
+	}
+
+	/** 발생 시각 최신순, 동일 시각은 내역 ID 순으로 정렬된 한 페이지를 balanceAfter와 함께 조회한다. */
+	public PointTransactionListView list(UUID memberId, PointTransactionCursor cursor, int size) {
+		List<PointTransactionRow> rows = cursor == null
+				? pointTransactionRepository.findFromStart(memberId, size + 1)
+				: pointTransactionRepository.findAfter(memberId, cursor.occurredAt(), cursor.transactionId(), size + 1);
+
+		boolean hasNext = rows.size() > size;
+		List<PointTransactionRow> page = hasNext ? rows.subList(0, size) : rows;
+		String nextCursor = hasNext
+				? new PointTransactionCursor(page.getLast().occurredAt(), page.getLast().id()).encode()
+				: null;
+		List<PointTransactionItemView> items = page.stream().map(this::toView).toList();
+		return new PointTransactionListView(items, new PageInfoView(nextCursor, hasNext));
+	}
+
+	private PointTransactionItemView toView(PointTransactionRow row) {
+		return new PointTransactionItemView(row.id(), row.type(), row.amount(), row.balanceAfter(), row.description(),
+				row.occurredAt().atZone(ASIA_SEOUL));
+	}
+
+	public record PointTransactionListView(List<PointTransactionItemView> items, PageInfoView page) {
+		public PointTransactionListView {
+			items = List.copyOf(items);
+		}
+	}
+
+	public record PointTransactionItemView(UUID transactionId, PointTransactionType type, long amount,
+			long balanceAfter, String description, ZonedDateTime occurredAt) {
+	}
+
+	public record PageInfoView(String nextCursor, boolean hasNext) {
+	}
+}

--- a/src/main/java/com/buyeoon/point/repository/PointTransactionRepository.java
+++ b/src/main/java/com/buyeoon/point/repository/PointTransactionRepository.java
@@ -2,12 +2,14 @@ package com.buyeoon.point.repository;
 
 import com.buyeoon.point.entity.PointTransactionEntity;
 import com.buyeoon.point.entity.PointTransactionType;
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-/** 회원의 포인트 잔액·누적 적립 합계를 계산하는 조회 전용 repository다. */
+/** 회원의 포인트 잔액·누적 적립 합계와 내역 목록을 조회하는 조회 전용 repository다. */
 public interface PointTransactionRepository extends JpaRepository<PointTransactionEntity, UUID> {
 
 	/** 회원의 포인트 잔액(전체 내역 amount 합계)을 계산한다. 내역이 없으면 0을 반환한다. */
@@ -18,4 +20,43 @@ public interface PointTransactionRepository extends JpaRepository<PointTransacti
 	@Query("SELECT COALESCE(SUM(t.amount), 0) FROM PointTransactionEntity t "
 			+ "WHERE t.memberId = :memberId AND t.type = :type")
 	long sumAmountByMemberIdAndType(@Param("memberId") UUID memberId, @Param("type") PointTransactionType type);
+
+	/** 회원의 첫 페이지 내역을 발생 시각 내림차순, 동일 시각은 내역 ID 내림차순으로 조회하며 balanceAfter를 함께 계산한다. */
+	default List<PointTransactionRow> findFromStart(UUID memberId, int limit) {
+		return findRowsFromStart(memberId, limit).stream().map(PointTransactionRow::from).toList();
+	}
+
+	/** 커서 이후의 내역을 같은 정렬 기준으로 조회하며 balanceAfter를 함께 계산한다. */
+	default List<PointTransactionRow> findAfter(UUID memberId, Instant occurredAt, UUID transactionId, int limit) {
+		return findRowsAfter(memberId, occurredAt, transactionId, limit).stream().map(PointTransactionRow::from)
+				.toList();
+	}
+
+	@Query(value = """
+			SELECT sub.id, sub.type::text, sub.amount, sub.description, sub.occurred_at, sub.balance_after
+			FROM (
+			    SELECT id, type, amount, description, occurred_at,
+			           SUM(amount) OVER (ORDER BY occurred_at, id) AS balance_after
+			    FROM point_transactions
+			    WHERE member_id = :memberId
+			) sub
+			ORDER BY sub.occurred_at DESC, sub.id DESC
+			LIMIT :limit
+			""", nativeQuery = true)
+	List<Object[]> findRowsFromStart(@Param("memberId") UUID memberId, @Param("limit") int limit);
+
+	@Query(value = """
+			SELECT sub.id, sub.type::text, sub.amount, sub.description, sub.occurred_at, sub.balance_after
+			FROM (
+			    SELECT id, type, amount, description, occurred_at,
+			           SUM(amount) OVER (ORDER BY occurred_at, id) AS balance_after
+			    FROM point_transactions
+			    WHERE member_id = :memberId
+			) sub
+			WHERE sub.occurred_at < :occurredAt OR (sub.occurred_at = :occurredAt AND sub.id < :transactionId)
+			ORDER BY sub.occurred_at DESC, sub.id DESC
+			LIMIT :limit
+			""", nativeQuery = true)
+	List<Object[]> findRowsAfter(@Param("memberId") UUID memberId, @Param("occurredAt") Instant occurredAt,
+			@Param("transactionId") UUID transactionId, @Param("limit") int limit);
 }

--- a/src/main/java/com/buyeoon/point/repository/PointTransactionRow.java
+++ b/src/main/java/com/buyeoon/point/repository/PointTransactionRow.java
@@ -1,0 +1,15 @@
+package com.buyeoon.point.repository;
+
+import com.buyeoon.point.entity.PointTransactionType;
+import java.time.Instant;
+import java.util.UUID;
+
+/** balanceAfter 윈도우 함수 계산 결과를 담는 포인트 내역 목록 조회 전용 row다. */
+public record PointTransactionRow(UUID id, PointTransactionType type, long amount, String description,
+		Instant occurredAt, long balanceAfter) {
+
+	static PointTransactionRow from(Object[] row) {
+		return new PointTransactionRow((UUID) row[0], PointTransactionType.valueOf((String) row[1]),
+				((Number) row[2]).longValue(), (String) row[3], (Instant) row[4], ((Number) row[5]).longValue());
+	}
+}

--- a/src/test/java/com/buyeoon/point/PointTransactionListIntegrationTests.java
+++ b/src/test/java/com/buyeoon/point/PointTransactionListIntegrationTests.java
@@ -1,0 +1,286 @@
+package com.buyeoon.point;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import com.jayway.jsonpath.JsonPath;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class PointTransactionListIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM point_transactions");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 내역은 발생 시각 최신순으로 반환되고 각 항목은 발생 시각·내역 ID 순으로 누계한 balanceAfter를 포함한다. */
+	@Test
+	@DisplayName("발생 시각 최신순으로 모든 필드와 balanceAfter를 반환한다")
+	void returnsOwnTransactionsDescendingWithBalanceAfter() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant base = Instant.parse("2026-08-10T00:00:00Z");
+		UUID first = insertTransaction(member.memberId(), "EARN", 100, "미션 보상 A", base);
+		UUID second = insertTransaction(member.memberId(), "EARN", 50, "미션 보상 B", base.plusSeconds(60));
+
+		mockMvc.perform(get("/members/me/point-transactions").header("Authorization", bearer(member)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.items", hasSize(2)))
+				.andExpect(jsonPath("$.data.items[0].transactionId").value(second.toString()))
+				.andExpect(jsonPath("$.data.items[0].type").value("EARN"))
+				.andExpect(jsonPath("$.data.items[0].amount").value(50))
+				.andExpect(jsonPath("$.data.items[0].balanceAfter").value(150))
+				.andExpect(jsonPath("$.data.items[0].description").value("미션 보상 B"))
+				.andExpect(jsonPath("$.data.items[0].occurredAt").value("2026-08-10T09:01:00+09:00"))
+				.andExpect(jsonPath("$.data.items[1].transactionId").value(first.toString()))
+				.andExpect(jsonPath("$.data.items[1].balanceAfter").value(100))
+				.andExpect(jsonPath("$.data.page.hasNext").value(false))
+				.andExpect(jsonPath("$.data.page.nextCursor").doesNotExist());
+	}
+
+	/** 동일 발생 시각 내역은 내역 ID 내림차순으로 순서가 흔들리지 않고 balanceAfter도 그 순서로 누계된다. */
+	@Test
+	@DisplayName("발생 시각이 같으면 내역 ID 순으로 정렬하고 balanceAfter도 그 순서로 누계된다")
+	void tieBreaksBySameOccurredAtByTransactionId() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant same = Instant.parse("2026-08-10T00:00:00Z");
+		UUID idA = insertTransaction(member.memberId(), "EARN", 10, "동시 적립1", same);
+		UUID idB = insertTransaction(member.memberId(), "EARN", 20, "동시 적립2", same);
+		UUID idC = insertTransaction(member.memberId(), "EARN", 30, "동시 적립3", same);
+		Map<UUID, Long> amountById = Map.of(idA, 10L, idB, 20L, idC, 30L);
+		List<UUID> ascendingById = jdbcTemplate.queryForList(
+				"SELECT id FROM point_transactions WHERE member_id = ? ORDER BY occurred_at, id", UUID.class,
+				member.memberId());
+		long cumulative = 0;
+		Map<UUID, Long> balanceAfterById = new java.util.LinkedHashMap<>();
+		for (UUID id : ascendingById) {
+			cumulative += amountById.get(id);
+			balanceAfterById.put(id, cumulative);
+		}
+		List<UUID> descending = ascendingById.reversed();
+
+		mockMvc.perform(get("/members/me/point-transactions").header("Authorization", bearer(member)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items", hasSize(3)))
+				.andExpect(jsonPath("$.data.items[0].transactionId").value(descending.get(0).toString()))
+				.andExpect(jsonPath("$.data.items[0].balanceAfter").value(balanceAfterById.get(descending.get(0))))
+				.andExpect(jsonPath("$.data.items[2].transactionId").value(descending.get(2).toString()))
+				.andExpect(jsonPath("$.data.items[2].balanceAfter").value(balanceAfterById.get(descending.get(2))));
+	}
+
+	/** cursor로 다음 페이지를 이어서 조회하고 hasNext를 정확히 계산한다. */
+	@Test
+	@DisplayName("cursor로 다음 페이지를 이어서 조회하고 hasNext를 정확히 계산한다")
+	void paginatesWithCursorAndComputesHasNextAccurately() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant base = Instant.parse("2026-08-10T00:00:00Z");
+		List<UUID> ids = List.of(insertTransaction(member.memberId(), "EARN", 10, "1", base),
+				insertTransaction(member.memberId(), "EARN", 10, "2", base.plusSeconds(1)),
+				insertTransaction(member.memberId(), "EARN", 10, "3", base.plusSeconds(2)),
+				insertTransaction(member.memberId(), "EARN", 10, "4", base.plusSeconds(3)),
+				insertTransaction(member.memberId(), "EARN", 10, "5", base.plusSeconds(4)));
+		List<String> expectedDescending = List.of(ids.get(4).toString(), ids.get(3).toString(), ids.get(2).toString(),
+				ids.get(1).toString(), ids.get(0).toString());
+
+		MvcResult firstPage = mockMvc
+				.perform(get("/members/me/point-transactions").param("size", "2").header("Authorization",
+						bearer(member)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items", hasSize(2)))
+				.andExpect(jsonPath("$.data.items[0].transactionId").value(expectedDescending.get(0)))
+				.andExpect(jsonPath("$.data.items[1].transactionId").value(expectedDescending.get(1)))
+				.andExpect(jsonPath("$.data.page.hasNext").value(true))
+				.andExpect(jsonPath("$.data.page.nextCursor").exists()).andReturn();
+		String firstCursor = JsonPath.read(firstPage.getResponse().getContentAsString(), "$.data.page.nextCursor");
+
+		MvcResult secondPage = mockMvc
+				.perform(get("/members/me/point-transactions").param("size", "2").param("cursor", firstCursor)
+						.header("Authorization", bearer(member)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items", hasSize(2)))
+				.andExpect(jsonPath("$.data.items[0].transactionId").value(expectedDescending.get(2)))
+				.andExpect(jsonPath("$.data.items[1].transactionId").value(expectedDescending.get(3)))
+				.andExpect(jsonPath("$.data.page.hasNext").value(true))
+				.andExpect(jsonPath("$.data.page.nextCursor").exists()).andReturn();
+		String secondCursor = JsonPath.read(secondPage.getResponse().getContentAsString(), "$.data.page.nextCursor");
+
+		mockMvc.perform(get("/members/me/point-transactions").param("size", "2").param("cursor", secondCursor)
+				.header("Authorization", bearer(member))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items", hasSize(1)))
+				.andExpect(jsonPath("$.data.items[0].transactionId").value(expectedDescending.get(4)))
+				.andExpect(jsonPath("$.data.page.hasNext").value(false))
+				.andExpect(jsonPath("$.data.page.nextCursor").doesNotExist());
+	}
+
+	/** size는 기본값 20이며 1~100을 벗어나거나 정수가 아니면 400 INVALID_REQUEST다. */
+	@Test
+	@DisplayName("size는 기본값 20이며 1~100을 벗어나거나 정수가 아니면 400 INVALID_REQUEST다")
+	void validatesSizeRange() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		for (int i = 0; i < 21; i++) {
+			insertTransaction(member.memberId(), "EARN", 10, "n" + i, Instant.now().plusSeconds(i));
+		}
+
+		mockMvc.perform(get("/members/me/point-transactions").header("Authorization", bearer(member)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items", hasSize(20)));
+
+		for (String invalidSize : List.of("0", "101", "abc", "-1")) {
+			mockMvc.perform(get("/members/me/point-transactions").param("size", invalidSize).header("Authorization",
+					bearer(member))).andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	/** 잘못된 형식의 cursor는 400 INVALID_REQUEST다. */
+	@Test
+	@DisplayName("잘못된 형식의 cursor는 400 INVALID_REQUEST다")
+	void validatesCursorFormat() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+
+		for (String invalidCursor : List.of("not-base64!!", "abc", "MTIz")) {
+			mockMvc.perform(get("/members/me/point-transactions").param("cursor", invalidCursor).header("Authorization",
+					bearer(member))).andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	/** 내역이 없으면 빈 목록과 hasNext false를 반환한다. */
+	@Test
+	@DisplayName("내역이 없으면 빈 목록과 hasNext false를 반환한다")
+	void returnsEmptyListWhenNoTransactions() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+
+		mockMvc.perform(get("/members/me/point-transactions").header("Authorization", bearer(member)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items", hasSize(0)))
+				.andExpect(jsonPath("$.data.page.hasNext").value(false));
+	}
+
+	/** 다른 회원의 내역은 결과에 포함되지 않는다. */
+	@Test
+	@DisplayName("다른 회원의 내역은 결과에 포함되지 않는다")
+	void excludesOtherMembersTransactions() throws Exception {
+		AuthenticatedMember me = insertAuthenticatedMember();
+		AuthenticatedMember other = insertAuthenticatedMember();
+		insertTransaction(other.memberId(), "EARN", 1000, "타인 적립", Instant.now());
+		UUID mine = insertTransaction(me.memberId(), "EARN", 10, "내 적립", Instant.now());
+
+		mockMvc.perform(get("/members/me/point-transactions").header("Authorization", bearer(me)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items", hasSize(1)))
+				.andExpect(jsonPath("$.data.items[0].transactionId").value(mine.toString()))
+				.andExpect(jsonPath("$.data.items[0].balanceAfter").value(10));
+	}
+
+	/** 인증되지 않은 요청은 401 UNAUTHORIZED다. */
+	@Test
+	@DisplayName("인증되지 않은 요청은 401 UNAUTHORIZED다")
+	void requiresAuthentication() throws Exception {
+		mockMvc.perform(get("/members/me/point-transactions")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** 반복 조회해도 DB 상태가 변하지 않는다. */
+	@Test
+	@DisplayName("반복 조회해도 DB 상태가 변하지 않는다")
+	void repeatedCallsDoNotChangeDbState() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		insertTransaction(member.memberId(), "EARN", 10, "적립", Instant.now());
+		List<Map<String, Object>> before = transactions();
+
+		for (int i = 0; i < 3; i++) {
+			mockMvc.perform(get("/members/me/point-transactions").header("Authorization", bearer(member)))
+					.andExpect(status().isOk());
+		}
+
+		assertThat(transactions()).isEqualTo(before);
+	}
+
+	private String bearer(AuthenticatedMember member) {
+		return "Bearer " + member.accessToken();
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private UUID insertTransaction(UUID memberId, String type, long amount, String description, Instant occurredAt) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO point_transactions (id, member_id, type, amount, description, occurred_at) "
+						+ "VALUES (?, ?, ?::point_transaction_type, ?, ?, ?)",
+				id, memberId, type, amount, description, Timestamp.from(occurredAt));
+		return id;
+	}
+
+	private List<Map<String, Object>> transactions() {
+		return jdbcTemplate.queryForList("""
+				SELECT id, member_id, type::text, amount, description, occurred_at
+				FROM point_transactions
+				ORDER BY id
+				""");
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## Summary
- `GET /members/me/point-transactions`로 회원 포인트 내역을 발생 시각 최신순 커서 페이지네이션으로 조회
- 각 항목의 `balanceAfter`를 `SUM(amount) OVER (ORDER BY occurred_at, id)` 윈도우 함수로 계산
- 동일 발생 시각은 내역 ID 순으로 tie-break, `cursor`/`size`(기본 20, 1~100) 검증과 401/400 처리 포함

Closes #107

## Test plan
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh`
- [x] `./scripts/test/test.sh`
- [x] Testcontainers PostgreSQL/PostGIS + 전체 Flyway + 실제 JWT 인증 통합 테스트(`PointTransactionListIntegrationTests`) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBTGn2St8gKX2BFb1iv4rG