### PR TITLE
feat: UC-14 과거 활동 배지 reconciliation 구현 (#124)

### DIFF
--- a/src/main/java/com/buyeoon/badge/BadgeEvaluationService.java
+++ b/src/main/java/com/buyeoon/badge/BadgeEvaluationService.java
@@ -1,6 +1,7 @@
 package com.buyeoon.badge;
 
 import com.buyeoon.badge.application.BadgeMetricProviderRegistry;
+import com.buyeoon.badge.application.BadgeMetricSnapshot;
 import com.buyeoon.badge.entity.BadgeConditionEntity;
 import com.buyeoon.badge.entity.BadgeEntity;
 import com.buyeoon.badge.repository.BadgeConditionRepository;
@@ -62,13 +63,14 @@ public class BadgeEvaluationService {
 				.findByIdBadgeIdIn(candidates.stream().map(BadgeEntity::getId).toList()).stream()
 				.collect(Collectors.groupingBy(condition -> condition.getId().badgeId()));
 
-		Map<BadgeMetric, Long> metricValues = new EnumMap<>(BadgeMetric.class);
+		Map<BadgeMetric, BadgeMetricSnapshot> metricSnapshots = new EnumMap<>(BadgeMetric.class);
 		List<AwardedBadgeResult> awarded = new ArrayList<>();
 		for (BadgeEntity badge : candidates) {
 			List<BadgeConditionEntity> conditions = conditionsByBadgeId.getOrDefault(badge.getId(), List.of());
 			boolean achieved = !conditions.isEmpty() && conditions.stream().allMatch(condition -> {
 				BadgeMetric metric = BadgeMetric.valueOf(condition.getId().metricKey());
-				long value = metricValues.computeIfAbsent(metric, m -> providerRegistry.get(m).calculate(memberId));
+				long value = metricSnapshots.computeIfAbsent(metric, m -> providerRegistry.get(m).calculate(memberId))
+						.value();
 				return value >= condition.getThreshold();
 			});
 			if (!achieved) {

--- a/src/main/java/com/buyeoon/badge/BadgeReconciliationScheduler.java
+++ b/src/main/java/com/buyeoon/badge/BadgeReconciliationScheduler.java
@@ -1,0 +1,20 @@
+package com.buyeoon.badge;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** 매일 `03:00 Asia/Seoul`에 배지 reconciliation을 실행하는 Scheduler다(ADR-003). */
+@Component
+public class BadgeReconciliationScheduler {
+
+	private final BadgeReconciliationService reconciliationService;
+
+	public BadgeReconciliationScheduler(BadgeReconciliationService reconciliationService) {
+		this.reconciliationService = reconciliationService;
+	}
+
+	@Scheduled(cron = "${badge.reconciliation.cron:0 0 3 * * *}", zone = "Asia/Seoul")
+	public void reconcileActiveMembers() {
+		reconciliationService.reconcile();
+	}
+}

--- a/src/main/java/com/buyeoon/badge/BadgeReconciliationService.java
+++ b/src/main/java/com/buyeoon/badge/BadgeReconciliationService.java
@@ -1,0 +1,147 @@
+package com.buyeoon.badge;
+
+import com.buyeoon.badge.application.BadgeMetricProviderRegistry;
+import com.buyeoon.badge.application.BadgeMetricSnapshot;
+import com.buyeoon.badge.entity.BadgeConditionEntity;
+import com.buyeoon.badge.entity.BadgeEntity;
+import com.buyeoon.badge.repository.BadgeConditionRepository;
+import com.buyeoon.badge.repository.BadgeMemberRepository;
+import com.buyeoon.badge.repository.BadgeRepository;
+import com.buyeoon.badge.repository.MemberBadgeRepository;
+import com.buyeoon.member.entity.MemberStatus;
+import com.buyeoon.notification.NotificationCreationService;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * 새 badge catalog 도입 전에 과거 활동으로 조건을 충족한 active member에게 daily reconciliation으로
+ * 배지를 지급하는 badge 도메인의 Scheduler entrypoint다(ADR-003). 회원별 transaction에서 member
+ * row를 먼저 잠그고 {@code ACTIVE} 상태를 다시 확인한 뒤 판정하며, 한 회원의 실패는 다른 회원 처리를 막지 않고 다음
+ * 실행에서 다시 판정한다.
+ */
+@Service
+public class BadgeReconciliationService {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(BadgeReconciliationService.class);
+	private static final int PAGE_SIZE = 200;
+	private static final Set<String> ALL_METRIC_KEYS = EnumSet.allOf(BadgeMetric.class).stream().map(Enum::name)
+			.collect(Collectors.toUnmodifiableSet());
+
+	private final BadgeMemberRepository members;
+	private final BadgeMetricProviderRegistry providerRegistry;
+	private final BadgeRepository badgeRepository;
+	private final BadgeConditionRepository badgeConditionRepository;
+	private final MemberBadgeRepository memberBadgeRepository;
+	private final NotificationCreationService notificationCreationService;
+	private final TransactionTemplate transactions;
+
+	public BadgeReconciliationService(BadgeMemberRepository members, BadgeMetricProviderRegistry providerRegistry,
+			BadgeRepository badgeRepository, BadgeConditionRepository badgeConditionRepository,
+			MemberBadgeRepository memberBadgeRepository, NotificationCreationService notificationCreationService,
+			PlatformTransactionManager transactionManager) {
+		this.members = members;
+		this.providerRegistry = providerRegistry;
+		this.badgeRepository = badgeRepository;
+		this.badgeConditionRepository = badgeConditionRepository;
+		this.memberBadgeRepository = memberBadgeRepository;
+		this.notificationCreationService = notificationCreationService;
+		this.transactions = new TransactionTemplate(transactionManager);
+	}
+
+	/** 활성 회원을 대상으로 reconciliation을 실행하고 새로 배지를 받은 회원 수를 반환한다. */
+	public int reconcile() {
+		int membersAwarded = 0;
+		int page = 0;
+		while (true) {
+			List<UUID> memberIds = members.findIdsByStatus(MemberStatus.ACTIVE, PageRequest.of(page, PAGE_SIZE));
+			if (memberIds.isEmpty()) {
+				return membersAwarded;
+			}
+			for (UUID memberId : memberIds) {
+				if (reconcileMember(memberId)) {
+					membersAwarded++;
+				}
+			}
+			page++;
+		}
+	}
+
+	private boolean reconcileMember(UUID memberId) {
+		try {
+			return Boolean.TRUE.equals(transactions.execute(status -> reconcileMemberInTransaction(memberId)));
+		} catch (RuntimeException exception) {
+			LOGGER.warn("배지 reconciliation에 실패했습니다. memberId={}", memberId, exception);
+			return false;
+		}
+	}
+
+	private boolean reconcileMemberInTransaction(UUID memberId) {
+		if (members.findByIdAndStatus(memberId, MemberStatus.ACTIVE).isEmpty()) {
+			return false;
+		}
+
+		List<BadgeEntity> candidates = badgeRepository.findNotEarnedByAnyMetric(memberId, ALL_METRIC_KEYS);
+		if (candidates.isEmpty()) {
+			return false;
+		}
+
+		Map<UUID, List<BadgeConditionEntity>> conditionsByBadgeId = badgeConditionRepository
+				.findByIdBadgeIdIn(candidates.stream().map(BadgeEntity::getId).toList()).stream()
+				.collect(Collectors.groupingBy(condition -> condition.getId().badgeId()));
+
+		Map<BadgeMetric, BadgeMetricSnapshot> metricSnapshots = new EnumMap<>(BadgeMetric.class);
+		boolean awardedAny = false;
+		for (BadgeEntity badge : candidates) {
+			List<BadgeConditionEntity> conditions = conditionsByBadgeId.getOrDefault(badge.getId(), List.of());
+			if (conditions.isEmpty()) {
+				continue;
+			}
+			boolean achieved = conditions.stream().allMatch(condition -> {
+				BadgeMetric metric = BadgeMetric.valueOf(condition.getId().metricKey());
+				BadgeMetricSnapshot snapshot = metricSnapshots.computeIfAbsent(metric,
+						m -> providerRegistry.get(m).calculate(memberId));
+				return snapshot.value() >= condition.getThreshold();
+			});
+			if (!achieved) {
+				continue;
+			}
+
+			UUID earningTripId = earningTripId(conditions, metricSnapshots);
+			if (memberBadgeRepository.awardIfAbsent(memberId, badge.getId(), earningTripId).isPresent()) {
+				notificationCreationService.createBadgeAwarded(memberId, badge.getId(), badge.getName());
+				awardedAny = true;
+			}
+		}
+		return awardedAny;
+	}
+
+	/**
+	 * 배지의 모든 조건에 기여한 활동 중 {@code latestContributionAt} 내림차순, metric key 오름차순, trip
+	 * ID 오름차순으로 정렬한 첫 활동의 여행을 반환한다(ADR-003).
+	 */
+	private UUID earningTripId(List<BadgeConditionEntity> conditions,
+			Map<BadgeMetric, BadgeMetricSnapshot> metricSnapshots) {
+		Comparator<BadgeConditionEntity> tieBreak = Comparator
+				.comparing((BadgeConditionEntity condition) -> metricSnapshots
+						.get(BadgeMetric.valueOf(condition.getId().metricKey())).latestContributionAt())
+				.reversed().thenComparing(condition -> condition.getId().metricKey())
+				.thenComparing(condition -> metricSnapshots.get(BadgeMetric.valueOf(condition.getId().metricKey()))
+						.latestContributingTripId());
+		BadgeConditionEntity earliestSortedCondition = conditions.stream().min(tieBreak)
+				.orElseThrow(() -> new IllegalStateException("배지 조건이 없습니다."));
+		return metricSnapshots.get(BadgeMetric.valueOf(earliestSortedCondition.getId().metricKey()))
+				.latestContributingTripId();
+	}
+}

--- a/src/main/java/com/buyeoon/badge/application/BadgeMetricProvider.java
+++ b/src/main/java/com/buyeoon/badge/application/BadgeMetricProvider.java
@@ -8,6 +8,8 @@ public interface BadgeMetricProvider {
 
 	BadgeMetric metric();
 
-	/** 회원의 전체 여행 활동을 기준으로 현재 메트릭값을 계산한다. */
-	long calculate(UUID memberId);
+	/**
+	 * 회원의 전체 여행 활동을 기준으로 현재 메트릭값과 가장 최근 기여 활동의 여행·시각을 계산한다.
+	 */
+	BadgeMetricSnapshot calculate(UUID memberId);
 }

--- a/src/main/java/com/buyeoon/badge/application/BadgeMetricSnapshot.java
+++ b/src/main/java/com/buyeoon/badge/application/BadgeMetricSnapshot.java
@@ -1,0 +1,12 @@
+package com.buyeoon.badge.application;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 메트릭의 현재값과 그 값에 기여한 활동 중 가장 최근 활동의 여행 ID·시각을 담는 스냅샷이다(ADR-003). 값이 0이면
+ * {@code latestContributingTripId}와 {@code latestContributionAt}은
+ * {@code null}이다.
+ */
+public record BadgeMetricSnapshot(long value, UUID latestContributingTripId, Instant latestContributionAt) {
+}

--- a/src/main/java/com/buyeoon/badge/application/HeritageVisitedCountProvider.java
+++ b/src/main/java/com/buyeoon/badge/application/HeritageVisitedCountProvider.java
@@ -2,6 +2,7 @@ package com.buyeoon.badge.application;
 
 import com.buyeoon.badge.BadgeMetric;
 import com.buyeoon.trip.HeritageVisitMetricQuery;
+import com.buyeoon.trip.HeritageVisitMetricSnapshot;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
 
@@ -24,7 +25,8 @@ public class HeritageVisitedCountProvider implements BadgeMetricProvider {
 	}
 
 	@Override
-	public long calculate(UUID memberId) {
-		return heritageVisitMetricQuery.countUniquePlacesVisitedByMemberId(memberId);
+	public BadgeMetricSnapshot calculate(UUID memberId) {
+		HeritageVisitMetricSnapshot snapshot = heritageVisitMetricQuery.snapshot(memberId);
+		return new BadgeMetricSnapshot(snapshot.count(), snapshot.latestTripId(), snapshot.latestVisitedAt());
 	}
 }

--- a/src/main/java/com/buyeoon/badge/application/MissionCompletedCountProvider.java
+++ b/src/main/java/com/buyeoon/badge/application/MissionCompletedCountProvider.java
@@ -2,6 +2,7 @@ package com.buyeoon.badge.application;
 
 import com.buyeoon.badge.BadgeMetric;
 import com.buyeoon.mission.MissionCompletionMetricQuery;
+import com.buyeoon.mission.MissionCompletionMetricSnapshot;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
 
@@ -24,7 +25,8 @@ public class MissionCompletedCountProvider implements BadgeMetricProvider {
 	}
 
 	@Override
-	public long calculate(UUID memberId) {
-		return missionCompletionMetricQuery.countCompletedByMemberId(memberId);
+	public BadgeMetricSnapshot calculate(UUID memberId) {
+		MissionCompletionMetricSnapshot snapshot = missionCompletionMetricQuery.snapshot(memberId);
+		return new BadgeMetricSnapshot(snapshot.count(), snapshot.latestTripId(), snapshot.latestCompletedAt());
 	}
 }

--- a/src/main/java/com/buyeoon/badge/application/PointDonationCountProvider.java
+++ b/src/main/java/com/buyeoon/badge/application/PointDonationCountProvider.java
@@ -1,0 +1,32 @@
+package com.buyeoon.badge.application;
+
+import com.buyeoon.badge.BadgeMetric;
+import com.buyeoon.point.PointDonationMetricQuery;
+import com.buyeoon.point.PointDonationMetricSnapshot;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+/**
+ * point 도메인의 공개 query seam으로 {@code POINT_DONATION_COUNT}를 계산하는
+ * Provider다(ADR-003).
+ */
+@Component
+public class PointDonationCountProvider implements BadgeMetricProvider {
+
+	private final PointDonationMetricQuery pointDonationMetricQuery;
+
+	public PointDonationCountProvider(PointDonationMetricQuery pointDonationMetricQuery) {
+		this.pointDonationMetricQuery = pointDonationMetricQuery;
+	}
+
+	@Override
+	public BadgeMetric metric() {
+		return BadgeMetric.POINT_DONATION_COUNT;
+	}
+
+	@Override
+	public BadgeMetricSnapshot calculate(UUID memberId) {
+		PointDonationMetricSnapshot snapshot = pointDonationMetricQuery.snapshot(memberId);
+		return new BadgeMetricSnapshot(snapshot.count(), snapshot.latestTripId(), snapshot.latestSettledAt());
+	}
+}

--- a/src/main/java/com/buyeoon/badge/repository/BadgeMemberRepository.java
+++ b/src/main/java/com/buyeoon/badge/repository/BadgeMemberRepository.java
@@ -1,0 +1,24 @@
+package com.buyeoon.badge.repository;
+
+import com.buyeoon.member.entity.MemberEntity;
+import com.buyeoon.member.entity.MemberStatus;
+import jakarta.persistence.LockModeType;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Reconciliation이 회원 행을 잠그고 대상 회원을 열거하기 위한 badge 도메인 소유의 리포지토리다. */
+public interface BadgeMemberRepository extends JpaRepository<MemberEntity, UUID> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<MemberEntity> findByIdAndStatus(UUID id, MemberStatus status);
+
+	/** Reconciliation 대상 회원을 ID 오름차순으로 페이지 단위로 열거한다. */
+	@Query("SELECT m.id FROM MemberEntity m WHERE m.status = :status ORDER BY m.id ASC")
+	List<UUID> findIdsByStatus(@Param("status") MemberStatus status, Pageable pageable);
+}

--- a/src/main/java/com/buyeoon/mission/MissionCompletionMetricQuery.java
+++ b/src/main/java/com/buyeoon/mission/MissionCompletionMetricQuery.java
@@ -1,9 +1,12 @@
 package com.buyeoon.mission;
 
+import com.buyeoon.mission.entity.MissionParticipationEntity;
 import com.buyeoon.mission.entity.MissionStatus;
 import com.buyeoon.mission.repository.MissionParticipationRepository;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,10 +26,18 @@ public class MissionCompletionMetricQuery {
 	}
 
 	/**
-	 * 회원이 전체 여행에서 완료한 mission participation 수를 센다. 같은 mission을 다른 여행에서 다시 완료하면 다시
-	 * 센다.
+	 * 회원이 전체 여행에서 완료한 mission participation 수와 가장 최근 완료 건의 여행·시각을 계산한다. 같은 mission을
+	 * 다른 여행에서 다시 완료하면 다시 센다. 완료 건이 없으면 여행·시각은 {@code null}이다.
 	 */
-	public long countCompletedByMemberId(UUID memberId) {
-		return missionParticipations.countByMemberIdAndStatus(memberId, MissionStatus.COMPLETED);
+	public MissionCompletionMetricSnapshot snapshot(UUID memberId) {
+		long count = missionParticipations.countByMemberIdAndStatus(memberId, MissionStatus.COMPLETED);
+		if (count == 0) {
+			return new MissionCompletionMetricSnapshot(0, null, null);
+		}
+		List<MissionParticipationEntity> latest = missionParticipations
+				.findByMemberIdAndStatusOrderByCompletedAtDescTripIdAsc(memberId, MissionStatus.COMPLETED,
+						PageRequest.of(0, 1));
+		MissionParticipationEntity mostRecent = latest.getFirst();
+		return new MissionCompletionMetricSnapshot(count, mostRecent.getTripId(), mostRecent.getCompletedAt());
 	}
 }

--- a/src/main/java/com/buyeoon/mission/MissionCompletionMetricSnapshot.java
+++ b/src/main/java/com/buyeoon/mission/MissionCompletionMetricSnapshot.java
@@ -1,0 +1,12 @@
+package com.buyeoon.mission;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * badge 도메인이 {@code MISSION_COMPLETED_COUNT}를 판정할 때 사용하는 mission 도메인의
+ * 스냅샷이다(ADR-003). {@code count}가 0이면 {@code latestTripId}와
+ * {@code latestCompletedAt}은 {@code null}이다.
+ */
+public record MissionCompletionMetricSnapshot(long count, UUID latestTripId, Instant latestCompletedAt) {
+}

--- a/src/main/java/com/buyeoon/mission/repository/MissionParticipationRepository.java
+++ b/src/main/java/com/buyeoon/mission/repository/MissionParticipationRepository.java
@@ -3,8 +3,10 @@ package com.buyeoon.mission.repository;
 import com.buyeoon.mission.entity.MissionParticipationEntity;
 import com.buyeoon.mission.entity.MissionStatus;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
@@ -30,4 +32,13 @@ public interface MissionParticipationRepository extends JpaRepository<MissionPar
 	@Query("SELECT COUNT(p) FROM MissionParticipationEntity p JOIN TripEntity t ON t.id = p.tripId "
 			+ "WHERE t.memberId = :memberId AND p.status = :status")
 	long countByMemberIdAndStatus(@Param("memberId") UUID memberId, @Param("status") MissionStatus status);
+
+	/**
+	 * 회원이 완료한 mission participation을 완료 시각 내림차순, 여행 ID 오름차순으로 조회한다. Reconciliation의
+	 * 최근 기여 trip tie-breaker(ADR-003)에 사용하며 {@code pageable}로 최근 1건만 조회한다.
+	 */
+	@Query("SELECT p FROM MissionParticipationEntity p JOIN TripEntity t ON t.id = p.tripId "
+			+ "WHERE t.memberId = :memberId AND p.status = :status " + "ORDER BY p.completedAt DESC, p.tripId ASC")
+	List<MissionParticipationEntity> findByMemberIdAndStatusOrderByCompletedAtDescTripIdAsc(
+			@Param("memberId") UUID memberId, @Param("status") MissionStatus status, Pageable pageable);
 }

--- a/src/main/java/com/buyeoon/point/PointDonationMetricQuery.java
+++ b/src/main/java/com/buyeoon/point/PointDonationMetricQuery.java
@@ -1,0 +1,41 @@
+package com.buyeoon.point;
+
+import com.buyeoon.point.entity.PointSettlementEntity;
+import com.buyeoon.point.entity.SettlementChoice;
+import com.buyeoon.point.repository.PointSettlementQueryRepository;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * badge 도메인이 {@code POINT_DONATION_COUNT}를 판정할 때 사용하는 point 도메인의 공개 query
+ * seam이다(ADR-003).
+ */
+@Service
+@Transactional(readOnly = true)
+public class PointDonationMetricQuery {
+
+	private final PointSettlementQueryRepository pointSettlements;
+
+	public PointDonationMetricQuery(PointSettlementQueryRepository pointSettlements) {
+		this.pointSettlements = pointSettlements;
+	}
+
+	/**
+	 * 회원이 `LEAVE_TO_BUYEO`를 선택하고 `settled_points > 0`으로 확정한 정산 수와 가장 최근 정산의 여행·시각을
+	 * 계산한다. `CARRY_OVER`와 0 point 정산은 포함하지 않는다. 해당 정산이 없으면 여행·시각은 {@code null}이다.
+	 */
+	public PointDonationMetricSnapshot snapshot(UUID memberId) {
+		long count = pointSettlements.countPositiveDonationsByMemberId(memberId, SettlementChoice.LEAVE_TO_BUYEO);
+		if (count == 0) {
+			return new PointDonationMetricSnapshot(0, null, null);
+		}
+		List<PointSettlementEntity> latest = pointSettlements
+				.findPositiveDonationsByMemberIdOrderBySettledAtDescTripIdAsc(memberId, SettlementChoice.LEAVE_TO_BUYEO,
+						PageRequest.of(0, 1));
+		PointSettlementEntity mostRecent = latest.getFirst();
+		return new PointDonationMetricSnapshot(count, mostRecent.getTripId(), mostRecent.getSettledAt());
+	}
+}

--- a/src/main/java/com/buyeoon/point/PointDonationMetricSnapshot.java
+++ b/src/main/java/com/buyeoon/point/PointDonationMetricSnapshot.java
@@ -1,0 +1,12 @@
+package com.buyeoon.point;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * badge 도메인이 {@code POINT_DONATION_COUNT}를 판정할 때 사용하는 point 도메인의
+ * 스냅샷이다(ADR-003). {@code count}가 0이면 {@code latestTripId}와
+ * {@code latestSettledAt}은 {@code null}이다.
+ */
+public record PointDonationMetricSnapshot(long count, UUID latestTripId, Instant latestSettledAt) {
+}

--- a/src/main/java/com/buyeoon/point/repository/PointSettlementQueryRepository.java
+++ b/src/main/java/com/buyeoon/point/repository/PointSettlementQueryRepository.java
@@ -4,6 +4,7 @@ import com.buyeoon.point.entity.PointSettlementEntity;
 import com.buyeoon.point.entity.SettlementChoice;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,4 +26,32 @@ public interface PointSettlementQueryRepository extends JpaRepository<PointSettl
 			""")
 	List<PointSettlementEntity> findActiveCarryOversByMemberId(@Param("memberId") UUID memberId,
 			@Param("choice") SettlementChoice choice);
+
+	/**
+	 * 회원이 `부여에 남기기`를 선택하고 양수 포인트를 정산한 건수를 센다({@code POINT_DONATION_COUNT},
+	 * ADR-003).
+	 */
+	@Query("""
+			SELECT COUNT(s) FROM PointSettlementEntity s
+			JOIN TripEntity t ON t.id = s.tripId
+			WHERE t.memberId = :memberId
+			  AND s.choice = :choice
+			  AND s.settledPoints > 0
+			""")
+	long countPositiveDonationsByMemberId(@Param("memberId") UUID memberId, @Param("choice") SettlementChoice choice);
+
+	/**
+	 * 회원의 양수 포인트 기부 정산을 정산 시각 내림차순, 여행 ID 오름차순으로 조회한다. Reconciliation의 최근 기여 trip
+	 * tie-breaker(ADR-003)에 사용하며 {@code pageable}로 최근 1건만 조회한다.
+	 */
+	@Query("""
+			SELECT s FROM PointSettlementEntity s
+			JOIN TripEntity t ON t.id = s.tripId
+			WHERE t.memberId = :memberId
+			  AND s.choice = :choice
+			  AND s.settledPoints > 0
+			ORDER BY s.settledAt DESC, s.tripId ASC
+			""")
+	List<PointSettlementEntity> findPositiveDonationsByMemberIdOrderBySettledAtDescTripIdAsc(
+			@Param("memberId") UUID memberId, @Param("choice") SettlementChoice choice, Pageable pageable);
 }

--- a/src/main/java/com/buyeoon/trip/HeritageVisitMetricQuery.java
+++ b/src/main/java/com/buyeoon/trip/HeritageVisitMetricQuery.java
@@ -1,6 +1,8 @@
 package com.buyeoon.trip;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,8 +22,17 @@ public class HeritageVisitMetricQuery {
 		this.visitRecords = visitRecords;
 	}
 
-	/** 회원이 전체 여행에서 방문한 고유 문화재 수를 센다. 같은 문화재를 다른 여행에서 다시 방문해도 다시 세지 않는다. */
-	public long countUniquePlacesVisitedByMemberId(UUID memberId) {
-		return visitRecords.countDistinctPlaceIdByMemberId(memberId);
+	/**
+	 * 회원이 전체 여행에서 방문한 고유 문화재 수와, 고유 문화재 수에 기여한 각 문화재의 최초 방문 중 가장 최근 방문의 여행·시각을
+	 * 계산한다. 같은 문화재를 다른 여행에서 다시 방문해도 다시 세지 않는다. 방문 기록이 없으면 여행·시각은 {@code null}이다.
+	 */
+	public HeritageVisitMetricSnapshot snapshot(UUID memberId) {
+		long count = visitRecords.countDistinctPlaceIdByMemberId(memberId);
+		if (count == 0) {
+			return new HeritageVisitMetricSnapshot(0, null, null);
+		}
+		List<Object[]> rows = visitRecords.findLatestContributingFirstVisitRows(memberId);
+		Object[] row = rows.getFirst();
+		return new HeritageVisitMetricSnapshot(count, (UUID) row[0], (Instant) row[1]);
 	}
 }

--- a/src/main/java/com/buyeoon/trip/HeritageVisitMetricSnapshot.java
+++ b/src/main/java/com/buyeoon/trip/HeritageVisitMetricSnapshot.java
@@ -1,0 +1,12 @@
+package com.buyeoon.trip;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * badge 도메인이 {@code HERITAGE_VISITED_COUNT}를 판정할 때 사용하는 trip 도메인의
+ * 스냅샷이다(ADR-003). {@code count}가 0이면 {@code latestTripId}와
+ * {@code latestVisitedAt}은 {@code null}이다.
+ */
+public record HeritageVisitMetricSnapshot(long count, UUID latestTripId, Instant latestVisitedAt) {
+}

--- a/src/main/java/com/buyeoon/trip/VisitRecordRepository.java
+++ b/src/main/java/com/buyeoon/trip/VisitRecordRepository.java
@@ -1,6 +1,7 @@
 package com.buyeoon.trip;
 
 import com.buyeoon.trip.entity.VisitRecordEntity;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,4 +21,22 @@ public interface VisitRecordRepository extends JpaRepository<VisitRecordEntity, 
 	@Query("SELECT COUNT(DISTINCT v.placeId) FROM VisitRecordEntity v JOIN TripEntity t ON t.id = v.tripId "
 			+ "WHERE t.memberId = :memberId")
 	long countDistinctPlaceIdByMemberId(@Param("memberId") UUID memberId);
+
+	/**
+	 * 고유 문화재 수에 기여한 각 문화재의 최초 방문 중 가장 최근 방문의 여행 ID·방문 시각을 조회한다. Reconciliation의 최근
+	 * 기여 trip tie-breaker(ADR-003)에 사용한다. 방문 기록이 없으면 빈 목록을 반환한다.
+	 */
+	@Query(value = """
+			SELECT first_visits.trip_id, first_visits.visited_at
+			FROM (
+			    SELECT DISTINCT ON (v.place_id) v.trip_id AS trip_id, v.visited_at AS visited_at
+			    FROM visit_records v
+			    JOIN trips t ON t.id = v.trip_id
+			    WHERE t.member_id = :memberId
+			    ORDER BY v.place_id, v.visited_at ASC, v.trip_id ASC
+			) first_visits
+			ORDER BY first_visits.visited_at DESC, first_visits.trip_id ASC
+			LIMIT 1
+			""", nativeQuery = true)
+	List<Object[]> findLatestContributingFirstVisitRows(@Param("memberId") UUID memberId);
 }

--- a/src/test/java/com/buyeoon/badge/BadgeReconciliationIntegrationTests.java
+++ b/src/test/java/com/buyeoon/badge/BadgeReconciliationIntegrationTests.java
@@ -1,0 +1,401 @@
+package com.buyeoon.badge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/** UC-14 과거 활동 배지 reconciliation 흐름의 통합 테스트다. */
+@SpringBootTest
+@Testcontainers
+class BadgeReconciliationIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+	// 시드 마이그레이션이 부여 지역에 장소·미션 예시 데이터를 채워두므로, 격리를 위해 남극 인근 좌표를 기준으로
+	// 테스트 데이터를 배치한다.
+	private static final double ORIGIN_LATITUDE = -75.0;
+	private static final double ORIGIN_LONGITUDE = 0.0;
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private BadgeReconciliationService reconciliationService;
+
+	@Autowired
+	private BadgeEvaluationService badgeEvaluationService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM notifications");
+		jdbcTemplate.update("DELETE FROM member_badges");
+		jdbcTemplate.update("DELETE FROM badge_conditions");
+		jdbcTemplate.update("DELETE FROM badges");
+		jdbcTemplate.update("DELETE FROM point_settlements");
+		jdbcTemplate.update("DELETE FROM visit_records");
+		jdbcTemplate.update("DELETE FROM mission_participations");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.execute("DROP TRIGGER IF EXISTS fail_member_badges_insert ON member_badges");
+		jdbcTemplate.execute("DROP FUNCTION IF EXISTS fail_member_badges_insert()");
+		jdbcTemplate.update(
+				"DELETE FROM missions WHERE place_id IN (SELECT id FROM places WHERE ST_Y(location::geometry) < -70)");
+		jdbcTemplate.update("DELETE FROM places WHERE ST_Y(location::geometry) < -70");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	@Test
+	@DisplayName("과거 미션·문화재·양수 포인트 기부 활동으로 조건을 충족한 active member는 배지와 알림을 받는다")
+	void reconcilesPastActivityAcrossAllThreeMetrics() {
+		UUID memberId = insertActiveMember();
+		UUID missionBadgeId = insertBadge("탐험가");
+		insertCondition(missionBadgeId, "MISSION_COMPLETED_COUNT", 1);
+		UUID heritageBadgeId = insertBadge("문화탐방가");
+		insertCondition(heritageBadgeId, "HERITAGE_VISITED_COUNT", 1);
+		UUID donationBadgeId = insertBadge("기부천사");
+		insertCondition(donationBadgeId, "POINT_DONATION_COUNT", 1);
+
+		UUID missionTrip = insertTrip(memberId);
+		UUID place = insertPlace("장소A");
+		UUID mission = insertMission(place);
+		insertCompletedParticipation(missionTrip, mission, Instant.now().minus(3, ChronoUnit.DAYS));
+
+		UUID heritageTrip = insertTrip(memberId);
+		insertVisitRecord(heritageTrip, mission, place, Instant.now().minus(2, ChronoUnit.DAYS));
+
+		UUID donationTrip = insertTrip(memberId);
+		insertSettlement(donationTrip, "LEAVE_TO_BUYEO", 100, Instant.now().minus(1, ChronoUnit.DAYS));
+
+		Instant before = Instant.now();
+		reconciliationService.reconcile();
+		Instant after = Instant.now();
+
+		assertThat(memberBadgeRow(memberId, missionBadgeId).get("trip_id")).isEqualTo(missionTrip);
+		assertThat(memberBadgeRow(memberId, heritageBadgeId).get("trip_id")).isEqualTo(heritageTrip);
+		assertThat(memberBadgeRow(memberId, donationBadgeId).get("trip_id")).isEqualTo(donationTrip);
+		for (UUID badgeId : List.of(missionBadgeId, heritageBadgeId, donationBadgeId)) {
+			Instant earnedAt = ((Timestamp) memberBadgeRow(memberId, badgeId).get("earned_at")).toInstant();
+			assertThat(earnedAt).isBetween(before, after);
+			assertThat(notificationCount(memberId, badgeId)).isEqualTo(1);
+		}
+	}
+
+	@Test
+	@DisplayName("CARRY_OVER와 0 point settlement는 포인트 기부 조건에 포함되지 않는다")
+	void excludesCarryOverAndZeroPointSettlements() {
+		UUID memberId = insertActiveMember();
+		UUID badgeId = insertBadge("기부천사");
+		insertCondition(badgeId, "POINT_DONATION_COUNT", 1);
+
+		UUID carryOverTrip = insertTrip(memberId);
+		insertSettlement(carryOverTrip, "CARRY_OVER", 100, Instant.now().minus(2, ChronoUnit.DAYS));
+		UUID zeroTrip = insertTrip(memberId);
+		insertSettlement(zeroTrip, "LEAVE_TO_BUYEO", 0, Instant.now().minus(1, ChronoUnit.DAYS));
+
+		reconciliationService.reconcile();
+
+		assertThat(memberBadgeCount(memberId, badgeId)).isZero();
+	}
+
+	@Test
+	@DisplayName("복합 조건 배지는 여러 metric에 기여한 활동 중 가장 최근 활동의 여행에 연결한다")
+	void compositeBadgeConnectsToLatestContributingTripAcrossMetrics() {
+		UUID memberId = insertActiveMember();
+		UUID badgeId = insertBadge("탐험 기부가");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
+		insertCondition(badgeId, "POINT_DONATION_COUNT", 1);
+
+		UUID missionTrip = insertTrip(memberId);
+		UUID place = insertPlace("장소A");
+		UUID mission = insertMission(place);
+		insertCompletedParticipation(missionTrip, mission, Instant.now().minus(5, ChronoUnit.DAYS));
+
+		UUID donationTrip = insertTrip(memberId);
+		insertSettlement(donationTrip, "LEAVE_TO_BUYEO", 50, Instant.now().minus(1, ChronoUnit.DAYS));
+
+		reconciliationService.reconcile();
+
+		assertThat(memberBadgeRow(memberId, badgeId).get("trip_id")).isEqualTo(donationTrip);
+	}
+
+	@Test
+	@DisplayName("고유 문화재 수는 각 문화재의 최초 방문만 세고, 재방문은 획득 여행에 영향을 주지 않는다")
+	void heritageMetricCountsOnlyFirstVisitPerPlace() {
+		UUID memberId = insertActiveMember();
+		UUID badgeId = insertBadge("문화탐방가");
+		insertCondition(badgeId, "HERITAGE_VISITED_COUNT", 2);
+
+		UUID placeA = insertPlace("장소A");
+		UUID missionA = insertMission(placeA);
+		UUID placeB = insertPlace("장소B");
+		UUID missionB = insertMission(placeB);
+
+		UUID firstVisitTripA = insertTrip(memberId);
+		insertVisitRecord(firstVisitTripA, missionA, placeA, Instant.now().minus(5, ChronoUnit.DAYS));
+		UUID firstVisitTripB = insertTrip(memberId);
+		insertVisitRecord(firstVisitTripB, missionB, placeB, Instant.now().minus(3, ChronoUnit.DAYS));
+		UUID revisitTrip = insertTrip(memberId);
+		insertVisitRecord(revisitTrip, missionA, placeA, Instant.now().minus(1, ChronoUnit.DAYS));
+
+		reconciliationService.reconcile();
+
+		assertThat(memberBadgeRow(memberId, badgeId).get("trip_id")).isEqualTo(firstVisitTripB);
+	}
+
+	@Test
+	@DisplayName("탈퇴한 회원은 member row lock 후 상태 재확인에서 걸러져 배지와 알림을 받지 않는다")
+	void skipsWithdrawnMemberAfterLockingMemberRow() {
+		UUID memberId = insertWithdrawnMember();
+		UUID badgeId = insertBadge("탐험가");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
+		UUID tripId = insertTrip(memberId);
+		UUID place = insertPlace("장소A");
+		UUID mission = insertMission(place);
+		insertCompletedParticipation(tripId, mission, Instant.now().minus(1, ChronoUnit.DAYS));
+
+		reconciliationService.reconcile();
+
+		assertThat(memberBadgeCount(memberId, badgeId)).isZero();
+		assertThat(notificationCount(memberId, badgeId)).isZero();
+	}
+
+	@Test
+	@DisplayName("이미 획득했거나 지급이 중단된 배지는 reconciliation에서 다시 지급하지 않는다")
+	void skipsAlreadyEarnedAndRetiredBadges() {
+		UUID memberId = insertActiveMember();
+		UUID tripId = insertTrip(memberId);
+		UUID place = insertPlace("장소A");
+		UUID mission = insertMission(place);
+		insertCompletedParticipation(tripId, mission, Instant.now().minus(1, ChronoUnit.DAYS));
+
+		UUID earnedBadgeId = insertBadge("탐험가");
+		insertCondition(earnedBadgeId, "MISSION_COMPLETED_COUNT", 1);
+		jdbcTemplate.update("INSERT INTO member_badges (member_id, badge_id, trip_id) VALUES (?, ?, ?)", memberId,
+				earnedBadgeId, tripId);
+
+		UUID retiredBadgeId = insertBadge("은퇴한 배지");
+		insertCondition(retiredBadgeId, "MISSION_COMPLETED_COUNT", 1);
+		jdbcTemplate.update("UPDATE badges SET retired_at = now() WHERE id = ?", retiredBadgeId);
+
+		reconciliationService.reconcile();
+
+		assertThat(memberBadgeCount(memberId, earnedBadgeId)).isEqualTo(1);
+		assertThat(notificationCount(memberId, earnedBadgeId)).isZero();
+		assertThat(memberBadgeCount(memberId, retiredBadgeId)).isZero();
+	}
+
+	@Test
+	@DisplayName("한 회원의 저장 실패는 그 회원만 rollback하고 다른 회원 처리를 막지 않으며 다음 실행에서 재판정한다")
+	void isolatesOneMemberFailureAndRetriesOnNextRun() {
+		UUID failingMemberId = insertActiveMember();
+		UUID healthyMemberId = insertActiveMember();
+		UUID badgeId = insertBadge("탐험가");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
+		UUID place = insertPlace("장소A");
+		UUID mission = insertMission(place);
+
+		UUID failingTrip = insertTrip(failingMemberId);
+		insertCompletedParticipation(failingTrip, mission, Instant.now().minus(1, ChronoUnit.DAYS));
+		UUID healthyTrip = insertTrip(healthyMemberId);
+		insertCompletedParticipation(healthyTrip, mission, Instant.now().minus(1, ChronoUnit.DAYS));
+
+		jdbcTemplate.execute("CREATE FUNCTION fail_member_badges_insert() RETURNS trigger AS $$ " + "BEGIN "
+				+ "    IF NEW.member_id = '" + failingMemberId + "' THEN "
+				+ "        RAISE EXCEPTION 'forced reconciliation failure'; " + "    END IF; " + "    RETURN NEW; "
+				+ "END; " + "$$ LANGUAGE plpgsql");
+		jdbcTemplate.execute("""
+				CREATE TRIGGER fail_member_badges_insert
+				BEFORE INSERT ON member_badges
+				FOR EACH ROW EXECUTE FUNCTION fail_member_badges_insert()
+				""");
+
+		reconciliationService.reconcile();
+
+		assertThat(memberBadgeCount(failingMemberId, badgeId)).isZero();
+		assertThat(memberBadgeCount(healthyMemberId, badgeId)).isEqualTo(1);
+
+		jdbcTemplate.execute("DROP TRIGGER fail_member_badges_insert ON member_badges");
+		jdbcTemplate.execute("DROP FUNCTION fail_member_badges_insert()");
+
+		reconciliationService.reconcile();
+
+		assertThat(memberBadgeCount(failingMemberId, badgeId)).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("실시간 판정과 reconciliation이 동시에 경합해도 획득 이력과 알림은 한 번만 생성된다")
+	void realtimeAndReconciliationRaceProduceExactlyOneAwardAndNotification() throws Exception {
+		UUID memberId = insertActiveMember();
+		UUID badgeId = insertBadge("탐험가");
+		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
+		UUID place = insertPlace("장소A");
+		UUID mission = insertMission(place);
+		UUID tripId = insertTrip(memberId);
+		insertCompletedParticipation(tripId, mission, Instant.now().minus(1, ChronoUnit.DAYS));
+
+		Set<BadgeMetric> affectedMetrics = EnumSet.of(BadgeMetric.MISSION_COMPLETED_COUNT);
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			Future<?> realtime = executor.submit(concurrentTask(ready, start,
+					() -> badgeEvaluationService.award(memberId, tripId, affectedMetrics)));
+			Future<?> reconciliation = executor.submit(concurrentTask(ready, start, reconciliationService::reconcile));
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			realtime.get(10, TimeUnit.SECONDS);
+			reconciliation.get(10, TimeUnit.SECONDS);
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertThat(memberBadgeCount(memberId, badgeId)).isEqualTo(1);
+		assertThat(notificationCount(memberId, badgeId)).isEqualTo(1);
+	}
+
+	private <T> Callable<T> concurrentTask(CountDownLatch ready, CountDownLatch start, Callable<T> task) {
+		return () -> {
+			ready.countDown();
+			if (!start.await(5, TimeUnit.SECONDS)) {
+				throw new IllegalStateException("동시 실행 시작 신호를 받지 못했습니다.");
+			}
+			return task.call();
+		};
+	}
+
+	private UUID insertActiveMember() {
+		UUID memberId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		return memberId;
+	}
+
+	private UUID insertWithdrawnMember() {
+		UUID memberId = UUID.randomUUID();
+		jdbcTemplate.update("""
+				INSERT INTO members (id, status, withdrawn_at, purge_after)
+				VALUES (?, 'WITHDRAWN', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '30 days')
+				""", memberId);
+		return memberId;
+	}
+
+	private UUID insertTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO trips (id, member_id, status, ended_at) VALUES (?, ?, 'ENDED', CURRENT_TIMESTAMP)", tripId,
+				memberId);
+		return tripId;
+	}
+
+	private UUID insertPlace(String name) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO places (id, category, name, location) VALUES (?, 'HERITAGE'::place_category, ?, "
+						+ "ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography)",
+				id, name, ORIGIN_LONGITUDE, ORIGIN_LATITUDE);
+		return id;
+	}
+
+	private UUID insertMission(UUID placeId) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update("""
+				INSERT INTO missions (id, place_id, type, title, description, reward_points)
+				VALUES (?, ?, 'PHOTO', '테스트 미션', '설명', 100)
+				""", id, placeId);
+		return id;
+	}
+
+	private void insertCompletedParticipation(UUID tripId, UUID missionId, Instant completedAt) {
+		jdbcTemplate.update("""
+				INSERT INTO mission_participations (trip_id, mission_id, status, attempt_count, completed_at)
+				VALUES (?, ?, 'COMPLETED', 1, ?)
+				""", tripId, missionId, Timestamp.from(completedAt));
+	}
+
+	private void insertVisitRecord(UUID tripId, UUID missionId, UUID placeId, Instant visitedAt) {
+		jdbcTemplate.update("INSERT INTO visit_records (trip_id, mission_id, place_id, visited_at) VALUES (?, ?, ?, ?)",
+				tripId, missionId, placeId, Timestamp.from(visitedAt));
+	}
+
+	private void insertSettlement(UUID tripId, String choice, long settledPoints, Instant settledAt) {
+		Timestamp settledAtTimestamp = Timestamp.from(settledAt);
+		Timestamp expiresAt = "CARRY_OVER".equals(choice)
+				? Timestamp.from(settledAt.plus(240, ChronoUnit.HOURS))
+				: null;
+		jdbcTemplate.update("""
+				INSERT INTO point_settlements (trip_id, choice, settled_points, expires_at, settled_at)
+				VALUES (?, ?::settlement_choice, ?, ?, ?)
+				""", tripId, choice, settledPoints, expiresAt, settledAtTimestamp);
+	}
+
+	private UUID insertBadge(String name) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO badges (id, category, name, description, condition_text) "
+				+ "VALUES (?, 'EXPLORATION'::badge_category, ?, '설명', '조건')", id, name);
+		return id;
+	}
+
+	private void insertCondition(UUID badgeId, String metricKey, long threshold) {
+		jdbcTemplate.update("INSERT INTO badge_conditions (badge_id, metric_key, threshold) VALUES (?, ?, ?)", badgeId,
+				metricKey, threshold);
+	}
+
+	private Map<String, Object> memberBadgeRow(UUID memberId, UUID badgeId) {
+		return jdbcTemplate.queryForMap("SELECT * FROM member_badges WHERE member_id = ? AND badge_id = ?", memberId,
+				badgeId);
+	}
+
+	private long memberBadgeCount(UUID memberId, UUID badgeId) {
+		return Objects.requireNonNull(
+				jdbcTemplate.queryForObject("SELECT count(*) FROM member_badges WHERE member_id = ? AND badge_id = ?",
+						Long.class, memberId, badgeId));
+	}
+
+	private long notificationCount(UUID memberId, UUID badgeId) {
+		return Objects.requireNonNull(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM notifications WHERE member_id = ? "
+						+ "AND type = 'BADGE' AND target_type = 'BADGE' AND target_id = ?",
+				Long.class, memberId, badgeId));
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+}


### PR DESCRIPTION
## Summary
- 새 badge catalog 도입 전에 lifetime 조건을 충족했거나 실시간 지급에서 누락된 active member가 매일 `03:00 Asia/Seoul` reconciliation으로 배지와 알림을 받도록 구현했다.
- `BadgeMetricProvider`가 값뿐 아니라 최근 기여 trip·시각을 담은 `BadgeMetricSnapshot`을 반환하도록 확장했다(ADR-003). mission·trip·point 세 도메인에 metric snapshot 공개 query seam을 추가했으며, point 도메인의 `POINT_DONATION_COUNT` seam은 #126의 blocker를 해소한다.
- `BadgeReconciliationService`/`Scheduler`: member row 잠금 후 `ACTIVE` 재확인, 회원별 transaction, 조건별 최근 기여 trip tie-break(`latestContributionAt` desc → metric key asc → trip ID asc), 회원별 실패 격리 및 다음 실행 재판정.

Closes #124

## Test plan
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh` (spotless / checkstyle / spotbugs)
- [x] `./gradlew test` — 326 tests, 신규 `BadgeReconciliationIntegrationTests` 8건 포함 전체 통과 (`PlaceControllerIntegrationTests`의 무관한 기존 flaky 케이스 1건은 단독 재실행 시 통과 확인)
- [ ] `./scripts/test/docker-build.sh` — 로컬 환경에 `APPLE_TEAM_ID` 등 시크릿이 없어 미실행 (이번 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vNwfTUR1GQJdsitCZWhdm