### PR TITLE
feat: UC-23 여행 끝내기 구현

### DIFF
--- a/src/main/java/com/buyeoon/trip/TripController.java
+++ b/src/main/java/com/buyeoon/trip/TripController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -23,9 +24,11 @@ import tools.jackson.databind.JsonNode;
 public class TripController {
 
 	private final TripStarter tripStart;
+	private final TripEnder tripEnd;
 
-	public TripController(TripStarter tripStart) {
+	public TripController(TripStarter tripStart, TripEnder tripEnd) {
 		this.tripStart = tripStart;
+		this.tripEnd = tripEnd;
 	}
 
 	@PostMapping("/trips")
@@ -35,6 +38,14 @@ public class TripController {
 		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
 		TripView trip = tripStart.start(memberId, idempotencyKey, parseRequest(request));
 		return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.of(trip));
+	}
+
+	@PostMapping("/trips/{tripId}/end")
+	public ResponseEntity<SuccessResponse<TripView>> end(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID tripId,
+			@RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		TripView trip = tripEnd.end(memberId, tripId, idempotencyKey);
+		return ResponseEntity.ok(SuccessResponse.of(trip));
 	}
 
 	private TripStartCommand parseRequest(JsonNode request) {

--- a/src/main/java/com/buyeoon/trip/TripEndService.java
+++ b/src/main/java/com/buyeoon/trip/TripEndService.java
@@ -1,0 +1,156 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.common.entity.IdempotencyRequestEntity;
+import com.buyeoon.common.entity.IdempotencyRequestId;
+import com.buyeoon.member.application.IdempotencyKeyReusedException;
+import com.buyeoon.member.application.InvalidStateTransitionException;
+import com.buyeoon.member.application.ResourceNotFoundException;
+import com.buyeoon.trip.TripStartService.TripView;
+import com.buyeoon.trip.entity.TripEntity;
+import com.buyeoon.trip.entity.TripStatus;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.ObjectWriter;
+
+/** UC-23 여행 종료 커맨드 서비스다. TripStartService의 멱등성/락 패턴을 재사용한다. */
+@Service
+public class TripEndService implements TripEnder {
+
+	private static final String OPERATION = "END_TRIP";
+	private static final Duration RETENTION = Duration.ofHours(24);
+	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+
+	private final JdbcOperations jdbcOperations;
+	private final TransactionTemplate transactions;
+	private final TripRepository trips;
+	private final IdempotencyRequestRepository idempotencyRequests;
+	private final ObjectReader objectReader;
+	private final ObjectWriter objectWriter;
+
+	public TripEndService(JdbcOperations jdbcOperations, PlatformTransactionManager transactionManager,
+			TripRepository trips, IdempotencyRequestRepository idempotencyRequests, ObjectMapper objectMapper) {
+		this.jdbcOperations = jdbcOperations;
+		this.transactions = new TransactionTemplate(transactionManager);
+		this.trips = trips;
+		this.idempotencyRequests = idempotencyRequests;
+		this.objectReader = objectMapper.reader();
+		this.objectWriter = objectMapper.writer();
+	}
+
+	@Override
+	public TripView end(UUID memberId, UUID tripId, String idempotencyKey) {
+		validateIdempotencyKey(idempotencyKey);
+		return Objects.requireNonNull(
+				transactions.execute(status -> endInTransaction(memberId, tripId, idempotencyKey)),
+				"여행 종료 트랜잭션 결과가 없습니다.");
+	}
+
+	private TripView endInTransaction(UUID memberId, UUID tripId, String idempotencyKey) {
+		Instant endedAt = clockTimestamp();
+		String requestHash = tripId.toString();
+
+		IdempotencyRequestId idempotencyId = new IdempotencyRequestId(memberId, idempotencyKey);
+		Optional<IdempotencyRequestEntity> existingRequest = idempotencyRequests.findById(idempotencyId);
+		if (existingRequest.isPresent()) {
+			IdempotencyRequestEntity request = existingRequest.get();
+			if (!request.getExpiresAt().isAfter(endedAt)) {
+				idempotencyRequests.delete(request);
+			} else {
+				return replay(request, requestHash);
+			}
+		}
+
+		TripEntity trip = trips.lockByIdAndMemberId(tripId, memberId).orElseThrow(ResourceNotFoundException::new);
+		if (trip.getStatus() != TripStatus.IN_PROGRESS) {
+			throw new InvalidStateTransitionException();
+		}
+
+		trip.end(endedAt);
+
+		TripView result = new TripView(trip.getId(), trip.getStatus(), trip.getStartedAt().atZone(ASIA_SEOUL),
+				trip.getEndedAt().atZone(ASIA_SEOUL), null);
+		String responseBody = writeResponse(result);
+		IdempotencyRequestEntity idempotencyRequest = IdempotencyRequestEntity.create(memberId, idempotencyKey,
+				OPERATION, requestHash, endedAt.plus(RETENTION));
+		idempotencyRequest.complete(200, responseBody);
+		idempotencyRequests.save(idempotencyRequest);
+		return result;
+	}
+
+	private TripView replay(IdempotencyRequestEntity request, String requestHash) {
+		if (!OPERATION.equals(request.getOperation()) || !requestHash.equals(request.getRequestHash())) {
+			throw new IdempotencyKeyReusedException();
+		}
+		if (!Integer.valueOf(200).equals(request.getResponseStatus()) || request.getResponseBody() == null) {
+			throw new IllegalStateException("완료되지 않은 멱등성 요청이 남아 있습니다.");
+		}
+		return readResponse(request.getResponseBody());
+	}
+
+	private Instant clockTimestamp() {
+		return Objects.requireNonNull(jdbcOperations.queryForObject("SELECT clock_timestamp()", Timestamp.class))
+				.toInstant();
+	}
+
+	private void validateIdempotencyKey(String idempotencyKey) {
+		if (idempotencyKey == null || idempotencyKey.length() < 8 || idempotencyKey.length() > 128) {
+			throw new InvalidTripStartRequestException();
+		}
+	}
+
+	private String writeResponse(TripView result) {
+		try {
+			return objectWriter.writeValueAsString(SuccessResponse.of(result));
+		} catch (JacksonException exception) {
+			throw new IllegalStateException("여행 종료 응답을 저장할 수 없습니다.", exception);
+		}
+	}
+
+	private TripView readResponse(String responseBody) {
+		try {
+			JsonNode data = required(objectReader.readTree(responseBody), "data");
+			return new TripView(UUID.fromString(requiredText(data, "tripId")),
+					TripStatus.valueOf(requiredText(data, "status")),
+					ZonedDateTime.parse(requiredText(data, "startedAt")), nullableDateTime(data, "endedAt"),
+					nullableDateTime(data, "settledAt"));
+		} catch (JacksonException | IllegalArgumentException exception) {
+			throw new IllegalStateException("저장된 여행 종료 응답을 읽을 수 없습니다.", exception);
+		}
+	}
+
+	private ZonedDateTime nullableDateTime(JsonNode data, String field) {
+		JsonNode value = data.get(field);
+		return value == null || value.isNull() ? null : ZonedDateTime.parse(value.stringValue());
+	}
+
+	private JsonNode required(JsonNode node, String field) {
+		JsonNode value = node == null ? null : node.get(field);
+		if (value == null) {
+			throw new IllegalStateException("저장된 여행 종료 응답 필드가 누락되었습니다: " + field);
+		}
+		return value;
+	}
+
+	private String requiredText(JsonNode node, String field) {
+		JsonNode value = required(node, field);
+		if (!value.isString()) {
+			throw new IllegalStateException("저장된 여행 종료 응답 필드가 문자열이 아닙니다: " + field);
+		}
+		return value.stringValue();
+	}
+}

--- a/src/main/java/com/buyeoon/trip/TripEnder.java
+++ b/src/main/java/com/buyeoon/trip/TripEnder.java
@@ -1,0 +1,9 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.trip.TripStartService.TripView;
+import java.util.UUID;
+
+public interface TripEnder {
+
+	TripView end(UUID memberId, UUID tripId, String idempotencyKey);
+}

--- a/src/main/java/com/buyeoon/trip/TripExceptionHandler.java
+++ b/src/main/java/com/buyeoon/trip/TripExceptionHandler.java
@@ -5,6 +5,7 @@ import com.buyeoon.member.application.IdempotencyKeyReusedException;
 import com.buyeoon.member.application.InvalidStateTransitionException;
 import com.buyeoon.member.application.OutsideBuyeoException;
 import com.buyeoon.member.application.RequiredTermsNotAgreedException;
+import com.buyeoon.member.application.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -48,5 +49,11 @@ public class TripExceptionHandler {
 	@ResponseStatus(HttpStatus.CONFLICT)
 	public ErrorResponse handleIdempotencyKeyReused() {
 		return ErrorResponse.idempotencyKeyReused();
+	}
+
+	@ExceptionHandler(ResourceNotFoundException.class)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public ErrorResponse handleResourceNotFound() {
+		return ErrorResponse.resourceNotFound();
 	}
 }

--- a/src/main/java/com/buyeoon/trip/TripRepository.java
+++ b/src/main/java/com/buyeoon/trip/TripRepository.java
@@ -19,4 +19,8 @@ public interface TripRepository extends JpaRepository<TripEntity, UUID> {
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT t FROM TripEntity t WHERE t.memberId = :memberId AND t.status = :status")
 	Optional<TripEntity> lockByMemberIdAndStatus(@Param("memberId") UUID memberId, @Param("status") TripStatus status);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT t FROM TripEntity t WHERE t.id = :id AND t.memberId = :memberId")
+	Optional<TripEntity> lockByIdAndMemberId(@Param("id") UUID id, @Param("memberId") UUID memberId);
 }

--- a/src/main/java/com/buyeoon/trip/entity/TripEntity.java
+++ b/src/main/java/com/buyeoon/trip/entity/TripEntity.java
@@ -48,4 +48,10 @@ public class TripEntity {
 		trip.memberId = memberId;
 		return trip;
 	}
+
+	/** 진행 중인 여행을 종료 상태로 전이하고 종료 시각을 기록한다. */
+	public void end(Instant endedAt) {
+		this.status = TripStatus.ENDED;
+		this.endedAt = endedAt;
+	}
 }

--- a/src/test/java/com/buyeoon/trip/TripEndIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/TripEndIntegrationTests.java
@@ -1,0 +1,231 @@
+package com.buyeoon.trip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class TripEndIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM idempotency_requests");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 진행 중인 여행을 종료하면 상태가 ENDED로 바뀌고 endedAt이 기록된다. */
+	@Test
+	@DisplayName("진행 중인 여행을 종료하면 ENDED로 전이하고 endedAt을 기록한다")
+	void endsInProgressTrip() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId());
+
+		performEnd(member, tripId, "end-trip-key-01").andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.tripId").value(tripId.toString()))
+				.andExpect(jsonPath("$.data.status").value("ENDED")).andExpect(jsonPath("$.data.endedAt").isString())
+				.andExpect(jsonPath("$.data.settledAt").isEmpty());
+
+		assertThat(jdbcTemplate.queryForObject("SELECT status::text FROM trips WHERE id = ?", String.class, tripId))
+				.isEqualTo("ENDED");
+		assertThat(jdbcTemplate.queryForObject("SELECT ended_at FROM trips WHERE id = ?", Timestamp.class, tripId))
+				.isNotNull();
+	}
+
+	/** 존재하지 않는 tripId로 종료를 요청하면 404를 반환한다. */
+	@Test
+	@DisplayName("존재하지 않는 tripId는 404를 반환한다")
+	void nonExistentTripReturnsNotFound() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+
+		performEnd(member, UUID.randomUUID(), "end-trip-key-03").andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 다른 회원 소유의 tripId로 종료를 요청하면 404를 반환한다. */
+	@Test
+	@DisplayName("타 회원 소유 tripId는 404를 반환한다")
+	void otherMembersTripReturnsNotFound() throws Exception {
+		AuthenticatedMember owner = insertAuthenticatedMember();
+		AuthenticatedMember requester = insertAuthenticatedMember();
+		UUID tripId = insertTrip(owner.memberId());
+
+		performEnd(requester, tripId, "end-trip-key-04").andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 인증되지 않은 요청은 401을 반환한다. */
+	@Test
+	@DisplayName("인증되지 않은 요청은 401을 반환한다")
+	void unauthenticatedRequestReturnsUnauthorized() throws Exception {
+		mockMvc.perform(post("/trips/" + UUID.randomUUID() + "/end").header("Idempotency-Key", "unauth-end-key"))
+				.andExpect(status().isUnauthorized()).andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** Idempotency-Key 없이 요청하면 400을 반환한다. */
+	@Test
+	@DisplayName("Idempotency-Key가 없으면 400을 반환한다")
+	void missingIdempotencyKeyReturnsBadRequest() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId());
+
+		performEnd(member, tripId, null).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	/** 같은 여행을 같은 멱등성 키로 다시 요청하면 최초 성공 응답을 그대로 반환한다. */
+	@Test
+	@DisplayName("같은 멱등성 키의 재요청은 최초 응답을 재사용한다")
+	void sameIdempotentRequestReturnsFirstResponse() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId());
+		String key = "end-trip-key-05";
+
+		String first = performEnd(member, tripId, key).andExpect(status().isOk()).andReturn().getResponse()
+				.getContentAsString();
+		String retried = performEnd(member, tripId, key).andExpect(status().isOk()).andReturn().getResponse()
+				.getContentAsString();
+
+		assertThat(retried).isEqualTo(first);
+	}
+
+	/** 이미 종료된 여행을 다른 멱등성 키로 다시 종료하면 409를 반환한다. */
+	@Test
+	@DisplayName("이미 종료된 여행을 다른 키로 재종료하면 409를 반환한다")
+	void endingAlreadyEndedTripWithDifferentKeyConflicts() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId());
+		performEnd(member, tripId, "end-trip-key-06a").andExpect(status().isOk());
+
+		performEnd(member, tripId, "end-trip-key-06b").andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("INVALID_STATE_TRANSITION"));
+	}
+
+	/** 같은 여행에 대한 동시 종료 요청은 하나만 성공한다. */
+	@Test
+	@DisplayName("동시 종료 요청은 하나만 성공한다")
+	void concurrentEndRequestsSucceedOnce() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId());
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+
+		try {
+			Future<MvcResult> first = executor
+					.submit(() -> concurrentEnd(member, tripId, "concurrent-end-a", ready, start));
+			Future<MvcResult> second = executor
+					.submit(() -> concurrentEnd(member, tripId, "concurrent-end-b", ready, start));
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			MvcResult firstResult = first.get(10, TimeUnit.SECONDS);
+			MvcResult secondResult = second.get(10, TimeUnit.SECONDS);
+			int[] statuses = {firstResult.getResponse().getStatus(), secondResult.getResponse().getStatus()};
+			assertThat(statuses).containsExactlyInAnyOrder(200, 409);
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertThat(jdbcTemplate.queryForObject("SELECT status::text FROM trips WHERE id = ?", String.class, tripId))
+				.isEqualTo("ENDED");
+	}
+
+	private MvcResult concurrentEnd(AuthenticatedMember member, UUID tripId, String key, CountDownLatch ready,
+			CountDownLatch start) throws Exception {
+		ready.countDown();
+		if (!start.await(5, TimeUnit.SECONDS)) {
+			throw new IllegalStateException("동시 요청 시작 신호를 받지 못했습니다.");
+		}
+		return performEnd(member, tripId, key).andReturn();
+	}
+
+	private ResultActions performEnd(AuthenticatedMember member, UUID tripId, String key) throws Exception {
+		var request = post("/trips/" + tripId + "/end").header("Authorization", "Bearer " + member.accessToken());
+		if (key != null) {
+			request.header("Idempotency-Key", key);
+		}
+		return mockMvc.perform(request);
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private UUID insertTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status) VALUES (?, ?, 'IN_PROGRESS')", tripId, memberId);
+		return tripId;
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## 변경 내용

- `POST /trips/{tripId}/end`를 신규 구현했습니다.
- `TripEntity.end()`로 IN_PROGRESS → ENDED 상태 전이와 `endedAt` 기록을 처리합니다.
- `TripEndService`가 `TripStartService`와 동일한 멱등성(24시간 보관)·트랜잭션·`PESSIMISTIC_WRITE` 락 패턴을 재사용합니다.
- `TripRepository.lockByIdAndMemberId`로 tripId+memberId 기준 락 조회를 추가했습니다.
- `ResourceNotFoundException`을 404로 매핑하는 핸들러를 추가했습니다.

## 설계 결정

- 소유권 미검증(존재하지 않거나 타 회원 소유)은 404, tripId가 존재하고 본인 소유이지만 IN_PROGRESS가 아닌 경우(이미 종료됨 등)는 409로 구분했습니다. UC-23 유즈케이스 문서의 예외 흐름이 "진행 중인 여행 없음"과 "이미 종료된 여행 재종료"를 동일하게 409로 정의하고 있어 이 매핑을 따랐습니다.

## 영향

- 응답 스키마는 기존 `TripEnvelope`(tripId, status, startedAt, endedAt, settledAt)를 그대로 재사용합니다.
- 종료 사유 구분, 포인트 정산(UC-24), 방문 요약(UC-17)은 범위에서 제외했습니다.

## 검증

- `TripEndIntegrationTests` (정상 종료, 404 2종, 401, 400, 멱등성 replay, 409, 동시 요청 직렬화)
- `TripStartIntegrationTests` 회귀 없음 확인
- `./scripts/test/format.sh`
- `./scripts/test/static-check.sh`
- `./scripts/test/test.sh`
- `./scripts/test/docker-build.sh`

Closes #132