### PR TITLE
feat: UC-24 미정산 여행 재시작 차단 (#140)

### DIFF
--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -278,7 +278,7 @@ paths:
     post:
       tags: [Trips]
       summary: 여행 시작
-      description: 필수 약관에 동의하고 디지털 군민증을 발급받은 회원이 부여 안에서 여행을 시작한다.
+      description: 필수 약관에 동의하고 디지털 군민증을 발급받은 회원이 진행 중이거나 종료 후 미정산인 여행이 없을 때 부여 안에서 여행을 시작한다.
       operationId: startTrip
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'
@@ -1054,7 +1054,7 @@ components:
                   code: OUTSIDE_BUYEO
                   message: 부여 안에서만 여행을 시작할 수 있습니다.
     TripStartConflict:
-      description: 멱등성 키 재사용 또는 이미 진행 중인 여행이 있는 상태
+      description: 멱등성 키 재사용, 이미 진행 중인 여행 또는 종료 후 미정산인 여행이 있는 상태
       content:
         application/json:
           schema:
@@ -1068,7 +1068,7 @@ components:
                   code: IDEMPOTENCY_KEY_REUSED
                   message: 같은 멱등성 키를 다른 요청에 재사용할 수 없습니다.
             invalidStateTransition:
-              summary: 이미 진행 중인 여행이 있음
+              summary: 이미 진행 중이거나 종료 후 미정산인 여행이 있음
               value:
                 success: false
                 data:

--- a/src/main/java/com/buyeoon/trip/TripRepository.java
+++ b/src/main/java/com/buyeoon/trip/TripRepository.java
@@ -3,6 +3,7 @@ package com.buyeoon.trip;
 import com.buyeoon.trip.entity.TripEntity;
 import com.buyeoon.trip.entity.TripStatus;
 import jakarta.persistence.LockModeType;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,11 +15,10 @@ public interface TripRepository extends JpaRepository<TripEntity, UUID> {
 
 	Optional<TripEntity> findByMemberIdAndStatus(UUID memberId, TripStatus status);
 
-	Optional<TripEntity> findByIdAndMemberId(UUID id, UUID memberId);
+	/** 회원이 여행 시작을 막는 상태의 여행을 소유하는지 확인한다. */
+	boolean existsByMemberIdAndStatusIn(UUID memberId, Collection<TripStatus> statuses);
 
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("SELECT t FROM TripEntity t WHERE t.memberId = :memberId AND t.status = :status")
-	Optional<TripEntity> lockByMemberIdAndStatus(@Param("memberId") UUID memberId, @Param("status") TripStatus status);
+	Optional<TripEntity> findByIdAndMemberId(UUID id, UUID memberId);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT t FROM TripEntity t WHERE t.id = :id AND t.memberId = :memberId")

--- a/src/main/java/com/buyeoon/trip/TripStartService.java
+++ b/src/main/java/com/buyeoon/trip/TripStartService.java
@@ -24,6 +24,7 @@ import java.time.ZonedDateTime;
 import java.util.HexFormat;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.stereotype.Service;
@@ -42,6 +43,7 @@ public class TripStartService implements TripStarter {
 	private static final String OPERATION = "START_TRIP";
 	private static final Duration RETENTION = Duration.ofHours(24);
 	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
+	private static final Set<TripStatus> START_BLOCKING_STATUSES = Set.of(TripStatus.IN_PROGRESS, TripStatus.ENDED);
 
 	private final JdbcOperations jdbcOperations;
 	private final TransactionTemplate transactions;
@@ -102,7 +104,7 @@ public class TripStartService implements TripStarter {
 		if (!citizenCards.existsByMemberId(memberId)) {
 			throw new CitizenCardNotIssuedException();
 		}
-		if (trips.lockByMemberIdAndStatus(memberId, TripStatus.IN_PROGRESS).isPresent()) {
+		if (trips.existsByMemberIdAndStatusIn(memberId, START_BLOCKING_STATUSES)) {
 			throw new InvalidStateTransitionException();
 		}
 

--- a/src/test/java/com/buyeoon/trip/TripStartIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/TripStartIntegrationTests.java
@@ -142,6 +142,38 @@ class TripStartIntegrationTests {
 				member.memberId())).isEqualTo(1L);
 	}
 
+	/** 종료했지만 정산하지 않은 여행이 있으면 새 여행과 성공 멱등성 결과를 만들지 않는다. */
+	@Test
+	@DisplayName("미정산 여행이 있으면 새 여행 시작을 거부한다")
+	void unsettledEndedTripIsRejected() throws Exception {
+		AuthenticatedMember member = readyMember();
+		insertPastTrip(member.memberId(), "ENDED");
+
+		performStart(member, "unsettled-trip-key", request(36.27, 126.91)).andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("INVALID_STATE_TRANSITION"));
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM trips WHERE member_id = ?", Long.class,
+				member.memberId())).isEqualTo(1L);
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM idempotency_requests WHERE member_id = ?",
+				Long.class, member.memberId())).isZero();
+	}
+
+	/** 이전 여행의 정산을 마친 회원은 새 여행을 시작할 수 있다. */
+	@Test
+	@DisplayName("정산 완료된 여행은 새 여행 시작을 막지 않는다")
+	void settledTripAllowsNewStart() throws Exception {
+		AuthenticatedMember member = readyMember();
+		insertPastTrip(member.memberId(), "SETTLED");
+
+		performStart(member, "settled-trip-key", request(36.27, 126.91)).andExpect(status().isCreated())
+				.andExpect(jsonPath("$.data.status").value("IN_PROGRESS"));
+
+		assertThat(
+				jdbcTemplate.queryForObject("SELECT count(*) FROM trips WHERE member_id = ? AND status = 'IN_PROGRESS'",
+						Long.class, member.memberId()))
+				.isEqualTo(1L);
+	}
+
 	/** 같은 키와 같은 본문의 재요청은 최초 성공 응답을 그대로 반환한다. */
 	@Test
 	@DisplayName("동일한 멱등성 요청은 최초 응답을 재사용한다")
@@ -309,6 +341,17 @@ class TripStartIntegrationTests {
 				INSERT INTO citizen_cards (member_id, theme_id, barcode_value)
 				VALUES (?, ?, ?)
 				""", memberId, themeId, UUID.randomUUID().toString());
+	}
+
+	/** 종료 또는 정산 완료된 과거 여행 테스트 데이터를 저장한다. */
+	private void insertPastTrip(UUID memberId, String status) {
+		Instant endedAt = Instant.parse("2026-08-12T09:00:00Z");
+		Timestamp settledAt = "SETTLED".equals(status) ? Timestamp.from(endedAt.plus(1, ChronoUnit.HOURS)) : null;
+		jdbcTemplate.update("""
+				INSERT INTO trips (id, member_id, status, started_at, ended_at, settled_at)
+				VALUES (?, ?, ?::trip_status, ?, ?, ?)
+				""", UUID.randomUUID(), memberId, status, Timestamp.from(endedAt.minus(1, ChronoUnit.HOURS)),
+				Timestamp.from(endedAt), settledAt);
 	}
 
 	private String request(double latitude, double longitude) {

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -267,7 +267,7 @@ paths:
     post:
       tags: [Trips]
       summary: 여행 시작
-      description: 필수 약관에 동의하고 디지털 군민증을 발급받은 회원이 부여 안에서 여행을 시작한다.
+      description: 필수 약관에 동의하고 디지털 군민증을 발급받은 회원이 진행 중이거나 종료 후 미정산인 여행이 없을 때 부여 안에서 여행을 시작한다.
       operationId: startTrip
       parameters:
         - $ref: '#/components/parameters/IdempotencyKey'


### PR DESCRIPTION
## Summary

- 회원 행을 먼저 잠근 뒤 `IN_PROGRESS`, `ENDED` 여행 존재 여부를 함께 확인합니다.
- 미정산 `ENDED` 여행이 있으면 새 여행과 성공 멱등성 결과를 만들지 않고 `409`를 반환합니다.
- `SETTLED` 여행 후 재시작 허용을 통합 테스트로 고정하고 OpenAPI 원본과 배포 Swagger 설명을 동기화합니다.

## Test

- [x] `TripStartIntegrationTests` 12개 통과
- [x] Spotless, Checkstyle, SpotBugs, 컴파일 통과
- [x] Docker image build 통과
- [ ] 전체 테스트: 348개 중 범위 밖 기존 실패 2개
  - `SchemaMappingTests`: #139 Flyway migration 반영 전 canonical schema 불일치
  - `BadgeReconciliationIntegrationTests`: 전체 suite scheduler 선실행 간섭, 단독 실행 통과
- [ ] Docker health check: 외부 PostgreSQL session pool 한도 초과(`EMAXCONNSESSION`, max 15)로 애플리케이션 시작 차단

## Review

- Standards: 차단 문제 없음
- Spec: #140 인수 조건 충족, 차단 문제 없음

Parent: #138

Closes #140
