### PR TITLE
feat: UC-14 배지 catalog startup 검증 구현 (#125)

### DIFF
--- a/src/main/java/com/buyeoon/badge/BadgeCatalogValidator.java
+++ b/src/main/java/com/buyeoon/badge/BadgeCatalogValidator.java
@@ -1,0 +1,75 @@
+package com.buyeoon.badge;
+
+import com.buyeoon.badge.application.BadgeMetricProviderRegistry;
+import com.buyeoon.badge.entity.BadgeConditionEntity;
+import com.buyeoon.badge.entity.BadgeEntity;
+import com.buyeoon.badge.repository.BadgeConditionRepository;
+import com.buyeoon.badge.repository.BadgeRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * 지급 가능한(지급이 중단되지 않은) 배지 catalog가 조건과 지원 metric Provider를 갖췄는지 애플리케이션 startup에
+ * 검증한다(ADR-003, 배지 rules #16). {@link SmartInitializingSingleton}은 모든 singleton
+ * bean이 생성된 직후, embedded 서버가 요청을 받기 전에 실행되므로 검증 실패 시 ApplicationContext 자체가 기동에
+ * 실패한다. Flyway로 관리하는 실제 schema가 없으면(H2 기반 경량 테스트 등) 검증할 catalog 자체가 없으므로
+ * Flyway가 적용된 경우에만 동작한다.
+ */
+@Component
+@ConditionalOnProperty(prefix = "spring.flyway", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class BadgeCatalogValidator implements SmartInitializingSingleton {
+
+	private final BadgeRepository badgeRepository;
+	private final BadgeConditionRepository badgeConditionRepository;
+	private final BadgeMetricProviderRegistry providerRegistry;
+
+	public BadgeCatalogValidator(BadgeRepository badgeRepository, BadgeConditionRepository badgeConditionRepository,
+			BadgeMetricProviderRegistry providerRegistry) {
+		this.badgeRepository = badgeRepository;
+		this.badgeConditionRepository = badgeConditionRepository;
+		this.providerRegistry = providerRegistry;
+	}
+
+	@Override
+	public void afterSingletonsInstantiated() {
+		List<BadgeEntity> awardableBadges = badgeRepository.findByRetiredAtIsNull();
+		if (awardableBadges.isEmpty()) {
+			return;
+		}
+
+		Map<UUID, List<BadgeConditionEntity>> conditionsByBadgeId = badgeConditionRepository
+				.findByIdBadgeIdIn(awardableBadges.stream().map(BadgeEntity::getId).toList()).stream()
+				.collect(Collectors.groupingBy(condition -> condition.getId().badgeId()));
+
+		List<String> errors = new ArrayList<>();
+		for (BadgeEntity badge : awardableBadges) {
+			validateBadge(badge, conditionsByBadgeId.getOrDefault(badge.getId(), List.of()), errors);
+		}
+
+		if (!errors.isEmpty()) {
+			throw new IllegalStateException("배지 catalog 검증 실패:\n" + String.join("\n", errors));
+		}
+	}
+
+	private void validateBadge(BadgeEntity badge, List<BadgeConditionEntity> conditions, List<String> errors) {
+		if (conditions.isEmpty()) {
+			errors.add("배지 '%s'(%s)에 조건이 하나도 없습니다.".formatted(badge.getName(), badge.getId()));
+			return;
+		}
+		for (BadgeConditionEntity condition : conditions) {
+			String metricKey = condition.getId().metricKey();
+			try {
+				providerRegistry.get(BadgeMetric.valueOf(metricKey));
+			} catch (IllegalArgumentException e) {
+				errors.add("배지 '%s'(%s)의 조건 metric '%s'에 등록된 Provider가 없습니다.".formatted(badge.getName(), badge.getId(),
+						metricKey));
+			}
+		}
+	}
+}

--- a/src/main/java/com/buyeoon/badge/repository/BadgeRepository.java
+++ b/src/main/java/com/buyeoon/badge/repository/BadgeRepository.java
@@ -10,6 +10,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface BadgeRepository extends JpaRepository<BadgeEntity, UUID> {
 
+	/** 지급이 중단되지 않아 startup catalog 검증 대상인 배지를 조회한다. */
+	List<BadgeEntity> findByRetiredAtIsNull();
+
 	/**
 	 * 지급이 중단되지 않았고 주어진 메트릭 중 하나 이상을 조건으로 가지며 회원이 아직 획득하지 않은 배지를 badge ID 오름차순으로
 	 * 조회한다.

--- a/src/test/java/com/buyeoon/badge/BadgeCatalogValidatorApplicationContextTests.java
+++ b/src/test/java/com/buyeoon/badge/BadgeCatalogValidatorApplicationContextTests.java
@@ -1,0 +1,140 @@
+package com.buyeoon.badge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.buyeoon.BuyeoOnApplication;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * UC-14 badge catalog startup 검증의 ApplicationContext 통합 테스트다. 실제
+ * PostgreSQL/Flyway schema에 각 시나리오의 fixture를 적재한 뒤 애플리케이션을 실제로 기동해 검증이 startup
+ * 시점에 동작함을 확인한다. Flyway 마이그레이션은 fixture를 적재할 테이블이 필요하므로 컨테이너 시작 직후 애플리케이션과 별개로
+ * 한 번 적용한다.
+ */
+@Testcontainers
+class BadgeCatalogValidatorApplicationContextTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	private ConfigurableApplicationContext context;
+
+	@BeforeAll
+	static void migrateSchema() {
+		Flyway.configure().dataSource(POSTGIS.getJdbcUrl(), APPLICATION_USERNAME, APPLICATION_PASSWORD).load()
+				.migrate();
+	}
+
+	@AfterEach
+	void cleanUp() {
+		if (context != null) {
+			context.close();
+		}
+		JdbcTemplate jdbcTemplate = jdbcTemplate();
+		jdbcTemplate.update("DELETE FROM member_badges");
+		jdbcTemplate.update("DELETE FROM badge_conditions");
+		jdbcTemplate.update("DELETE FROM badges");
+	}
+
+	@Test
+	@DisplayName("Empty catalog는 애플리케이션을 정상 기동한다")
+	void emptyCatalogStartsSuccessfully() {
+		context = startApplication();
+
+		assertThat(context.isActive()).isTrue();
+	}
+
+	@Test
+	@DisplayName("조건과 지원 Provider를 갖춘 catalog는 애플리케이션을 정상 기동한다")
+	void validCatalogStartsSuccessfully() {
+		insertBadgeWithCondition("탐험가", "MISSION_COMPLETED_COUNT", null);
+
+		context = startApplication();
+
+		assertThat(context.isActive()).isTrue();
+	}
+
+	@Test
+	@DisplayName("Condition이 없는 지급 가능 배지가 있으면 명확한 원인과 함께 startup이 실패한다")
+	void badgeWithoutConditionsFailsStartup() {
+		insertBadgeWithoutCondition("무조건 배지", null);
+
+		assertThatThrownBy(this::startApplication).hasStackTraceContaining("무조건 배지").hasStackTraceContaining("조건");
+	}
+
+	@Test
+	@DisplayName("등록된 Provider가 없는 metric을 가진 지급 가능 배지가 있으면 명확한 원인과 함께 startup이 실패한다")
+	void badgeWithUnsupportedMetricFailsStartup() {
+		insertBadgeWithCondition("미지원 메트릭 배지", "UNSUPPORTED_METRIC", null);
+
+		assertThatThrownBy(this::startApplication).hasStackTraceContaining("미지원 메트릭 배지")
+				.hasStackTraceContaining("UNSUPPORTED_METRIC");
+	}
+
+	@Test
+	@DisplayName("Retired badge는 조건이 없거나 미지원 metric이어도 startup을 막지 않는다")
+	void retiredBadgeDoesNotBlockStartup() {
+		Instant retiredAt = Instant.now();
+		insertBadgeWithoutCondition("은퇴한 무조건 배지", retiredAt);
+		insertBadgeWithCondition("은퇴한 미지원 메트릭 배지", "UNSUPPORTED_METRIC", retiredAt);
+
+		context = startApplication();
+
+		assertThat(context.isActive()).isTrue();
+	}
+
+	private ConfigurableApplicationContext startApplication() {
+		return new SpringApplicationBuilder(BuyeoOnApplication.class).web(WebApplicationType.SERVLET).run(
+				"--server.port=0", "--spring.datasource.url=" + POSTGIS.getJdbcUrl(),
+				"--spring.datasource.driver-class-name=org.postgresql.Driver",
+				"--spring.datasource.username=" + APPLICATION_USERNAME,
+				"--spring.datasource.password=" + APPLICATION_PASSWORD, "--spring.flyway.enabled=true",
+				"--spring.jpa.hibernate.ddl-auto=validate",
+				"--spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private void insertBadgeWithoutCondition(String name, Instant retiredAt) {
+		jdbcTemplate().update(
+				"INSERT INTO badges (id, category, name, description, condition_text, retired_at) "
+						+ "VALUES (?, 'EXPLORATION'::badge_category, ?, '설명', '조건', ?)",
+				UUID.randomUUID(), name, retiredAt == null ? null : Timestamp.from(retiredAt));
+	}
+
+	private void insertBadgeWithCondition(String name, String metricKey, Instant retiredAt) {
+		UUID badgeId = UUID.randomUUID();
+		jdbcTemplate().update(
+				"INSERT INTO badges (id, category, name, description, condition_text, retired_at) "
+						+ "VALUES (?, 'EXPLORATION'::badge_category, ?, '설명', '조건', ?)",
+				badgeId, name, retiredAt == null ? null : Timestamp.from(retiredAt));
+		jdbcTemplate().update("INSERT INTO badge_conditions (badge_id, metric_key, threshold) VALUES (?, ?, 1)",
+				badgeId, metricKey);
+	}
+
+	private JdbcTemplate jdbcTemplate() {
+		return new JdbcTemplate(
+				new DriverManagerDataSource(POSTGIS.getJdbcUrl(), APPLICATION_USERNAME, APPLICATION_PASSWORD));
+	}
+}

--- a/src/test/java/com/buyeoon/badge/BadgeCatalogValidatorTests.java
+++ b/src/test/java/com/buyeoon/badge/BadgeCatalogValidatorTests.java
@@ -1,0 +1,93 @@
+package com.buyeoon.badge;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.buyeoon.badge.application.BadgeMetricProviderRegistry;
+import com.buyeoon.badge.entity.BadgeCategory;
+import com.buyeoon.badge.entity.BadgeConditionEntity;
+import com.buyeoon.badge.entity.BadgeEntity;
+import com.buyeoon.badge.repository.BadgeConditionRepository;
+import com.buyeoon.badge.repository.BadgeRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/** UC-14 badge catalog startup 검증 로직의 단위 테스트다. */
+class BadgeCatalogValidatorTests {
+
+	private final BadgeRepository badgeRepository = mock(BadgeRepository.class);
+	private final BadgeConditionRepository badgeConditionRepository = mock(BadgeConditionRepository.class);
+	private final BadgeMetricProviderRegistry providerRegistry = mock(BadgeMetricProviderRegistry.class);
+	private final BadgeCatalogValidator validator = new BadgeCatalogValidator(badgeRepository, badgeConditionRepository,
+			providerRegistry);
+
+	@Test
+	@DisplayName("Empty catalog는 검증을 통과한다")
+	void emptyCatalogPasses() {
+		when(badgeRepository.findByRetiredAtIsNull()).thenReturn(List.of());
+
+		validator.afterSingletonsInstantiated();
+
+		verifyNoInteractions(badgeConditionRepository, providerRegistry);
+	}
+
+	@Test
+	@DisplayName("조건과 지원 Provider를 갖춘 catalog는 검증을 통과한다")
+	void validCatalogPasses() {
+		BadgeEntity badge = badge("탐험가");
+		when(badgeRepository.findByRetiredAtIsNull()).thenReturn(List.of(badge));
+		when(badgeConditionRepository.findByIdBadgeIdIn(List.of(badge.getId())))
+				.thenReturn(List.of(BadgeConditionEntity.create(badge.getId(), "MISSION_COMPLETED_COUNT", 1)));
+		when(providerRegistry.get(BadgeMetric.MISSION_COMPLETED_COUNT)).thenReturn(null);
+
+		validator.afterSingletonsInstantiated();
+	}
+
+	@Test
+	@DisplayName("Condition이 없는 지급 가능 배지가 있으면 명확한 원인과 함께 예외를 던진다")
+	void badgeWithoutConditionsFails() {
+		BadgeEntity badge = badge("탐험가");
+		when(badgeRepository.findByRetiredAtIsNull()).thenReturn(List.of(badge));
+		when(badgeConditionRepository.findByIdBadgeIdIn(List.of(badge.getId()))).thenReturn(List.of());
+
+		assertThatThrownBy(validator::afterSingletonsInstantiated).isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining(badge.getId().toString()).hasMessageContaining("탐험가").hasMessageContaining("조건");
+	}
+
+	@Test
+	@DisplayName("등록된 Provider가 없는 metric을 가진 지급 가능 배지가 있으면 명확한 원인과 함께 예외를 던진다")
+	void badgeWithUnsupportedMetricFails() {
+		BadgeEntity badge = badge("탐험가");
+		when(badgeRepository.findByRetiredAtIsNull()).thenReturn(List.of(badge));
+		when(badgeConditionRepository.findByIdBadgeIdIn(List.of(badge.getId())))
+				.thenReturn(List.of(BadgeConditionEntity.create(badge.getId(), "UNSUPPORTED_METRIC", 1)));
+
+		assertThatThrownBy(validator::afterSingletonsInstantiated).isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining(badge.getId().toString()).hasMessageContaining("UNSUPPORTED_METRIC");
+	}
+
+	@Test
+	@DisplayName("Registry에 Provider가 없는 지원 metric이면 명확한 원인과 함께 예외를 던진다")
+	void badgeWithMetricMissingFromRegistryFails() {
+		BadgeEntity badge = badge("탐험가");
+		when(badgeRepository.findByRetiredAtIsNull()).thenReturn(List.of(badge));
+		when(badgeConditionRepository.findByIdBadgeIdIn(List.of(badge.getId())))
+				.thenReturn(List.of(BadgeConditionEntity.create(badge.getId(), "POINT_DONATION_COUNT", 1)));
+		when(providerRegistry.get(BadgeMetric.POINT_DONATION_COUNT))
+				.thenThrow(new IllegalArgumentException("지원하지 않는 배지 메트릭: POINT_DONATION_COUNT"));
+
+		assertThatThrownBy(validator::afterSingletonsInstantiated).isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining(badge.getId().toString()).hasMessageContaining("POINT_DONATION_COUNT");
+	}
+
+	private BadgeEntity badge(String name) {
+		BadgeEntity badge = BadgeEntity.create(BadgeCategory.EXPLORATION, name, "설명", null, "조건");
+		ReflectionTestUtils.setField(badge, "id", UUID.randomUUID());
+		return badge;
+	}
+}

--- a/src/test/java/com/buyeoon/badge/application/BadgeMetricProviderRegistryDuplicateProviderTests.java
+++ b/src/test/java/com/buyeoon/badge/application/BadgeMetricProviderRegistryDuplicateProviderTests.java
@@ -1,0 +1,84 @@
+package com.buyeoon.badge.application;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.buyeoon.badge.BadgeMetric;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 같은 {@link BadgeMetric}을 담당하는 {@link BadgeMetricProvider}가 중복 등록되면
+ * {@link BadgeMetricProviderRegistry} 생성 시 애플리케이션 startup이 실패함을 좁은
+ * ApplicationContext로 검증한다(ADR-003).
+ */
+class BadgeMetricProviderRegistryDuplicateProviderTests {
+
+	@Test
+	@DisplayName("같은 metric의 Provider가 두 개 등록되면 ApplicationContext startup이 실패한다")
+	void duplicateProviderRegistrationFailsStartup() {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.register(DuplicateProviderConfig.class, BadgeMetricProviderRegistry.class);
+
+			assertThatThrownBy(context::refresh).hasStackTraceContaining("Duplicate key");
+		}
+	}
+
+	@Test
+	@DisplayName("서로 다른 metric의 Provider는 정상적으로 Registry에 등록된다")
+	void distinctProvidersStartUpSuccessfully() {
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+			context.register(DistinctProviderConfig.class, BadgeMetricProviderRegistry.class);
+			context.refresh();
+
+			BadgeMetricProviderRegistry registry = context.getBean(BadgeMetricProviderRegistry.class);
+			assertThatThrownBy(() -> registry.get(BadgeMetric.POINT_DONATION_COUNT))
+					.isInstanceOf(IllegalArgumentException.class);
+		}
+	}
+
+	@Configuration
+	static class DuplicateProviderConfig {
+
+		@Bean
+		BadgeMetricProvider firstMissionProvider() {
+			return stubProvider(BadgeMetric.MISSION_COMPLETED_COUNT);
+		}
+
+		@Bean
+		BadgeMetricProvider secondMissionProvider() {
+			return stubProvider(BadgeMetric.MISSION_COMPLETED_COUNT);
+		}
+	}
+
+	@Configuration
+	static class DistinctProviderConfig {
+
+		@Bean
+		BadgeMetricProvider missionProvider() {
+			return stubProvider(BadgeMetric.MISSION_COMPLETED_COUNT);
+		}
+
+		@Bean
+		BadgeMetricProvider heritageProvider() {
+			return stubProvider(BadgeMetric.HERITAGE_VISITED_COUNT);
+		}
+	}
+
+	private static BadgeMetricProvider stubProvider(BadgeMetric metric) {
+		return new BadgeMetricProvider() {
+			@Override
+			public BadgeMetric metric() {
+				return metric;
+			}
+
+			@Override
+			public BadgeMetricSnapshot calculate(UUID memberId) {
+				throw new UnsupportedOperationException();
+			}
+		};
+	}
+}


### PR DESCRIPTION
## Summary
- 지급이 중단되지 않은 배지가 조건을 하나 이상 가지는지, 각 조건의 metric에 등록된 `BadgeMetricProvider`가 있는지 애플리케이션 startup에 검증한다.
- 검증 실패 시 `ApplicationContext` 자체가 명확한 원인과 함께 기동을 실패시켜, mission/point 등 사용자 요청을 받기 전에 잘못된 catalog를 차단한다.
- Empty catalog와 retired badge는 검증 대상에서 자연히 제외되어 정상 기동한다.
- 같은 metric에 Provider가 중복 등록되면 `BadgeMetricProviderRegistry` 생성 시점에 startup이 실패함을 좁은 ApplicationContext 테스트로 확인했다.
- `spring.flyway.enabled=false`인 환경(schema가 없는 경량 wiring 테스트)에서는 validator 자체를 비활성화해, 기존 `BuyeoOnApplicationTests` smoke 테스트를 깨지 않도록 했다.

Closes #125

## Test plan
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh` (compileJava, spotlessCheck, checkstyle, spotbugs, 전체 `./gradlew check`)
- [x] `BadgeCatalogValidatorTests` — 단위 테스트(mock 기반, 모든 분기)
- [x] `BadgeCatalogValidatorApplicationContextTests` — 실제 PostgreSQL/Flyway 환경에서 empty/valid/조건없음/미지원metric/retired 시나리오별 실제 애플리케이션 기동 성공·실패 확인
- [x] `BadgeMetricProviderRegistryDuplicateProviderTests` — Provider 중복 등록 시 startup 실패 확인
- [ ] `./scripts/test/docker-build.sh` — 이 변경과 무관한 로컬 `.env`의 `APPLE_PRIVATE_KEY_BASE64` 누락으로 미실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vNwfTUR1GQJdsitCZWhdm