### PR TITLE
feat: UC-17 여행 통계 조회 구현 (#100)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ application-local.properties
 temp/
 
 _workspace/
+
+.omc/

--- a/src/main/java/com/buyeoon/trip/TripController.java
+++ b/src/main/java/com/buyeoon/trip/TripController.java
@@ -1,6 +1,7 @@
 package com.buyeoon.trip;
 
 import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.trip.TripQueryService.TripStatisticsView;
 import com.buyeoon.trip.TripStartService.LocationCommand;
 import com.buyeoon.trip.TripStartService.TripStartCommand;
 import com.buyeoon.trip.TripStartService.TripView;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,10 +27,12 @@ public class TripController {
 
 	private final TripStarter tripStart;
 	private final TripEnder tripEnd;
+	private final TripQueryService tripQuery;
 
-	public TripController(TripStarter tripStart, TripEnder tripEnd) {
+	public TripController(TripStarter tripStart, TripEnder tripEnd, TripQueryService tripQuery) {
 		this.tripStart = tripStart;
 		this.tripEnd = tripEnd;
+		this.tripQuery = tripQuery;
 	}
 
 	@PostMapping("/trips")
@@ -46,6 +50,23 @@ public class TripController {
 		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
 		TripView trip = tripEnd.end(memberId, tripId, idempotencyKey);
 		return ResponseEntity.ok(SuccessResponse.of(trip));
+	}
+
+	@GetMapping("/trips/{tripId}/statistics")
+	public ResponseEntity<SuccessResponse<TripStatisticsResponse>> statistics(@AuthenticationPrincipal Jwt jwt,
+			@PathVariable UUID tripId) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		TripStatisticsView statistics = tripQuery.getStatistics(memberId, tripId);
+		return ResponseEntity.ok(SuccessResponse.of(TripStatisticsResponse.from(statistics)));
+	}
+
+	/** 이동 거리·소모 칼로리는 MVP에서 계산하지 않으므로 항상 null이다. */
+	private record TripStatisticsResponse(UUID tripId, Double distanceKm, long visitedPlaceCount, long durationMinutes,
+			Integer caloriesKcal) {
+		static TripStatisticsResponse from(TripStatisticsView statistics) {
+			return new TripStatisticsResponse(statistics.tripId(), null, statistics.visitedPlaceCount(),
+					statistics.durationMinutes(), null);
+		}
 	}
 
 	private TripStartCommand parseRequest(JsonNode request) {

--- a/src/main/java/com/buyeoon/trip/TripQueryService.java
+++ b/src/main/java/com/buyeoon/trip/TripQueryService.java
@@ -1,7 +1,11 @@
 package com.buyeoon.trip;
 
+import com.buyeoon.member.application.ResourceNotFoundException;
 import com.buyeoon.trip.entity.TripEntity;
 import com.buyeoon.trip.entity.TripStatus;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -13,9 +17,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class TripQueryService {
 
 	private final TripRepository tripRepository;
+	private final VisitRecordRepository visitRecordRepository;
 
-	public TripQueryService(TripRepository tripRepository) {
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public TripQueryService(TripRepository tripRepository, VisitRecordRepository visitRecordRepository) {
 		this.tripRepository = tripRepository;
+		this.visitRecordRepository = visitRecordRepository;
 	}
 
 	public boolean hasActiveTrip(UUID memberId) {
@@ -25,5 +32,18 @@ public class TripQueryService {
 	/** 요청 회원이 소유한 여행의 현재 상태를 조회한다. 소유한 여행이 없으면 빈 값을 반환한다. */
 	public Optional<TripStatus> findOwnedTripStatus(UUID memberId, UUID tripId) {
 		return tripRepository.findByIdAndMemberId(tripId, memberId).map(TripEntity::getStatus);
+	}
+
+	/** 요청 회원이 소유한 여행의 통계를 계산한다. 소유하지 않았거나 존재하지 않으면 404 예외를 던진다. */
+	public TripStatisticsView getStatistics(UUID memberId, UUID tripId) {
+		TripEntity trip = tripRepository.findByIdAndMemberId(tripId, memberId)
+				.orElseThrow(ResourceNotFoundException::new);
+		Instant until = trip.getStatus() == TripStatus.IN_PROGRESS ? Instant.now() : trip.getEndedAt();
+		long durationMinutes = Duration.between(trip.getStartedAt(), until).toMinutes();
+		long visitedPlaceCount = visitRecordRepository.countByTripId(tripId);
+		return new TripStatisticsView(tripId, visitedPlaceCount, durationMinutes);
+	}
+
+	public record TripStatisticsView(UUID tripId, long visitedPlaceCount, long durationMinutes) {
 	}
 }

--- a/src/main/java/com/buyeoon/trip/VisitRecordRepository.java
+++ b/src/main/java/com/buyeoon/trip/VisitRecordRepository.java
@@ -13,4 +13,6 @@ public interface VisitRecordRepository extends JpaRepository<VisitRecordEntity, 
 			+ "ON CONFLICT (trip_id, place_id) DO NOTHING RETURNING id", nativeQuery = true)
 	Optional<UUID> insertIfAbsent(@Param("tripId") UUID tripId, @Param("missionId") UUID missionId,
 			@Param("placeId") UUID placeId);
+
+	long countByTripId(UUID tripId);
 }

--- a/src/test/java/com/buyeoon/trip/TripStatisticsIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/TripStatisticsIntegrationTests.java
@@ -1,0 +1,221 @@
+package com.buyeoon.trip;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class TripStatisticsIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM visit_records");
+		jdbcTemplate.update("DELETE FROM missions");
+		jdbcTemplate.update("DELETE FROM places");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 존재하지 않는 tripId로 조회하면 404를 반환한다. */
+	@Test
+	@DisplayName("존재하지 않는 tripId는 404를 반환한다")
+	void nonExistentTripReturnsNotFound() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+
+		performGet(member, UUID.randomUUID()).andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 다른 회원 소유의 tripId로 조회하면 404를 반환한다. */
+	@Test
+	@DisplayName("타 회원 소유 tripId는 404를 반환한다")
+	void otherMembersTripReturnsNotFound() throws Exception {
+		AuthenticatedMember owner = insertAuthenticatedMember();
+		AuthenticatedMember requester = insertAuthenticatedMember();
+		UUID tripId = insertTrip(owner.memberId(), "IN_PROGRESS", null, null);
+
+		performGet(requester, tripId).andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 인증되지 않은 요청은 401을 반환한다. */
+	@Test
+	@DisplayName("인증되지 않은 요청은 401을 반환한다")
+	void unauthenticatedRequestReturnsUnauthorized() throws Exception {
+		mockMvc.perform(get("/trips/" + UUID.randomUUID() + "/statistics")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** 진행 중인 여행은 시작 시각부터 요청 처리 시각까지의 분 수를 반환한다. */
+	@Test
+	@DisplayName("진행 중인 여행은 시작부터 현재까지의 분 수를 반환한다")
+	void inProgressTripReturnsElapsedDuration() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(90, ChronoUnit.SECONDS);
+		UUID tripId = insertTrip(member.memberId(), "IN_PROGRESS", startedAt, null);
+
+		performGet(member, tripId).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.tripId").value(tripId.toString()))
+				.andExpect(jsonPath("$.data.durationMinutes").value(1))
+				.andExpect(jsonPath("$.data.visitedPlaceCount").value(0))
+				.andExpect(jsonPath("$.data.distanceKm").isEmpty())
+				.andExpect(jsonPath("$.data.caloriesKcal").isEmpty());
+	}
+
+	/** 종료된 여행은 시작 시각부터 종료 시각까지의 분 수를 반환한다. */
+	@Test
+	@DisplayName("종료된 여행은 시작부터 종료까지의 분 수를 반환한다")
+	void endedTripReturnsFixedDuration() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(1, ChronoUnit.HOURS);
+		Instant endedAt = startedAt.plus(30, ChronoUnit.MINUTES);
+		UUID tripId = insertTrip(member.memberId(), "ENDED", startedAt, endedAt);
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.durationMinutes").value(30));
+	}
+
+	/** 정산 완료된 여행도 시작부터 종료까지의 분 수를 반환한다. */
+	@Test
+	@DisplayName("정산 완료된 여행은 시작부터 종료까지의 분 수를 반환한다")
+	void settledTripReturnsFixedDuration() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(2, ChronoUnit.HOURS);
+		Instant endedAt = startedAt.plus(45, ChronoUnit.MINUTES);
+		UUID tripId = insertTrip(member.memberId(), "SETTLED", startedAt, endedAt);
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.durationMinutes").value(45));
+	}
+
+	/** 방문 기록이 없는 여행은 visitedPlaceCount 0을 반환한다. */
+	@Test
+	@DisplayName("방문 기록이 없으면 visitedPlaceCount는 0이다")
+	void noVisitRecordsReturnsZeroCount() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId(), "IN_PROGRESS", Instant.now(), null);
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.visitedPlaceCount").value(0));
+	}
+
+	/** 같은 여행에서 같은 문화재를 여러 미션으로 방문 확정해도 visitedPlaceCount는 한 번만 계산한다. */
+	@Test
+	@DisplayName("같은 문화재의 중복 방문 기록은 한 번만 카운트한다")
+	void duplicatePlaceVisitCountedOnce() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId(), "IN_PROGRESS", Instant.now(), null);
+		UUID placeId = insertPlace("문화재 A");
+		UUID missionA = insertMission(placeId, "미션 A");
+		UUID missionB = insertMission(placeId, "미션 B");
+		insertVisitRecord(tripId, missionA, placeId);
+		jdbcTemplate.update(
+				"INSERT INTO visit_records (id, trip_id, mission_id, place_id) VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING",
+				UUID.randomUUID(), tripId, missionB, placeId);
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.visitedPlaceCount").value(1));
+	}
+
+	private ResultActions performGet(AuthenticatedMember member, UUID tripId) throws Exception {
+		return mockMvc.perform(
+				get("/trips/" + tripId + "/statistics").header("Authorization", "Bearer " + member.accessToken()));
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private UUID insertTrip(UUID memberId, String status, Instant startedAt, Instant endedAt) {
+		UUID tripId = UUID.randomUUID();
+		Instant settledAt = "SETTLED".equals(status) ? endedAt : null;
+		jdbcTemplate.update(
+				"INSERT INTO trips (id, member_id, status, started_at, ended_at, settled_at) "
+						+ "VALUES (?, ?, ?::trip_status, ?, ?, ?)",
+				tripId, memberId, status, Timestamp.from(startedAt == null ? Instant.now() : startedAt),
+				endedAt == null ? null : Timestamp.from(endedAt), settledAt == null ? null : Timestamp.from(settledAt));
+		return tripId;
+	}
+
+	private UUID insertPlace(String name) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate
+				.update("INSERT INTO places (id, category, name, location) VALUES (?, 'HERITAGE'::place_category, ?, "
+						+ "ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography)", id, name, 126.9, 36.2);
+		return id;
+	}
+
+	private UUID insertMission(UUID placeId, String title) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO missions (id, place_id, type, title, description, reward_points, ox_correct_answer) "
+						+ "VALUES (?, ?, 'OX'::mission_type, ?, '설명', 10, true)",
+				id, placeId, title);
+		return id;
+	}
+
+	private void insertVisitRecord(UUID tripId, UUID missionId, UUID placeId) {
+		jdbcTemplate.update("INSERT INTO visit_records (id, trip_id, mission_id, place_id) VALUES (?, ?, ?, ?)",
+				UUID.randomUUID(), tripId, missionId, placeId);
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## 요약

- `GET /trips/{tripId}/statistics`에서 탐방한 문화재 수(`visitedPlaceCount`)와 탐방 시간(`durationMinutes`)을 반환한다.
- `distanceKm`, `caloriesKcal`는 MVP 범위 제외로 항상 `null`.
- `TripQueryService.getStatistics`가 `findByIdAndMemberId` 단일 쿼리로 소유권과 존재를 함께 검증해 타 회원 여행의 존재 여부가 새지 않는다(403 대신 404).
- 방문 수 중복 제거는 `visit_records`의 `UNIQUE(trip_id, place_id)` DB 제약에 위임하고 서비스 레이어에서 별도 로직을 두지 않았다.
- 분 환산은 반올림이 아닌 내림(`Duration.toMinutes()`).

Closes #100

## 테스트 계획

- [x] `TripStatisticsIntegrationTests` 신규 8개 시나리오: 미존재 404, 타회원 404, 미인증 401, IN_PROGRESS 경과 시간, ENDED 고정 시간, SETTLED 고정 시간, 방문 0건, 동일 문화재 중복 방문 1회 카운트
- [x] `format.sh`, `static-check.sh`(checkstyle/spotbugs/spotlessCheck) 통과
- [x] 전체 `test.sh` 실행: 320개 중 319개 통과. 실패 1건(`PlaceControllerIntegrationTests` 동시성 테스트)은 이번 변경과 무관한 기존 flaky이며 단독 실행 시 통과 확인
- [ ] `docker-build.sh`는 로컬 공유 DB 커넥션 풀(Supabase session pooler, pool_size 15) 고갈로 이번 세션에서 완주하지 못함 — 코드 변경과 무관한 인프라 이슈로 판단, 별도 확인 필요

## 리뷰

Standards, Spec 두 축 코드 리뷰 완료 — 차단 문제 없음(LOW 관찰만 존재, 테스트 보일러플레이트/jsonPath 단언 강화 등 비차단).

🤖 Generated with [Claude Code](https://claude.com/claude-code)