### PR TITLE
feat: UC-24 이월 포인트 만료 확정 구현 (#139)

### DIFF
--- a/src/main/java/com/buyeoon/point/application/PointExpirationScheduler.java
+++ b/src/main/java/com/buyeoon/point/application/PointExpirationScheduler.java
@@ -1,0 +1,20 @@
+package com.buyeoon.point.application;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** 포인트 요청이 없는 회원도 포함해 만료 도래 이월 포인트를 정기적으로 확정하는 point 도메인의 Scheduler다. */
+@Component
+public class PointExpirationScheduler {
+
+	private final PointExpirationService expirationService;
+
+	public PointExpirationScheduler(PointExpirationService expirationService) {
+		this.expirationService = expirationService;
+	}
+
+	@Scheduled(fixedDelayString = "${point.expiration.interval:PT1M}", initialDelayString = "${point.expiration.initial-delay:PT1M}")
+	public void expireDueCarryOvers() {
+		expirationService.expireAllDue();
+	}
+}

--- a/src/main/java/com/buyeoon/point/application/PointExpirationService.java
+++ b/src/main/java/com/buyeoon/point/application/PointExpirationService.java
@@ -1,0 +1,175 @@
+package com.buyeoon.point.application;
+
+import com.buyeoon.member.entity.MemberStatus;
+import com.buyeoon.point.repository.PointMemberRepository;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * 이월 포인트 만료를 확정하는 point 도메인의 공개 seam이다. 활성 회원 행을 먼저 잠그고 만료 도래한
+ * {@code CARRY_OVER} 정산을 {@code EXPIRE} 내역으로 확정한다. 호출자가 이미 트랜잭션 안에 있으면 그 트랜잭션에
+ * 참여하고, 없으면 회원별로 새 트랜잭션을 시작한다.
+ */
+@Service
+public final class PointExpirationService {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PointExpirationService.class);
+	private static final String EXPIRE_DESCRIPTION = "이월 포인트 만료";
+	private static final int BATCH_SIZE = 200;
+
+	private final PointMemberRepository members;
+	private final JdbcOperations jdbcOperations;
+	private final TransactionTemplate transactions;
+
+	public PointExpirationService(PointMemberRepository members, JdbcOperations jdbcOperations,
+			PlatformTransactionManager transactionManager) {
+		this.members = members;
+		this.jdbcOperations = jdbcOperations;
+		this.transactions = new TransactionTemplate(transactionManager);
+	}
+
+	/**
+	 * 만료 도래 정산이 있는 모든 활성 회원을 순회하며 회원별 독립 트랜잭션으로 만료를 확정한다. 한 회원의 실패는 로그로 남기고 다른 회원
+	 * 처리를 막지 않으며, 실패한 회원은 다음 실행에서 다시 시도한다. 확정한 EXPIRE 내역 수를 반환한다.
+	 */
+	public int expireAllDue() {
+		int expiredSettlements = 0;
+		Set<UUID> processedMemberIds = new HashSet<>();
+		DueSettlementRef cursor = null;
+		while (true) {
+			List<DueSettlementRef> batch = dueSettlementRefsAfter(cursor);
+			if (batch.isEmpty()) {
+				return expiredSettlements;
+			}
+			for (DueSettlementRef ref : batch) {
+				if (processedMemberIds.add(ref.memberId())) {
+					expiredSettlements += expireMemberSafely(ref.memberId());
+				}
+			}
+			cursor = batch.getLast();
+		}
+	}
+
+	/**
+	 * 지정한 회원의 만료 도래 {@code CARRY_OVER} 정산을 확정하고 처리한 건수를 반환한다. 회원이 활성 상태가 아니면 아무 것도
+	 * 하지 않는다.
+	 */
+	public int expireDueSettlements(UUID memberId) {
+		Integer expired = transactions.execute(status -> expireDueSettlementsInTransaction(memberId));
+		return expired == null ? 0 : expired;
+	}
+
+	private int expireMemberSafely(UUID memberId) {
+		try {
+			return expireDueSettlements(memberId);
+		} catch (RuntimeException exception) {
+			LOGGER.warn("이월 포인트 만료 확정에 실패했습니다. memberId={}", memberId, exception);
+			return 0;
+		}
+	}
+
+	private int expireDueSettlementsInTransaction(UUID memberId) {
+		if (members.findByIdAndStatus(memberId, MemberStatus.ACTIVE).isEmpty()) {
+			return 0;
+		}
+		List<DueSettlement> due = lockDueSettlements(memberId);
+		if (due.isEmpty()) {
+			return 0;
+		}
+		Instant processedAt = currentDbTime();
+		for (DueSettlement settlement : due) {
+			confirmExpiration(memberId, settlement, processedAt);
+		}
+		return due.size();
+	}
+
+	private void confirmExpiration(UUID memberId, DueSettlement settlement, Instant processedAt) {
+		jdbcOperations.update("""
+				INSERT INTO point_transactions (member_id, trip_id, type, amount, description, occurred_at)
+				VALUES (?, ?, 'EXPIRE', ?, ?, ?)
+				""", memberId, settlement.tripId(), -settlement.settledPoints(), EXPIRE_DESCRIPTION,
+				Timestamp.from(settlement.expiresAt()));
+		int updated = jdbcOperations.update("""
+				UPDATE point_settlements
+				SET expired_at = ?
+				WHERE id = ? AND expired_at IS NULL
+				""", Timestamp.from(processedAt), settlement.id());
+		if (updated != 1) {
+			throw new IllegalStateException("이월 포인트 만료 확정에 실패했습니다. settlementId=" + settlement.id());
+		}
+	}
+
+	private List<DueSettlement> lockDueSettlements(UUID memberId) {
+		return jdbcOperations.query("""
+				SELECT settlement.id, settlement.trip_id, settlement.settled_points, settlement.expires_at
+				FROM point_settlements settlement
+				JOIN trips trip ON trip.id = settlement.trip_id
+				WHERE trip.member_id = ?
+				  AND settlement.choice = 'CARRY_OVER'
+				  AND settlement.expired_at IS NULL
+				  AND settlement.expires_at <= CURRENT_TIMESTAMP
+				ORDER BY settlement.expires_at, settlement.id
+				FOR UPDATE OF settlement
+				""", this::mapDueSettlement, memberId);
+	}
+
+	private List<DueSettlementRef> dueSettlementRefsAfter(DueSettlementRef cursor) {
+		if (cursor == null) {
+			return jdbcOperations.query("""
+					SELECT settlement.id AS settlement_id, settlement.expires_at, trip.member_id
+					FROM point_settlements settlement
+					JOIN trips trip ON trip.id = settlement.trip_id
+					WHERE settlement.choice = 'CARRY_OVER'
+					  AND settlement.expired_at IS NULL
+					  AND settlement.expires_at <= CURRENT_TIMESTAMP
+					ORDER BY settlement.expires_at, settlement.id
+					LIMIT ?
+					""", this::mapDueSettlementRef, BATCH_SIZE);
+		}
+		return jdbcOperations.query("""
+				SELECT settlement.id AS settlement_id, settlement.expires_at, trip.member_id
+				FROM point_settlements settlement
+				JOIN trips trip ON trip.id = settlement.trip_id
+				WHERE settlement.choice = 'CARRY_OVER'
+				  AND settlement.expired_at IS NULL
+				  AND settlement.expires_at <= CURRENT_TIMESTAMP
+				  AND (settlement.expires_at, settlement.id) > (?, ?)
+				ORDER BY settlement.expires_at, settlement.id
+				LIMIT ?
+				""", this::mapDueSettlementRef, Timestamp.from(cursor.expiresAt()), cursor.settlementId(), BATCH_SIZE);
+	}
+
+	private Instant currentDbTime() {
+		return Objects.requireNonNull(jdbcOperations.queryForObject("SELECT CURRENT_TIMESTAMP", Timestamp.class))
+				.toInstant();
+	}
+
+	private DueSettlement mapDueSettlement(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new DueSettlement(resultSet.getObject("id", UUID.class), resultSet.getObject("trip_id", UUID.class),
+				resultSet.getLong("settled_points"), resultSet.getTimestamp("expires_at").toInstant());
+	}
+
+	private DueSettlementRef mapDueSettlementRef(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new DueSettlementRef(resultSet.getObject("settlement_id", UUID.class),
+				resultSet.getTimestamp("expires_at").toInstant(), resultSet.getObject("member_id", UUID.class));
+	}
+
+	private record DueSettlement(UUID id, UUID tripId, long settledPoints, Instant expiresAt) {
+	}
+
+	private record DueSettlementRef(UUID settlementId, Instant expiresAt, UUID memberId) {
+	}
+}

--- a/src/main/java/com/buyeoon/point/entity/PointSettlementEntity.java
+++ b/src/main/java/com/buyeoon/point/entity/PointSettlementEntity.java
@@ -41,15 +41,17 @@ public class PointSettlementEntity {
 	@Column(name = "settled_at", nullable = false, updatable = false)
 	private Instant settledAt;
 
-	public static PointSettlementEntity create(
-			UUID tripId, SettlementChoice choice, long settledPoints, Instant settledAt) {
+	@Column(name = "expired_at")
+	private Instant expiredAt;
+
+	public static PointSettlementEntity create(UUID tripId, SettlementChoice choice, long settledPoints,
+			Instant settledAt) {
 		PointSettlementEntity settlement = new PointSettlementEntity();
 		settlement.tripId = tripId;
 		settlement.choice = choice;
 		settlement.settledPoints = settledPoints;
 		settlement.settledAt = settledAt;
-		settlement.expiresAt =
-				choice == SettlementChoice.CARRY_OVER ? settledAt.plus(Duration.ofHours(240)) : null;
+		settlement.expiresAt = choice == SettlementChoice.CARRY_OVER ? settledAt.plus(Duration.ofHours(240)) : null;
 		return settlement;
 	}
 }

--- a/src/main/java/com/buyeoon/point/repository/PointMemberRepository.java
+++ b/src/main/java/com/buyeoon/point/repository/PointMemberRepository.java
@@ -1,0 +1,16 @@
+package com.buyeoon.point.repository;
+
+import com.buyeoon.member.entity.MemberEntity;
+import com.buyeoon.member.entity.MemberStatus;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+/** 이월 포인트 만료 처리가 회원 행을 잠그기 위한 point 도메인 소유의 읽기 전용 리포지토리다. */
+public interface PointMemberRepository extends JpaRepository<MemberEntity, UUID> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<MemberEntity> findByIdAndStatus(UUID id, MemberStatus status);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,3 +45,6 @@ location.buyeo-boundary=${BUYEO_BOUNDARY:classpath:boundaries/buyeo-44760.geojso
 member.purge.batch-size=${MEMBER_PURGE_BATCH_SIZE:100}
 member.purge.interval=${MEMBER_PURGE_INTERVAL:PT1M}
 member.purge.initial-delay=${MEMBER_PURGE_INITIAL_DELAY:PT1M}
+
+point.expiration.interval=${POINT_EXPIRATION_INTERVAL:PT1M}
+point.expiration.initial-delay=${POINT_EXPIRATION_INITIAL_DELAY:PT1M}

--- a/src/main/resources/db/migration/V12__track_point_settlement_expiration.sql
+++ b/src/main/resources/db/migration/V12__track_point_settlement_expiration.sql
@@ -1,0 +1,19 @@
+ALTER TABLE point_settlements
+    ADD COLUMN expired_at timestamptz; -- 이월 포인트 만료 처리를 실제로 확정한 시각
+
+ALTER TABLE point_settlements
+    DROP CONSTRAINT point_settlements_check;
+
+ALTER TABLE point_settlements
+    ADD CONSTRAINT point_settlements_check CHECK (
+        (choice = 'LEAVE_TO_BUYEO' AND expires_at IS NULL AND expired_at IS NULL)
+        OR (
+            choice = 'CARRY_OVER'
+            AND expires_at = settled_at + INTERVAL '240 hours'
+            AND (expired_at IS NULL OR expired_at >= expires_at)
+        )
+    );
+
+CREATE INDEX point_settlements_due_expiration_idx
+    ON point_settlements (expires_at, id)
+    WHERE choice = 'CARRY_OVER' AND expired_at IS NULL;

--- a/src/test/java/com/buyeoon/persistence/SchemaMappingTests.java
+++ b/src/test/java/com/buyeoon/persistence/SchemaMappingTests.java
@@ -33,6 +33,8 @@ class SchemaMappingTests {
 			.of("src/main/resources/db/migration/V8__track_member_data_purge.sql");
 	private static final Path LOCATION_TERM_MIGRATION = Path
 			.of("src/main/resources/db/migration/V9.1__add_location_term_type.sql");
+	private static final Path POINT_SETTLEMENT_EXPIRATION_MIGRATION = Path
+			.of("src/main/resources/db/migration/V12__track_point_settlement_expiration.sql");
 	private static final Pattern CREATE_TABLE = Pattern.compile("CREATE TABLE ([a-z_]+) ");
 
 	/** 초기 스키마에 후속 마이그레이션을 적용한 정의가 기준 DB 스키마와 같음을 보장한다. */
@@ -138,6 +140,25 @@ class SchemaMappingTests {
 				.contains("purged_at IS NULL");
 		assertThat(migration).contains("ADD COLUMN purged_at timestamptz").contains("members_lifecycle_ck")
 				.contains("members_due_purge_idx").contains("mission_photos_object_key_prefix_ck");
+	}
+
+	/** 이월 포인트 만료 처리 시각과 만료 대상 조회 인덱스가 기준 스키마와 업그레이드 경로에 함께 존재하는지 검증한다. */
+	@Test
+	@DisplayName("이월 포인트 만료 처리 시각은 기준 스키마와 마이그레이션에 정의되어 있다")
+	void pointSettlementExpirationIsDefinedInSchemaAndMigration() throws IOException {
+		String canonicalSchema = Files.readString(SCHEMA_SOURCE, StandardCharsets.UTF_8);
+		String migration = Files.readString(POINT_SETTLEMENT_EXPIRATION_MIGRATION, StandardCharsets.UTF_8);
+
+		assertThat(canonicalSchema).contains("expired_at timestamptz, -- 이월 포인트 만료 처리를 실제로 확정한 시각")
+				.contains("AND (expired_at IS NULL OR expired_at >= expires_at)")
+				.contains("CREATE INDEX point_settlements_due_expiration_idx")
+				.contains("ON point_settlements (expires_at, id)")
+				.contains("WHERE choice = 'CARRY_OVER' AND expired_at IS NULL;");
+		assertThat(migration).contains("ADD COLUMN expired_at timestamptz")
+				.contains("AND (expired_at IS NULL OR expired_at >= expires_at)")
+				.contains("CREATE INDEX point_settlements_due_expiration_idx")
+				.contains("ON point_settlements (expires_at, id)")
+				.contains("WHERE choice = 'CARRY_OVER' AND expired_at IS NULL;");
 	}
 
 	/** 미션 상태와 시도 횟수 제약이 신규 설치용 스키마와 기존 DB 업그레이드에 모두 반영됐는지 검증한다. */

--- a/src/test/java/com/buyeoon/point/PointExpirationIntegrationTests.java
+++ b/src/test/java/com/buyeoon/point/PointExpirationIntegrationTests.java
@@ -1,0 +1,292 @@
+package com.buyeoon.point;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.buyeoon.point.application.PointExpirationService;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/** UC-24 이월 포인트 만료 확정 흐름의 통합 테스트다. */
+@SpringBootTest
+@Testcontainers
+class PointExpirationIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private PointExpirationService expirationService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.execute("DROP TRIGGER IF EXISTS fail_point_transactions_insert ON point_transactions");
+		jdbcTemplate.execute("DROP FUNCTION IF EXISTS fail_point_transactions_insert()");
+		jdbcTemplate.update("DELETE FROM point_transactions");
+		jdbcTemplate.update("DELETE FROM point_settlements");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	@Test
+	@DisplayName("만료 시각이 도래한 CARRY_OVER 정산은 약속된 만료 시각의 EXPIRE 내역과 실제 처리 시각을 정확히 한 번 기록한다")
+	void expiresDueCarryOverExactlyOnce() {
+		UUID memberId = insertActiveMember();
+		UUID tripId = insertTrip(memberId);
+		Instant expiresAt = Instant.now().minusSeconds(60);
+		insertCarryOverSettlement(tripId, 300, expiresAt.minus(240, ChronoUnit.HOURS));
+
+		Instant before = currentDbTime();
+		int expired = expirationService.expireDueSettlements(memberId);
+		Instant after = currentDbTime();
+
+		assertThat(expired).isEqualTo(1);
+		Map<String, Object> transaction = onlyExpireTransaction(memberId);
+		assertThat(transaction.get("amount")).isEqualTo(-300L);
+		assertThat(((Timestamp) transaction.get("occurred_at")).toInstant()).isEqualTo(expiresAt);
+
+		Map<String, Object> settlement = settlementRow(tripId);
+		Instant expiredAt = ((Timestamp) settlement.get("expired_at")).toInstant();
+		assertThat(expiredAt).isBetween(before, after);
+	}
+
+	@Test
+	@DisplayName("아직 만료되지 않은 이월 정산은 변경하지 않는다")
+	void doesNotTouchNotYetDueCarryOver() {
+		UUID memberId = insertActiveMember();
+		UUID tripId = insertTrip(memberId);
+		insertCarryOverSettlement(tripId, 100, Instant.now().minus(1, ChronoUnit.HOURS));
+
+		int expired = expirationService.expireDueSettlements(memberId);
+
+		assertThat(expired).isZero();
+		assertThat(settlementRow(tripId).get("expired_at")).isNull();
+		assertThat(pointTransactionCount(memberId)).isZero();
+	}
+
+	@Test
+	@DisplayName("이미 만료 처리된 정산은 다시 처리하지 않는다")
+	void doesNotReprocessAlreadyExpiredSettlement() {
+		UUID memberId = insertActiveMember();
+		UUID tripId = insertTrip(memberId);
+		Instant expiresAt = Instant.now().minus(2, ChronoUnit.HOURS);
+		insertCarryOverSettlement(tripId, 150, expiresAt.minus(240, ChronoUnit.HOURS));
+
+		assertThat(expirationService.expireDueSettlements(memberId)).isEqualTo(1);
+		Instant firstExpiredAt = ((Timestamp) settlementRow(tripId).get("expired_at")).toInstant();
+
+		assertThat(expirationService.expireDueSettlements(memberId)).isZero();
+		assertThat(pointTransactionCount(memberId)).isEqualTo(1);
+		assertThat(((Timestamp) settlementRow(tripId).get("expired_at")).toInstant()).isEqualTo(firstExpiredAt);
+	}
+
+	@Test
+	@DisplayName("탈퇴 회원은 새 EXPIRE 내역을 만들지 않는다")
+	void skipsWithdrawnMember() {
+		UUID memberId = insertWithdrawnMember();
+		UUID tripId = insertTrip(memberId);
+		insertCarryOverSettlement(tripId, 100, Instant.now().minus(241, ChronoUnit.HOURS));
+
+		int expired = expirationService.expireDueSettlements(memberId);
+
+		assertThat(expired).isZero();
+		assertThat(settlementRow(tripId).get("expired_at")).isNull();
+	}
+
+	@Test
+	@DisplayName("한 회원의 만료 대상 정산이 여러 건이면 회원별 호출 한 번으로 모두 확정한다")
+	void expiresAllDueSettlementsForOneMemberInOneCall() {
+		UUID memberId = insertActiveMember();
+		UUID firstTrip = insertTrip(memberId);
+		UUID secondTrip = insertTrip(memberId);
+		insertCarryOverSettlement(firstTrip, 100, Instant.now().minus(241, ChronoUnit.HOURS));
+		insertCarryOverSettlement(secondTrip, 200, Instant.now().minus(300, ChronoUnit.HOURS));
+
+		int expired = expirationService.expireDueSettlements(memberId);
+
+		assertThat(expired).isEqualTo(2);
+		assertThat(pointTransactionCount(memberId)).isEqualTo(2);
+		assertThat(settlementRow(firstTrip).get("expired_at")).isNotNull();
+		assertThat(settlementRow(secondTrip).get("expired_at")).isNotNull();
+	}
+
+	@Test
+	@DisplayName("만료 도래 정산이 있는 모든 활성 회원을 순회해 만료를 확정한다")
+	void expireAllDueProcessesEveryActiveMemberWithDueSettlements() {
+		UUID firstMemberId = insertActiveMember();
+		UUID firstTrip = insertTrip(firstMemberId);
+		insertCarryOverSettlement(firstTrip, 100, Instant.now().minus(241, ChronoUnit.HOURS));
+		UUID secondMemberId = insertActiveMember();
+		UUID secondTrip = insertTrip(secondMemberId);
+		insertCarryOverSettlement(secondTrip, 50, Instant.now().minus(300, ChronoUnit.HOURS));
+		UUID notYetDueMemberId = insertActiveMember();
+		UUID notYetDueTrip = insertTrip(notYetDueMemberId);
+		insertCarryOverSettlement(notYetDueTrip, 40, Instant.now().minus(1, ChronoUnit.HOURS));
+
+		int expired = expirationService.expireAllDue();
+
+		assertThat(expired).isEqualTo(2);
+		assertThat(settlementRow(firstTrip).get("expired_at")).isNotNull();
+		assertThat(settlementRow(secondTrip).get("expired_at")).isNotNull();
+		assertThat(settlementRow(notYetDueTrip).get("expired_at")).isNull();
+	}
+
+	@Test
+	@DisplayName("한 회원의 만료 확정 실패는 다른 회원 처리를 막지 않으며 실패한 회원은 다음 실행에서 재시도한다")
+	void isolatesOneMemberFailureAndRetriesOnNextRun() {
+		UUID failingMemberId = insertActiveMember();
+		UUID failingTrip = insertTrip(failingMemberId);
+		insertCarryOverSettlement(failingTrip, 100, Instant.now().minus(241, ChronoUnit.HOURS));
+		UUID healthyMemberId = insertActiveMember();
+		UUID healthyTrip = insertTrip(healthyMemberId);
+		insertCarryOverSettlement(healthyTrip, 100, Instant.now().minus(241, ChronoUnit.HOURS));
+
+		jdbcTemplate.execute("CREATE FUNCTION fail_point_transactions_insert() RETURNS trigger AS $$ " + "BEGIN "
+				+ "    IF NEW.member_id = '" + failingMemberId + "' THEN "
+				+ "        RAISE EXCEPTION 'forced expiration failure'; " + "    END IF; " + "    RETURN NEW; "
+				+ "END; " + "$$ LANGUAGE plpgsql");
+		jdbcTemplate.execute("""
+				CREATE TRIGGER fail_point_transactions_insert
+				BEFORE INSERT ON point_transactions
+				FOR EACH ROW EXECUTE FUNCTION fail_point_transactions_insert()
+				""");
+
+		int expired = expirationService.expireAllDue();
+
+		assertThat(expired).isEqualTo(1);
+		assertThat(settlementRow(failingTrip).get("expired_at")).isNull();
+		assertThat(settlementRow(healthyTrip).get("expired_at")).isNotNull();
+
+		jdbcTemplate.execute("DROP TRIGGER fail_point_transactions_insert ON point_transactions");
+		jdbcTemplate.execute("DROP FUNCTION fail_point_transactions_insert()");
+
+		assertThat(expirationService.expireAllDue()).isEqualTo(1);
+		assertThat(settlementRow(failingTrip).get("expired_at")).isNotNull();
+	}
+
+	@Test
+	@DisplayName("같은 정산의 동시 만료 처리 요청에도 EXPIRE 내역과 잔액 차감은 한 번만 확정된다")
+	void concurrentExpirationOfSameSettlementProducesExactlyOneExpireTransaction() throws Exception {
+		UUID memberId = insertActiveMember();
+		UUID tripId = insertTrip(memberId);
+		insertCarryOverSettlement(tripId, 300, Instant.now().minus(241, ChronoUnit.HOURS));
+
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			Callable<Integer> task = () -> {
+				ready.countDown();
+				if (!start.await(5, TimeUnit.SECONDS)) {
+					throw new IllegalStateException("동시 실행 시작 신호를 받지 못했습니다.");
+				}
+				return expirationService.expireDueSettlements(memberId);
+			};
+			Future<Integer> first = executor.submit(task);
+			Future<Integer> second = executor.submit(task);
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			int totalExpired = first.get(10, TimeUnit.SECONDS) + second.get(10, TimeUnit.SECONDS);
+			assertThat(totalExpired).isEqualTo(1);
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertThat(pointTransactionCount(memberId)).isEqualTo(1);
+		Map<String, Object> transaction = onlyExpireTransaction(memberId);
+		assertThat(transaction.get("amount")).isEqualTo(-300L);
+	}
+
+	private UUID insertActiveMember() {
+		UUID memberId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		return memberId;
+	}
+
+	private UUID insertWithdrawnMember() {
+		UUID memberId = UUID.randomUUID();
+		jdbcTemplate.update("""
+				INSERT INTO members (id, status, withdrawn_at, purge_after)
+				VALUES (?, 'WITHDRAWN', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '30 days')
+				""", memberId);
+		return memberId;
+	}
+
+	private UUID insertTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status, ended_at, settled_at) "
+				+ "VALUES (?, ?, 'SETTLED', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", tripId, memberId);
+		return tripId;
+	}
+
+	private void insertCarryOverSettlement(UUID tripId, long settledPoints, Instant settledAt) {
+		jdbcTemplate.update("""
+				INSERT INTO point_settlements (trip_id, choice, settled_points, expires_at, settled_at)
+				VALUES (?, 'CARRY_OVER', ?, ?, ?)
+				""", tripId, settledPoints, Timestamp.from(settledAt.plus(240, ChronoUnit.HOURS)),
+				Timestamp.from(settledAt));
+	}
+
+	private Instant currentDbTime() {
+		return Objects.requireNonNull(jdbcTemplate.queryForObject("SELECT CURRENT_TIMESTAMP", Timestamp.class))
+				.toInstant();
+	}
+
+	private Map<String, Object> settlementRow(UUID tripId) {
+		return jdbcTemplate.queryForMap("SELECT * FROM point_settlements WHERE trip_id = ?", tripId);
+	}
+
+	private Map<String, Object> onlyExpireTransaction(UUID memberId) {
+		List<Map<String, Object>> rows = jdbcTemplate
+				.queryForList("SELECT * FROM point_transactions WHERE member_id = ? AND type = 'EXPIRE'", memberId);
+		assertThat(rows).hasSize(1);
+		return rows.get(0);
+	}
+
+	private long pointTransactionCount(UUID memberId) {
+		return Objects.requireNonNull(jdbcTemplate
+				.queryForObject("SELECT count(*) FROM point_transactions WHERE member_id = ?", Long.class, memberId));
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+}

--- a/src/test/java/com/buyeoon/point/application/PointExpirationSchedulerTests.java
+++ b/src/test/java/com/buyeoon/point/application/PointExpirationSchedulerTests.java
@@ -1,0 +1,20 @@
+package com.buyeoon.point.application;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PointExpirationSchedulerTests {
+
+	@Test
+	@DisplayName("스케줄 실행은 포인트 만료 확정 서비스에 위임한다")
+	void delegatesScheduledExecution() {
+		PointExpirationService expirationService = mock(PointExpirationService.class);
+
+		new PointExpirationScheduler(expirationService).expireDueCarryOvers();
+
+		verify(expirationService).expireAllDue();
+	}
+}


### PR DESCRIPTION
## Summary
- `point_settlements`에 `expired_at`을 추가하고 만료 대상 조회 인덱스(`point_settlements_due_expiration_idx`)를 만드는 Flyway migration(V12)을 추가했다.
- 활성 회원 행을 먼저 잠그고 만료 도래 `CARRY_OVER` 정산 행을 잠근 뒤, 해당 금액의 음수 `EXPIRE` 내역과 `expired_at`을 하나의 트랜잭션으로 확정하는 `PointExpirationService`를 추가했다.
- `EXPIRE.occurred_at`에는 약속된 `expires_at`을, `point_settlements.expired_at`에는 실제 처리 DB 시각을 기록한다.
- 포인트 요청이 없는 회원도 처리하는 멱등한 `PointExpirationScheduler`(`@Scheduled`)를 추가했다. 회원별 독립 트랜잭션으로 실행해 한 회원의 실패가 다른 회원 처리를 막지 않는다.
- HTTP 진입점 연동(#141), 정산 미리보기/확정(#142, #143)은 이번 티켓 범위 밖이며 후속 Sub-issue에서 다룬다.

Closes #139

## Test plan
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh` (compileJava, spotlessCheck, checkstyle, spotbugs)
- [x] `./gradlew test` — 신규/관련 테스트 전부 통과 (`PointExpirationIntegrationTests`: 정확히 한 번 만료, occurred_at/expired_at 구분, 만료 전·이미 처리된 정산 미변경, 탈퇴 회원 skip, 회원별 다건 배치, 회원별 실패 격리 및 재시도, 실제 동시 경합 테스트; `PointExpirationSchedulerTests`; `SchemaMappingTests`의 신규 전용 테스트)
- [ ] `./scripts/test/docker-build.sh` — 이 환경에 `.env` 시크릿(`APPLE_CLIENT_ID` 등)이 없어 실행하지 못함(이번 변경과 무관한 환경 제약)
- 참고: `SchemaMappingTests.canonicalSchemaMatchesMigrationChain`은 `main`에서도 이미 실패 중이던 pre-existing 상태(문서가 #143 범위인 `NO_POINTS`까지 앞서 반영되어 있음)로, #143 완료 시 함께 해소된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vNwfTUR1GQJdsitCZWhdm