### PR TITLE
feat: UC-14 미션 완료 lifetime 배지 획득 구현

### DIFF
--- a/src/main/java/com/buyeoon/badge/BadgeEvaluationService.java
+++ b/src/main/java/com/buyeoon/badge/BadgeEvaluationService.java
@@ -1,0 +1,92 @@
+package com.buyeoon.badge;
+
+import com.buyeoon.badge.application.BadgeMetricProviderRegistry;
+import com.buyeoon.badge.entity.BadgeConditionEntity;
+import com.buyeoon.badge.entity.BadgeEntity;
+import com.buyeoon.badge.repository.BadgeConditionRepository;
+import com.buyeoon.badge.repository.BadgeRepository;
+import com.buyeoon.badge.repository.MemberBadgeRepository;
+import com.buyeoon.notification.NotificationCreationService;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 다른 도메인이 activity 처리 후 미획득 배지를 판정할 때 사용하는 badge 도메인의 공개 seam이다(ADR-003). 호출하는
+ * application service가 source 변경을 flush한 뒤 같은 transaction에서 동기 호출해야 방금 확정한
+ * activity를 포함해 판정한다.
+ */
+@Service
+public class BadgeEvaluationService {
+
+	private final BadgeMetricProviderRegistry providerRegistry;
+	private final BadgeRepository badgeRepository;
+	private final BadgeConditionRepository badgeConditionRepository;
+	private final MemberBadgeRepository memberBadgeRepository;
+	private final NotificationCreationService notificationCreationService;
+
+	public BadgeEvaluationService(BadgeMetricProviderRegistry providerRegistry, BadgeRepository badgeRepository,
+			BadgeConditionRepository badgeConditionRepository, MemberBadgeRepository memberBadgeRepository,
+			NotificationCreationService notificationCreationService) {
+		this.providerRegistry = providerRegistry;
+		this.badgeRepository = badgeRepository;
+		this.badgeConditionRepository = badgeConditionRepository;
+		this.memberBadgeRepository = memberBadgeRepository;
+		this.notificationCreationService = notificationCreationService;
+	}
+
+	/**
+	 * 변경된 metric과 관련된 미획득 배지의 모든 조건을 판정하고, 처음 충족한 배지를 badge ID 오름차순으로 지급한다.
+	 * Activity, 새 배지 획득과 {@code BADGE} 알림은 호출자의 transaction에 참여해 같은 transaction으로
+	 * 확정한다.
+	 */
+	@Transactional
+	public List<AwardedBadgeResult> award(UUID memberId, UUID tripId, Set<BadgeMetric> affectedMetrics) {
+		if (affectedMetrics.isEmpty()) {
+			return List.of();
+		}
+		Set<String> affectedMetricKeys = affectedMetrics.stream().map(Enum::name).collect(Collectors.toSet());
+		List<BadgeEntity> candidates = badgeRepository.findNotEarnedByAnyMetric(memberId, affectedMetricKeys);
+		if (candidates.isEmpty()) {
+			return List.of();
+		}
+
+		Map<UUID, List<BadgeConditionEntity>> conditionsByBadgeId = badgeConditionRepository
+				.findByIdBadgeIdIn(candidates.stream().map(BadgeEntity::getId).toList()).stream()
+				.collect(Collectors.groupingBy(condition -> condition.getId().badgeId()));
+
+		Map<BadgeMetric, Long> metricValues = new EnumMap<>(BadgeMetric.class);
+		List<AwardedBadgeResult> awarded = new ArrayList<>();
+		for (BadgeEntity badge : candidates) {
+			List<BadgeConditionEntity> conditions = conditionsByBadgeId.getOrDefault(badge.getId(), List.of());
+			boolean achieved = !conditions.isEmpty() && conditions.stream().allMatch(condition -> {
+				BadgeMetric metric = BadgeMetric.valueOf(condition.getId().metricKey());
+				long value = metricValues.computeIfAbsent(metric, m -> providerRegistry.get(m).calculate(memberId));
+				return value >= condition.getThreshold();
+			});
+			if (!achieved) {
+				continue;
+			}
+			memberBadgeRepository.awardIfAbsent(memberId, badge.getId(), tripId).ifPresent(earnedAt -> {
+				notificationCreationService.createBadgeAwarded(memberId, badge.getId(), badge.getName());
+				awarded.add(new AwardedBadgeResult(badge.getId(), badge.getName(), badge.getImageKey(),
+						badge.getConditionText(), earnedAt));
+			});
+		}
+		return awarded;
+	}
+
+	/**
+	 * 이번 activity 처리로 새로 지급된 배지의 semantic result다. 만료되는 Presigned URL 대신 image key를
+	 * 담아 idempotency record에 그대로 저장할 수 있다.
+	 */
+	public record AwardedBadgeResult(UUID badgeId, String name, String imageKey, String condition, Instant earnedAt) {
+	}
+}

--- a/src/main/java/com/buyeoon/badge/BadgeMetric.java
+++ b/src/main/java/com/buyeoon/badge/BadgeMetric.java
@@ -1,0 +1,6 @@
+package com.buyeoon.badge;
+
+/** 배지 조건 판정에 사용하는 Spring 계산 메트릭이다(ADR-003). */
+public enum BadgeMetric {
+	MISSION_COMPLETED_COUNT, HERITAGE_VISITED_COUNT, POINT_DONATION_COUNT
+}

--- a/src/main/java/com/buyeoon/badge/application/BadgeMetricProvider.java
+++ b/src/main/java/com/buyeoon/badge/application/BadgeMetricProvider.java
@@ -1,0 +1,13 @@
+package com.buyeoon.badge.application;
+
+import com.buyeoon.badge.BadgeMetric;
+import java.util.UUID;
+
+/** 메트릭별 원본 활동 데이터를 집계하는 Provider다(ADR-003). */
+public interface BadgeMetricProvider {
+
+	BadgeMetric metric();
+
+	/** 회원의 전체 여행 활동을 기준으로 현재 메트릭값을 계산한다. */
+	long calculate(UUID memberId);
+}

--- a/src/main/java/com/buyeoon/badge/application/BadgeMetricProviderRegistry.java
+++ b/src/main/java/com/buyeoon/badge/application/BadgeMetricProviderRegistry.java
@@ -1,0 +1,30 @@
+package com.buyeoon.badge.application;
+
+import com.buyeoon.badge.BadgeMetric;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring이 주입한 모든 {@link BadgeMetricProvider}를 메트릭 키로 조회하는 Registry다(ADR-003).
+ */
+@Component
+public class BadgeMetricProviderRegistry {
+
+	private final Map<BadgeMetric, BadgeMetricProvider> providers;
+
+	public BadgeMetricProviderRegistry(List<BadgeMetricProvider> providers) {
+		this.providers = providers.stream()
+				.collect(Collectors.toUnmodifiableMap(BadgeMetricProvider::metric, Function.identity()));
+	}
+
+	public BadgeMetricProvider get(BadgeMetric metric) {
+		BadgeMetricProvider provider = providers.get(metric);
+		if (provider == null) {
+			throw new IllegalArgumentException("지원하지 않는 배지 메트릭: " + metric);
+		}
+		return provider;
+	}
+}

--- a/src/main/java/com/buyeoon/badge/application/MissionCompletedCountProvider.java
+++ b/src/main/java/com/buyeoon/badge/application/MissionCompletedCountProvider.java
@@ -1,0 +1,30 @@
+package com.buyeoon.badge.application;
+
+import com.buyeoon.badge.BadgeMetric;
+import com.buyeoon.mission.MissionCompletionMetricQuery;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+/**
+ * mission 도메인의 공개 query seam으로 {@code MISSION_COMPLETED_COUNT}를 계산하는
+ * Provider다(ADR-003).
+ */
+@Component
+public class MissionCompletedCountProvider implements BadgeMetricProvider {
+
+	private final MissionCompletionMetricQuery missionCompletionMetricQuery;
+
+	public MissionCompletedCountProvider(MissionCompletionMetricQuery missionCompletionMetricQuery) {
+		this.missionCompletionMetricQuery = missionCompletionMetricQuery;
+	}
+
+	@Override
+	public BadgeMetric metric() {
+		return BadgeMetric.MISSION_COMPLETED_COUNT;
+	}
+
+	@Override
+	public long calculate(UUID memberId) {
+		return missionCompletionMetricQuery.countCompletedByMemberId(memberId);
+	}
+}

--- a/src/main/java/com/buyeoon/badge/repository/BadgeConditionRepository.java
+++ b/src/main/java/com/buyeoon/badge/repository/BadgeConditionRepository.java
@@ -1,0 +1,13 @@
+package com.buyeoon.badge.repository;
+
+import com.buyeoon.badge.entity.BadgeConditionEntity;
+import com.buyeoon.badge.entity.BadgeConditionId;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BadgeConditionRepository extends JpaRepository<BadgeConditionEntity, BadgeConditionId> {
+
+	List<BadgeConditionEntity> findByIdBadgeIdIn(Collection<UUID> badgeIds);
+}

--- a/src/main/java/com/buyeoon/badge/repository/BadgeRepository.java
+++ b/src/main/java/com/buyeoon/badge/repository/BadgeRepository.java
@@ -1,0 +1,28 @@
+package com.buyeoon.badge.repository;
+
+import com.buyeoon.badge.entity.BadgeEntity;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BadgeRepository extends JpaRepository<BadgeEntity, UUID> {
+
+	/**
+	 * 지급이 중단되지 않았고 주어진 메트릭 중 하나 이상을 조건으로 가지며 회원이 아직 획득하지 않은 배지를 badge ID 오름차순으로
+	 * 조회한다.
+	 */
+	@Query("""
+			SELECT b FROM BadgeEntity b
+			WHERE b.retiredAt IS NULL
+			  AND EXISTS (SELECT 1 FROM BadgeConditionEntity c WHERE c.id.badgeId = b.id AND c.id.metricKey IN :metricKeys)
+			  AND NOT EXISTS (
+			      SELECT 1 FROM MemberBadgeEntity mb WHERE mb.id.badgeId = b.id AND mb.id.memberId = :memberId
+			  )
+			ORDER BY b.id ASC
+			""")
+	List<BadgeEntity> findNotEarnedByAnyMetric(@Param("memberId") UUID memberId,
+			@Param("metricKeys") Set<String> metricKeys);
+}

--- a/src/main/java/com/buyeoon/badge/repository/MemberBadgeRepository.java
+++ b/src/main/java/com/buyeoon/badge/repository/MemberBadgeRepository.java
@@ -1,0 +1,22 @@
+package com.buyeoon.badge.repository;
+
+import com.buyeoon.badge.entity.MemberBadgeEntity;
+import com.buyeoon.badge.entity.MemberBadgeId;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberBadgeRepository extends JpaRepository<MemberBadgeEntity, MemberBadgeId> {
+
+	/**
+	 * {@code (member_id, badge_id)} 유일성으로 중복 획득을 막는다(ADR-003). 실제로 새 이력을 만든 경우에만
+	 * DB가 기록한 획득 시각을 반환하고, 이미 획득한 배지면 빈 값을 반환한다.
+	 */
+	@Query(value = "INSERT INTO member_badges (member_id, badge_id, trip_id) VALUES (:memberId, :badgeId, :tripId) "
+			+ "ON CONFLICT (member_id, badge_id) DO NOTHING RETURNING earned_at", nativeQuery = true)
+	Optional<Instant> awardIfAbsent(@Param("memberId") UUID memberId, @Param("badgeId") UUID badgeId,
+			@Param("tripId") UUID tripId);
+}

--- a/src/main/java/com/buyeoon/mission/MissionCompletionMetricQuery.java
+++ b/src/main/java/com/buyeoon/mission/MissionCompletionMetricQuery.java
@@ -1,0 +1,32 @@
+package com.buyeoon.mission;
+
+import com.buyeoon.mission.entity.MissionStatus;
+import com.buyeoon.mission.repository.MissionParticipationRepository;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * badge 도메인이 {@code MISSION_COMPLETED_COUNT}를 판정할 때 사용하는 mission 도메인의 공개 query
+ * seam이다(ADR-003).
+ */
+@Service
+@Transactional(readOnly = true)
+public class MissionCompletionMetricQuery {
+
+	private final MissionParticipationRepository missionParticipations;
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public MissionCompletionMetricQuery(MissionParticipationRepository missionParticipations) {
+		this.missionParticipations = missionParticipations;
+	}
+
+	/**
+	 * 회원이 전체 여행에서 완료한 mission participation 수를 센다. 같은 mission을 다른 여행에서 다시 완료하면 다시
+	 * 센다.
+	 */
+	public long countCompletedByMemberId(UUID memberId) {
+		return missionParticipations.countByMemberIdAndStatus(memberId, MissionStatus.COMPLETED);
+	}
+}

--- a/src/main/java/com/buyeoon/mission/application/MissionSubmissionService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionSubmissionService.java
@@ -1,10 +1,14 @@
 package com.buyeoon.mission.application;
 
+import com.buyeoon.badge.BadgeEvaluationService;
+import com.buyeoon.badge.BadgeEvaluationService.AwardedBadgeResult;
+import com.buyeoon.badge.BadgeMetric;
 import com.buyeoon.common.api.SuccessResponse;
 import com.buyeoon.common.entity.IdempotencyRequestEntity;
 import com.buyeoon.common.entity.IdempotencyRequestId;
 import com.buyeoon.common.storage.MissionPhotoObjectStore;
 import com.buyeoon.common.storage.MissionPhotoObjectStore.MissionPhotoObject;
+import com.buyeoon.common.storage.PublicImageUrlService;
 import com.buyeoon.member.application.IdempotencyKeyReusedException;
 import com.buyeoon.member.application.InvalidStateTransitionException;
 import com.buyeoon.mission.entity.MissionChoiceEntity;
@@ -36,7 +40,10 @@ import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -73,6 +80,8 @@ public class MissionSubmissionService {
 	private final MissionIdempotencyRequestRepository idempotencyRequests;
 	private final VisitRecordService visitRecordService;
 	private final PointRewardService pointRewardService;
+	private final BadgeEvaluationService badgeEvaluationService;
+	private final PublicImageUrlService publicImageUrlService;
 	private final ApplicationEventPublisher events;
 	private final ObjectReader objectReader;
 	private final ObjectWriter objectWriter;
@@ -84,6 +93,7 @@ public class MissionSubmissionService {
 			MissionSubmissionRepository missionSubmissions, MissionPhotoRepository missionPhotos,
 			MissionPhotoObjectStore missionPhotoObjectStore, MissionIdempotencyRequestRepository idempotencyRequests,
 			VisitRecordService visitRecordService, PointRewardService pointRewardService,
+			BadgeEvaluationService badgeEvaluationService, PublicImageUrlService publicImageUrlService,
 			ApplicationEventPublisher events, ObjectMapper objectMapper) {
 		this.jdbcOperations = jdbcOperations;
 		this.transactions = new TransactionTemplate(transactionManager);
@@ -97,6 +107,8 @@ public class MissionSubmissionService {
 		this.idempotencyRequests = idempotencyRequests;
 		this.visitRecordService = visitRecordService;
 		this.pointRewardService = pointRewardService;
+		this.badgeEvaluationService = badgeEvaluationService;
+		this.publicImageUrlService = publicImageUrlService;
 		this.events = events;
 		this.objectReader = objectMapper.reader();
 		this.objectWriter = objectMapper.writer();
@@ -106,13 +118,14 @@ public class MissionSubmissionService {
 			MissionSubmissionCommand command) {
 		validateIdempotencyKey(idempotencyKey);
 		String requestHash = hash(missionId, command);
-		return Objects.requireNonNull(
+		MissionSubmissionResult result = Objects.requireNonNull(
 				transactions.execute(
 						status -> submitInTransaction(memberId, missionId, idempotencyKey, requestHash, command)),
 				"미션 제출 트랜잭션 결과가 없습니다.");
+		return toView(result);
 	}
 
-	private MissionSubmissionView submitInTransaction(UUID memberId, UUID missionId, String idempotencyKey,
+	private MissionSubmissionResult submitInTransaction(UUID memberId, UUID missionId, String idempotencyKey,
 			String requestHash, MissionSubmissionCommand command) {
 		TripStatus tripStatus = tripQueryService.findOwnedTripStatus(memberId, command.tripId())
 				.orElseThrow(TripNotFoundException::new);
@@ -163,6 +176,7 @@ public class MissionSubmissionService {
 		long pointBalance = pointRewardService.currentBalance(memberId);
 		boolean visitRecorded = false;
 		UUID visitId = null;
+		List<AwardedBadgeResult> newlyAwardedBadges = List.of();
 
 		if (participation.isCompleted()) {
 			PlaceEntity place = detail.place();
@@ -177,11 +191,17 @@ public class MissionSubmissionService {
 
 			events.publishEvent(
 					new MissionCompleted(memberId, command.tripId(), missionId, participation.getId(), occurredAt));
+
+			// badge Provider query가 방금 완료한 mission participation을 포함하도록 flush한 뒤
+			// 판정한다(ADR-003).
+			missionParticipations.flush();
+			newlyAwardedBadges = badgeEvaluationService.award(memberId, command.tripId(),
+					EnumSet.of(BadgeMetric.MISSION_COMPLETED_COUNT));
 		}
 
 		Integer remainingAttempts = remainingAttempts(mission.getMaxAttempts(), participation);
-		MissionSubmissionView result = new MissionSubmissionView(missionId, participation.isCompleted(),
-				remainingAttempts, rewardPoints, pointBalance, visitRecorded, visitId);
+		MissionSubmissionResult result = new MissionSubmissionResult(missionId, participation.isCompleted(),
+				remainingAttempts, rewardPoints, pointBalance, visitRecorded, visitId, newlyAwardedBadges);
 
 		String responseBody = writeResponse(result);
 		IdempotencyRequestEntity idempotencyRequest = IdempotencyRequestEntity.create(memberId, idempotencyKey,
@@ -253,7 +273,7 @@ public class MissionSubmissionService {
 		return participation.getStatus() == MissionStatus.AVAILABLE ? maxAttempts - participation.getAttemptCount() : 0;
 	}
 
-	private MissionSubmissionView replay(IdempotencyRequestEntity request, String requestHash) {
+	private MissionSubmissionResult replay(IdempotencyRequestEntity request, String requestHash) {
 		if (!OPERATION.equals(request.getOperation()) || !requestHash.equals(request.getRequestHash())) {
 			throw new IdempotencyKeyReusedException();
 		}
@@ -302,7 +322,7 @@ public class MissionSubmissionService {
 		digest.update(bytes);
 	}
 
-	private String writeResponse(MissionSubmissionView result) {
+	private String writeResponse(MissionSubmissionResult result) {
 		try {
 			return objectWriter.writeValueAsString(SuccessResponse.of(result));
 		} catch (JacksonException exception) {
@@ -310,16 +330,42 @@ public class MissionSubmissionService {
 		}
 	}
 
-	private MissionSubmissionView readResponse(String responseBody) {
+	private MissionSubmissionResult readResponse(String responseBody) {
 		try {
 			JsonNode data = required(objectReader.readTree(responseBody), "data");
-			return new MissionSubmissionView(UUID.fromString(requiredText(data, "missionId")),
+			return new MissionSubmissionResult(UUID.fromString(requiredText(data, "missionId")),
 					requiredBoolean(data, "completed"), nullableInt(data, "remainingAttempts"),
 					requiredInt(data, "rewardPoints"), requiredLong(data, "pointBalance"),
-					requiredBoolean(data, "visitRecorded"), nullableUuid(data, "visitId"));
+					requiredBoolean(data, "visitRecorded"), nullableUuid(data, "visitId"),
+					readBadges(required(data, "newlyAwardedBadges")));
 		} catch (JacksonException | IllegalArgumentException exception) {
 			throw new IllegalStateException("저장된 미션 제출 응답을 읽을 수 없습니다.", exception);
 		}
+	}
+
+	private List<AwardedBadgeResult> readBadges(JsonNode node) {
+		if (!node.isArray()) {
+			throw new IllegalStateException("저장된 미션 제출 응답의 배지 목록이 배열이 아닙니다.");
+		}
+		List<AwardedBadgeResult> badges = new ArrayList<>(node.size());
+		for (int index = 0; index < node.size(); index++) {
+			JsonNode badge = node.get(index);
+			badges.add(new AwardedBadgeResult(UUID.fromString(requiredText(badge, "badgeId")),
+					requiredText(badge, "name"), nullableText(badge, "imageKey"), requiredText(badge, "condition"),
+					Instant.parse(requiredText(badge, "earnedAt"))));
+		}
+		return badges;
+	}
+
+	/** 새로 획득한 배지의 image key를 요청 시점마다 새로 서명한 Presigned URL로 바꿔 최종 응답을 만든다. */
+	private MissionSubmissionView toView(MissionSubmissionResult result) {
+		List<AwardedBadgeView> badges = result.newlyAwardedBadges().stream()
+				.map(badge -> new AwardedBadgeView(badge.badgeId(), badge.name(),
+						badge.imageKey() != null ? publicImageUrlService.create(badge.imageKey()) : null,
+						badge.condition(), badge.earnedAt()))
+				.toList();
+		return new MissionSubmissionView(result.missionId(), result.completed(), result.remainingAttempts(),
+				result.rewardPoints(), result.pointBalance(), result.visitRecorded(), result.visitId(), badges);
 	}
 
 	private JsonNode required(JsonNode node, String field) {
@@ -360,6 +406,11 @@ public class MissionSubmissionService {
 		return value == null || value.isNull() ? null : UUID.fromString(value.stringValue());
 	}
 
+	private String nullableText(JsonNode node, String field) {
+		JsonNode value = node.get(field);
+		return value == null || value.isNull() ? null : value.stringValue();
+	}
+
 	public record MissionSubmissionCommand(UUID tripId, MissionType type, String choiceId, Boolean oxAnswer,
 			UUID photoId, LocationCommand location) {
 	}
@@ -367,7 +418,23 @@ public class MissionSubmissionService {
 	public record LocationCommand(double latitude, double longitude, Double accuracyMeters, OffsetDateTime capturedAt) {
 	}
 
+	/** 멱등성 레코드에 저장하는 semantic result다. 배지 image key는 만료되는 URL 대신 그대로 저장한다. */
+	private record MissionSubmissionResult(UUID missionId, boolean completed, Integer remainingAttempts,
+			int rewardPoints, long pointBalance, boolean visitRecorded, UUID visitId,
+			List<AwardedBadgeResult> newlyAwardedBadges) {
+		private MissionSubmissionResult {
+			newlyAwardedBadges = List.copyOf(newlyAwardedBadges);
+		}
+	}
+
 	public record MissionSubmissionView(UUID missionId, boolean completed, Integer remainingAttempts, int rewardPoints,
-			long pointBalance, boolean visitRecorded, UUID visitId) {
+			long pointBalance, boolean visitRecorded, UUID visitId, List<AwardedBadgeView> newlyAwardedBadges) {
+		public MissionSubmissionView {
+			newlyAwardedBadges = List.copyOf(newlyAwardedBadges);
+		}
+	}
+
+	/** 요청마다 새로 서명한 10분 유효 Presigned URL을 담은 응답용 배지 뷰다. */
+	public record AwardedBadgeView(UUID badgeId, String name, String imageUrl, String condition, Instant earnedAt) {
 	}
 }

--- a/src/main/java/com/buyeoon/mission/repository/MissionParticipationRepository.java
+++ b/src/main/java/com/buyeoon/mission/repository/MissionParticipationRepository.java
@@ -1,6 +1,7 @@
 package com.buyeoon.mission.repository;
 
 import com.buyeoon.mission.entity.MissionParticipationEntity;
+import com.buyeoon.mission.entity.MissionStatus;
 import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import java.util.UUID;
@@ -21,4 +22,12 @@ public interface MissionParticipationRepository extends JpaRepository<MissionPar
 	@Query("SELECT p FROM MissionParticipationEntity p WHERE p.tripId = :tripId AND p.missionId = :missionId")
 	Optional<MissionParticipationEntity> lockByTripIdAndMissionId(@Param("tripId") UUID tripId,
 			@Param("missionId") UUID missionId);
+
+	/**
+	 * 회원이 전체 여행에서 완료한 mission participation 수를 센다({@code MISSION_COMPLETED_COUNT},
+	 * ADR-003).
+	 */
+	@Query("SELECT COUNT(p) FROM MissionParticipationEntity p JOIN TripEntity t ON t.id = p.tripId "
+			+ "WHERE t.memberId = :memberId AND p.status = :status")
+	long countByMemberIdAndStatus(@Param("memberId") UUID memberId, @Param("status") MissionStatus status);
 }

--- a/src/main/java/com/buyeoon/notification/NotificationCreationService.java
+++ b/src/main/java/com/buyeoon/notification/NotificationCreationService.java
@@ -1,0 +1,24 @@
+package com.buyeoon.notification;
+
+import com.buyeoon.notification.entity.NotificationEntity;
+import com.buyeoon.notification.entity.NotificationType;
+import com.buyeoon.notification.repository.NotificationRepository;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+/** 다른 도메인이 회원에게 알림을 남길 때 사용하는 notification 도메인의 공개 seam이다. */
+@Service
+public class NotificationCreationService {
+
+	private final NotificationRepository notifications;
+
+	public NotificationCreationService(NotificationRepository notifications) {
+		this.notifications = notifications;
+	}
+
+	/** 새로 획득한 배지마다 {@code BADGE} 알림을 한 건 생성한다. */
+	public void createBadgeAwarded(UUID memberId, UUID badgeId, String badgeName) {
+		notifications.save(NotificationEntity.create(memberId, NotificationType.BADGE, "새로운 배지를 획득했어요!",
+				badgeName + " 배지를 획득했어요.", "BADGE", badgeId));
+	}
+}

--- a/src/test/java/com/buyeoon/mission/MissionBadgeAwardIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionBadgeAwardIntegrationTests.java
@@ -1,0 +1,471 @@
+package com.buyeoon.mission;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import java.net.URI;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/** UC-14 미션 완료로 배지를 획득하는 흐름의 통합 테스트다. */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class MissionBadgeAwardIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	// 시드 마이그레이션이 부여 지역에 장소·미션 예시 데이터를 채워두므로, 격리를 위해 남극 인근 좌표를
+	// 기준으로 테스트 데이터를 배치한다.
+	private static final double ORIGIN_LATITUDE = -75.0;
+	private static final double ORIGIN_LONGITUDE = 0.0;
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	private AuthenticatedMember member;
+
+	@BeforeAll
+	static void configureAwsCredentials() {
+		System.setProperty("aws.accessKeyId", "test-access-key");
+		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	@AfterAll
+	static void clearAwsCredentials() {
+		System.clearProperty("aws.accessKeyId");
+		System.clearProperty("aws.secretAccessKey");
+	}
+
+	@BeforeEach
+	void setUpMember() {
+		member = insertAuthenticatedMember();
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM notifications");
+		jdbcTemplate.update("DELETE FROM member_badges");
+		jdbcTemplate.update("DELETE FROM badge_conditions");
+		jdbcTemplate.update("DELETE FROM badges");
+		jdbcTemplate.update("DELETE FROM idempotency_requests");
+		jdbcTemplate.update("DELETE FROM point_transactions");
+		jdbcTemplate.update("DELETE FROM visit_records");
+		jdbcTemplate.update("DELETE FROM mission_submissions");
+		jdbcTemplate.update("DELETE FROM mission_participations");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate
+				.update("DELETE FROM mission_choices WHERE mission_id IN (SELECT id FROM missions WHERE place_id IN "
+						+ "(SELECT id FROM places WHERE ST_Y(location::geometry) < -70))");
+		jdbcTemplate.update(
+				"DELETE FROM missions WHERE place_id IN (SELECT id FROM places WHERE ST_Y(location::geometry) < -70)");
+		jdbcTemplate.update("DELETE FROM places WHERE ST_Y(location::geometry) < -70");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 첫 완료로 threshold를 충족하면 response에 배지가 포함되고 획득 이력과 알림이 같은 트랜잭션에 저장된다. */
+	@Test
+	@DisplayName("미션 완료로 threshold를 처음 충족하면 배지·획득 이력·알림이 함께 생긴다")
+	void firstMissionCompletionAwardsBadgeWithHistoryAndNotification() throws Exception {
+		UUID badgeId = insertBadge("탐험가", "public/badges/explorer.png", "미션 1회 완료");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("장소", 50);
+		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
+
+		MvcResult result = mockMvc.perform(submit(missionId, "award-first", oxRequest(tripId, true)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.newlyAwardedBadges", hasSize(1)))
+				.andExpect(jsonPath("$.data.newlyAwardedBadges[0].badgeId").value(badgeId.toString()))
+				.andExpect(jsonPath("$.data.newlyAwardedBadges[0].name").value("탐험가"))
+				.andExpect(jsonPath("$.data.newlyAwardedBadges[0].condition").value("미션 1회 완료"))
+				.andExpect(jsonPath("$.data.newlyAwardedBadges[0].earnedAt").isNotEmpty())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges[0].imageUrl").isNotEmpty()).andReturn();
+
+		JsonNode badge = objectMapper.readTree(result.getResponse().getContentAsString()).get("data")
+				.get("newlyAwardedBadges").get(0);
+		URI imageUri = URI.create(badge.get("imageUrl").stringValue());
+		assertThat(imageUri.getPath()).isEqualTo("/public/badges/explorer.png");
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM member_badges WHERE member_id = ? AND badge_id = ? AND trip_id = ?",
+				Integer.class, member.memberId(), badgeId, tripId)).isEqualTo(1);
+		Map<String, Object> notification = jdbcTemplate.queryForMap(
+				"SELECT title, body, target_type, target_id FROM notifications WHERE member_id = ? AND type = 'BADGE'",
+				member.memberId());
+		assertThat(notification.get("title")).isEqualTo("새로운 배지를 획득했어요!");
+		assertThat(notification.get("body")).isEqualTo("탐험가 배지를 획득했어요.");
+		assertThat(notification.get("target_type")).isEqualTo("BADGE");
+		assertThat(notification.get("target_id")).isEqualTo(badgeId);
+	}
+
+	/** GET /members/me/notifications로도 같은 배지 알림을 조회할 수 있다. */
+	@Test
+	@DisplayName("배지 획득 알림은 알림 목록 조회에서도 확인할 수 있다")
+	void badgeNotificationIsVisibleThroughNotificationsEndpoint() throws Exception {
+		UUID badgeId = insertBadge("탐험가", null, "미션 1회 완료");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("장소", 50);
+		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
+
+		mockMvc.perform(submit(missionId, "award-notif", oxRequest(tripId, true))).andExpect(status().isOk());
+
+		mockMvc.perform(get("/members/me/notifications").header("Authorization", "Bearer " + member.accessToken()))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items[0].type").value("BADGE"))
+				.andExpect(jsonPath("$.data.items[0].title").value("새로운 배지를 획득했어요!"))
+				.andExpect(jsonPath("$.data.items[0].body").value("탐험가 배지를 획득했어요."))
+				.andExpect(jsonPath("$.data.items[0].targetType").value("BADGE"))
+				.andExpect(jsonPath("$.data.items[0].targetId").value(badgeId.toString()));
+	}
+
+	/** 이미지가 없는 배지는 imageUrl이 null이다. */
+	@Test
+	@DisplayName("이미지가 없는 배지는 imageUrl이 null이다")
+	void badgeWithoutImageHasNullImageUrl() throws Exception {
+		UUID badgeId = insertBadge("무이미지 배지", null, "미션 1회 완료");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("장소", 50);
+		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
+
+		mockMvc.perform(submit(missionId, "award-no-image", oxRequest(tripId, true))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges[0].imageUrl").isEmpty());
+	}
+
+	/** threshold를 충족하지 못하면 newlyAwardedBadges는 빈 배열이다. */
+	@Test
+	@DisplayName("threshold를 충족하지 못하면 빈 배열을 반환한다")
+	void belowThresholdReturnsEmptyArray() throws Exception {
+		UUID badgeId = insertBadge("두 번 완료", null, "미션 2회 완료");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 2);
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("장소", 50);
+		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
+
+		mockMvc.perform(submit(missionId, "below-threshold", oxRequest(tripId, true))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges").isArray())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges", hasSize(0)));
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM member_badges WHERE badge_id = ?", Integer.class,
+				badgeId)).isZero();
+	}
+
+	/** 다른 여행에서 같은 미션을 다시 완료하면 lifetime 완료 수가 다시 늘어 threshold를 충족시킬 수 있다. */
+	@Test
+	@DisplayName("다른 여행의 같은 미션 재완료는 lifetime 완료 수를 다시 늘린다")
+	void completingSameMissionInAnotherTripIncreasesLifetimeCount() throws Exception {
+		UUID badgeId = insertBadge("두 번 완료", null, "미션 2회 완료");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 2);
+		UUID place = insertProjectedPlace("장소", 50);
+		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
+
+		UUID firstTrip = startTrip(member.memberId());
+		mockMvc.perform(submit(missionId, "lifetime-trip-1", oxRequest(firstTrip, true))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges", hasSize(0)));
+		endTrip(firstTrip);
+
+		UUID secondTrip = startTrip(member.memberId());
+		mockMvc.perform(submit(missionId, "lifetime-trip-2", oxRequest(secondTrip, true))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges", hasSize(1)))
+				.andExpect(jsonPath("$.data.newlyAwardedBadges[0].badgeId").value(badgeId.toString()));
+
+		assertThat(jdbcTemplate.queryForObject("SELECT trip_id FROM member_badges WHERE member_id = ? AND badge_id = ?",
+				UUID.class, member.memberId(), badgeId)).isEqualTo(secondTrip);
+	}
+
+	/** 여러 배지 조건을 함께 충족하면 badge ID 오름차순으로 반환한다. */
+	@Test
+	@DisplayName("여러 배지를 동시에 충족하면 badge ID 오름차순으로 반환한다")
+	void multipleBadgesAreAwardedInBadgeIdAscendingOrder() throws Exception {
+		UUID first = insertBadge("배지A", null, "미션 1회 완료");
+		UUID second = insertBadge("배지B", null, "미션 1회 완료");
+		insertCondition(first, "MISSION_COMPLETED_COUNT", 1);
+		insertCondition(second, "MISSION_COMPLETED_COUNT", 1);
+		// PostgreSQL의 uuid 오름차순은 Java UUID#compareTo와 다를 수 있으므로 DB 정렬 결과를 그대로 사용한다.
+		List<UUID> ascending = jdbcTemplate.queryForList("SELECT id FROM badges ORDER BY id ASC", UUID.class);
+		UUID expectedFirst = ascending.get(0);
+		UUID expectedSecond = ascending.get(1);
+
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("장소", 50);
+		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
+
+		mockMvc.perform(submit(missionId, "multi-badge", oxRequest(tripId, true))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges", hasSize(2)))
+				.andExpect(jsonPath("$.data.newlyAwardedBadges[0].badgeId").value(expectedFirst.toString()))
+				.andExpect(jsonPath("$.data.newlyAwardedBadges[1].badgeId").value(expectedSecond.toString()));
+	}
+
+	/** 이미 획득한 배지는 다시 지급되거나 알림을 다시 만들지 않고 최초 여행 연결을 유지한다. */
+	@Test
+	@DisplayName("이미 획득한 배지는 다시 지급되지 않고 최초 여행 연결을 유지한다")
+	void alreadyEarnedBadgeIsNotAwardedAgain() throws Exception {
+		UUID badgeId = insertBadge("탐험가", null, "미션 1회 완료");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
+		UUID place = insertProjectedPlace("장소", 50);
+
+		UUID firstTrip = startTrip(member.memberId());
+		UUID firstMission = insertOxMission(place, "미션1", 100, null, true);
+		mockMvc.perform(submit(firstMission, "earn-once", oxRequest(firstTrip, true))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges", hasSize(1)));
+		endTrip(firstTrip);
+
+		UUID secondTrip = startTrip(member.memberId());
+		UUID secondMission = insertOxMission(place, "미션2", 100, null, true);
+		mockMvc.perform(submit(secondMission, "earn-again", oxRequest(secondTrip, true))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges", hasSize(0)));
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM member_badges WHERE badge_id = ?", Integer.class,
+				badgeId)).isEqualTo(1);
+		assertThat(jdbcTemplate.queryForObject("SELECT trip_id FROM member_badges WHERE badge_id = ?", UUID.class,
+				badgeId)).isEqualTo(firstTrip);
+		assertThat(
+				jdbcTemplate.queryForObject("SELECT count(*) FROM notifications WHERE type = 'BADGE'", Integer.class))
+				.isEqualTo(1);
+	}
+
+	/** 지급이 중단된 배지는 조건을 충족해도 지급하지 않는다. */
+	@Test
+	@DisplayName("지급이 중단된 배지는 조건을 충족해도 지급하지 않는다")
+	void retiredBadgeIsNeverAwarded() throws Exception {
+		UUID badgeId = insertBadge("퇴역 배지", null, "미션 1회 완료");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
+		jdbcTemplate.update("UPDATE badges SET retired_at = now() WHERE id = ?", badgeId);
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("장소", 50);
+		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
+
+		mockMvc.perform(submit(missionId, "retired-badge", oxRequest(tripId, true))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges", hasSize(0)));
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM member_badges WHERE badge_id = ?", Integer.class,
+				badgeId)).isZero();
+	}
+
+	/** 같은 배지 조건을 동시에 충족해도 획득 이력과 알림은 한 번만 생성된다. */
+	@Test
+	@DisplayName("동시에 같은 배지 조건을 충족해도 획득 이력과 알림은 한 번만 생성된다")
+	void concurrentCompletionsAwardBadgeExactlyOnce() throws Exception {
+		UUID badgeId = insertBadge("탐험가", null, "미션 1회 완료");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("장소", 50);
+		UUID firstMission = insertOxMission(place, "미션1", 100, null, true);
+		UUID secondMission = insertOxMission(place, "미션2", 100, null, true);
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+
+		try {
+			Future<MvcResult> first = executor.submit(
+					() -> concurrentSubmit(firstMission, "concurrent-badge-a", oxRequest(tripId, true), ready, start));
+			Future<MvcResult> second = executor.submit(
+					() -> concurrentSubmit(secondMission, "concurrent-badge-b", oxRequest(tripId, true), ready, start));
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			MvcResult firstResult = first.get(10, TimeUnit.SECONDS);
+			MvcResult secondResult = second.get(10, TimeUnit.SECONDS);
+			assertThat(firstResult.getResponse().getStatus()).isEqualTo(200);
+			assertThat(secondResult.getResponse().getStatus()).isEqualTo(200);
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM member_badges WHERE badge_id = ?", Integer.class,
+				badgeId)).isEqualTo(1);
+		assertThat(
+				jdbcTemplate.queryForObject("SELECT count(*) FROM notifications WHERE type = 'BADGE'", Integer.class))
+				.isEqualTo(1);
+	}
+
+	/** 같은 멱등성 키의 재요청은 최초 지급 결과를 재사용하고 배지·알림을 다시 만들지 않지만 이미지 URL은 새로 생성한다. */
+	@Test
+	@DisplayName("같은 멱등성 키의 재요청은 최초 지급 결과를 재사용하고 부작용을 반복하지 않는다")
+	void idempotentReplayReusesAwardResultWithoutDuplicatingSideEffects() throws Exception {
+		UUID badgeId = insertBadge("탐험가", "public/badges/explorer.png", "미션 1회 완료");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("장소", 50);
+		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
+		String key = "replay-badge-key";
+		String body = oxRequest(tripId, true);
+
+		MvcResult firstResult = mockMvc.perform(submit(missionId, key, body)).andExpect(status().isOk()).andReturn();
+		MvcResult retriedResult = mockMvc.perform(submit(missionId, key, body)).andExpect(status().isOk()).andReturn();
+
+		JsonNode firstBadge = objectMapper.readTree(firstResult.getResponse().getContentAsString()).get("data")
+				.get("newlyAwardedBadges").get(0);
+		JsonNode retriedBadge = objectMapper.readTree(retriedResult.getResponse().getContentAsString()).get("data")
+				.get("newlyAwardedBadges").get(0);
+		assertThat(retriedBadge.get("badgeId").stringValue()).isEqualTo(firstBadge.get("badgeId").stringValue());
+		assertThat(retriedBadge.get("earnedAt").stringValue()).isEqualTo(firstBadge.get("earnedAt").stringValue());
+		assertThat(URI.create(retriedBadge.get("imageUrl").stringValue()).getPath())
+				.isEqualTo(URI.create(firstBadge.get("imageUrl").stringValue()).getPath());
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM member_badges WHERE badge_id = ?", Integer.class,
+				badgeId)).isEqualTo(1);
+		assertThat(
+				jdbcTemplate.queryForObject("SELECT count(*) FROM notifications WHERE type = 'BADGE'", Integer.class))
+				.isEqualTo(1);
+	}
+
+	private MvcResult concurrentSubmit(UUID missionId, String key, String body, CountDownLatch ready,
+			CountDownLatch start) throws Exception {
+		ready.countDown();
+		if (!start.await(5, TimeUnit.SECONDS)) {
+			throw new IllegalStateException("동시 요청 시작 신호를 받지 못했습니다.");
+		}
+		return mockMvc.perform(submit(missionId, key, body)).andReturn();
+	}
+
+	private MockHttpServletRequestBuilder submit(UUID missionId, String idempotencyKey, String body) {
+		return post("/missions/{missionId}/submissions", missionId)
+				.header("Authorization", "Bearer " + member.accessToken()).header("Idempotency-Key", idempotencyKey)
+				.contentType(MediaType.APPLICATION_JSON).content(body);
+	}
+
+	private String oxRequest(UUID tripId, boolean oxAnswer) {
+		return "{\"tripId\":\"" + tripId + "\",\"type\":\"OX\",\"oxAnswer\":" + oxAnswer + ",\"location\":"
+				+ locationJson() + "}";
+	}
+
+	private String locationJson() {
+		return "{\"latitude\":" + ORIGIN_LATITUDE + ",\"longitude\":" + ORIGIN_LONGITUDE
+				+ ",\"accuracyMeters\":5.5,\"capturedAt\":\"2026-08-12T15:30:00+09:00\"}";
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private UUID startTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status) VALUES (?, ?, 'IN_PROGRESS')", tripId, memberId);
+		return tripId;
+	}
+
+	private void endTrip(UUID tripId) {
+		jdbcTemplate.update("UPDATE trips SET status = 'ENDED', ended_at = now() WHERE id = ?", tripId);
+	}
+
+	private UUID insertPlace(String name, double latitude, double longitude) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate
+				.update("INSERT INTO places (id, category, name, location) VALUES (?, 'HERITAGE'::place_category, ?, "
+						+ "ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography)", id, name, longitude, latitude);
+		return id;
+	}
+
+	/**
+	 * 원점에서 지정한 거리(m)만큼 떨어진 지점에 장소를 만든다. 삽입과 조회가 같은 PostGIS geodesic 계산을 쓰므로 왕복 오차가
+	 * 없다.
+	 */
+	private UUID insertProjectedPlace(String name, double distanceMeters) {
+		Map<String, Object> point = jdbcTemplate.queryForMap(
+				"SELECT ST_Y(pt::geometry) AS lat, ST_X(pt::geometry) AS lon FROM "
+						+ "(SELECT ST_Project(ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?, 0) AS pt) t",
+				ORIGIN_LONGITUDE, ORIGIN_LATITUDE, distanceMeters);
+		return insertPlace(name, ((Number) point.get("lat")).doubleValue(), ((Number) point.get("lon")).doubleValue());
+	}
+
+	private UUID insertOxMission(UUID placeId, String title, int rewardPoints, Integer maxAttempts,
+			boolean correctAnswer) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO missions (id, place_id, type, title, description, reward_points, max_attempts, "
+						+ "ox_correct_answer) VALUES (?, ?, 'OX'::mission_type, ?, '설명', ?, ?, ?)",
+				id, placeId, title, rewardPoints, maxAttempts, correctAnswer);
+		return id;
+	}
+
+	private UUID insertBadge(String name, String imageKey, String conditionText) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO badges (id, category, name, description, image_key, condition_text) "
+						+ "VALUES (?, 'EXPLORATION'::badge_category, ?, '설명', ?, ?)",
+				id, name, imageKey, conditionText);
+		return id;
+	}
+
+	private void insertCondition(UUID badgeId, String metricKey, long threshold) {
+		jdbcTemplate.update("INSERT INTO badge_conditions (badge_id, metric_key, threshold) VALUES (?, ?, ?)", badgeId,
+				metricKey, threshold);
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("storage.images.bucket", () -> "buyeoon-test-images");
+		registry.add("storage.images.region", () -> "ap-northeast-2");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## Summary
- 미션 완료 시 badge 도메인의 공개 seam(`BadgeEvaluationService`)을 동기 호출해 `MISSION_COMPLETED_COUNT` 조건을 판정하고, 처음 충족한 배지를 badge ID 오름차순으로 지급한다(ADR-003).
- 새 배지·`member_badges` 획득 이력·`BADGE` 알림을 mission completion과 같은 트랜잭션으로 확정하며, `submitMission` 응답에 `newlyAwardedBadges`를 추가한다.
- Idempotency 레코드에는 image key만 저장하고, 최초 응답과 replay 모두 요청 시점마다 10분 유효 Presigned URL을 새로 생성한다(만료 URL을 영속 데이터에 저장하지 않음).
- Mission 도메인에 `MissionCompletionMetricQuery` 공개 query seam을, notification 도메인에 `NotificationCreationService` 공개 seam을 추가했다.
- 범위 제외: Heritage/포인트 기부 metric, 복합 배지, daily reconciliation, startup catalog validation, 초기 catalog seed, FCM push, UC-18 조회 API.

## Test plan
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh` (checkstyle, spotbugs, 전체 `./gradlew test`)
- [x] `MissionBadgeAwardIntegrationTests` 10건: 최초 획득, 알림 조회, 이미지 없는 배지, threshold 미달, 다른 여행 재완료 시 카운트 재증가, 여러 배지 badge ID 오름차순, 이미 획득·retired 배지 재지급 방지, 동시 요청 시 1회만 지급, idempotent replay(URL만 재생성)
- [ ] `./scripts/test/docker-build.sh` — 로컬 `.env`에 `APPLE_CLIENT_ID` 누락으로 실패(이번 변경과 무관한 기존 환경 이슈)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vNwfTUR1GQJdsitCZWhdm