### PR TITLE
feat: UC-24 포인트 진입점 만료 선반영·직렬화 (#141)

### DIFF
--- a/docs/domains/point/use-cases/uc-24-settle-trip-points.md
+++ b/docs/domains/point/use-cases/uc-24-settle-trip-points.md
@@ -2,9 +2,9 @@
 id: UC-24
 title: 여행 포인트 정산
 owner: point
-participants: [member, trip, badge, notification]
+participants: [member, trip, mission, badge, notification]
 policies: [authorization, idempotency, date-time, concurrency, transactions]
-api: ["GET /trips/{tripId}/settlement-preview", "PUT /trips/{tripId}/settlement"]
+api: ["GET /trips/{tripId}/settlement-preview", "PUT /trips/{tripId}/settlement", "GET /members/me/points", "GET /members/me/point-transactions", "POST /missions/{missionId}/submissions"]
 adrs: [ADR-003, ADR-010]
 ---
 

--- a/src/main/java/com/buyeoon/mission/api/MissionExceptionHandler.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionExceptionHandler.java
@@ -12,6 +12,7 @@ import com.buyeoon.mission.application.TripNotFoundException;
 import com.buyeoon.mission.application.TripNotInProgressException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -64,5 +65,12 @@ public class MissionExceptionHandler {
 	@ResponseStatus(HttpStatus.CONFLICT)
 	public ErrorResponse handleIdempotencyKeyReused() {
 		return ErrorResponse.idempotencyKeyReused();
+	}
+
+	/** 회원 행 잠금 시 활성 상태가 아니면 인증 실패 응답을 반환한다. */
+	@ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	public ErrorResponse handleUnauthorized() {
+		return ErrorResponse.unauthorized();
 	}
 }

--- a/src/main/java/com/buyeoon/mission/application/MissionSubmissionService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionSubmissionService.java
@@ -127,6 +127,7 @@ public class MissionSubmissionService {
 
 	private MissionSubmissionResult submitInTransaction(UUID memberId, UUID missionId, String idempotencyKey,
 			String requestHash, MissionSubmissionCommand command) {
+		long pointBalance = pointRewardService.currentBalance(memberId);
 		TripStatus tripStatus = tripQueryService.findOwnedTripStatus(memberId, command.tripId())
 				.orElseThrow(TripNotFoundException::new);
 		if (tripStatus != TripStatus.IN_PROGRESS) {
@@ -173,7 +174,6 @@ public class MissionSubmissionService {
 		missionSubmissions.save(toSubmissionEntity(participation.getId(), command, correct, photoRecordId));
 
 		int rewardPoints = 0;
-		long pointBalance = pointRewardService.currentBalance(memberId);
 		boolean visitRecorded = false;
 		UUID visitId = null;
 		List<AwardedBadgeResult> newlyAwardedBadges = List.of();

--- a/src/main/java/com/buyeoon/point/PointRewardService.java
+++ b/src/main/java/com/buyeoon/point/PointRewardService.java
@@ -2,30 +2,39 @@ package com.buyeoon.point;
 
 import com.buyeoon.point.entity.PointTransactionEntity;
 import com.buyeoon.point.entity.PointTransactionType;
+import com.buyeoon.point.application.PointExpirationService;
 import com.buyeoon.point.repository.PointTransactionRepository;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /** 다른 도메인이 미션 완료 보상을 지급할 때 사용하는 point 도메인의 공개 seam이다. */
 @Service
 public class PointRewardService {
 
 	private final PointTransactionRepository pointTransactions;
+	private final PointExpirationService pointExpirationService;
 
-	/** 포인트 내역 저장과 잔액 조회를 담당하는 통합 repository를 주입받는다. */
-	public PointRewardService(PointTransactionRepository pointTransactions) {
+	/** 포인트 내역 repository와 요청 시점 만료 확정 seam을 주입받는다. */
+	public PointRewardService(PointTransactionRepository pointTransactions,
+			PointExpirationService pointExpirationService) {
 		this.pointTransactions = pointTransactions;
+		this.pointExpirationService = pointExpirationService;
 	}
 
 	/** 미션 완료 보상을 지급하고 회원의 갱신된 포인트 잔액을 반환한다. */
+	@Transactional
 	public long reward(UUID memberId, UUID tripId, UUID participationId, int amount, String description) {
+		pointExpirationService.expireDueSettlementsForActiveMember(memberId);
 		pointTransactions.save(PointTransactionEntity.create(memberId, tripId, participationId,
 				PointTransactionType.EARN, amount, description));
-		return currentBalance(memberId);
+		return pointTransactions.sumAmountByMemberId(memberId);
 	}
 
-	/** 회원의 현재 포인트 잔액을 포인트 내역 합계로 계산한다. */
+	/** 활성 회원 행을 잠그고 만료 도래분을 반영한 현재 포인트 잔액을 계산한다. */
+	@Transactional
 	public long currentBalance(UUID memberId) {
+		pointExpirationService.expireDueSettlementsForActiveMember(memberId);
 		return pointTransactions.sumAmountByMemberId(memberId);
 	}
 }

--- a/src/main/java/com/buyeoon/point/api/PointExceptionHandler.java
+++ b/src/main/java/com/buyeoon/point/api/PointExceptionHandler.java
@@ -2,6 +2,7 @@ package com.buyeoon.point.api;
 
 import com.buyeoon.common.api.ErrorResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,5 +14,12 @@ public class PointExceptionHandler {
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ErrorResponse handleInvalidRequest() {
 		return ErrorResponse.invalidRequest();
+	}
+
+	/** 회원 행 잠금 시 활성 상태가 아니면 인증 실패 응답을 반환한다. */
+	@ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
+	public ErrorResponse handleUnauthorized() {
+		return ErrorResponse.unauthorized();
 	}
 }

--- a/src/main/java/com/buyeoon/point/application/PointExpirationService.java
+++ b/src/main/java/com/buyeoon/point/application/PointExpirationService.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -68,8 +69,15 @@ public final class PointExpirationService {
 	 * 하지 않는다.
 	 */
 	public int expireDueSettlements(UUID memberId) {
-		Integer expired = transactions.execute(status -> expireDueSettlementsInTransaction(memberId));
+		Integer expired = transactions.execute(status -> expireDueSettlementsInTransaction(memberId, false));
 		return expired == null ? 0 : expired;
+	}
+
+	/**
+	 * 활성 회원 행을 잠근 뒤 만료 도래 정산을 확정한다. 탈퇴가 먼저 확정됐거나 회원이 없으면 인증 실패로 처리한다.
+	 */
+	public void expireDueSettlementsForActiveMember(UUID memberId) {
+		transactions.executeWithoutResult(status -> expireDueSettlementsInTransaction(memberId, true));
 	}
 
 	private int expireMemberSafely(UUID memberId) {
@@ -81,8 +89,11 @@ public final class PointExpirationService {
 		}
 	}
 
-	private int expireDueSettlementsInTransaction(UUID memberId) {
+	private int expireDueSettlementsInTransaction(UUID memberId, boolean activeMemberRequired) {
 		if (members.findByIdAndStatus(memberId, MemberStatus.ACTIVE).isEmpty()) {
+			if (activeMemberRequired) {
+				throw new AuthenticationCredentialsNotFoundException("활성 회원이 아닙니다.");
+			}
 			return 0;
 		}
 		List<DueSettlement> due = lockDueSettlements(memberId);
@@ -90,8 +101,13 @@ public final class PointExpirationService {
 			return 0;
 		}
 		Instant processedAt = currentDbTime();
+		long balance = currentBalance(memberId);
 		for (DueSettlement settlement : due) {
+			if (balance < settlement.settledPoints()) {
+				throw new IllegalStateException("만료 포인트가 현재 잔액보다 큽니다. settlementId=" + settlement.id());
+			}
 			confirmExpiration(memberId, settlement, processedAt);
+			balance -= settlement.settledPoints();
 		}
 		return due.size();
 	}
@@ -155,6 +171,14 @@ public final class PointExpirationService {
 	private Instant currentDbTime() {
 		return Objects.requireNonNull(jdbcOperations.queryForObject("SELECT CURRENT_TIMESTAMP", Timestamp.class))
 				.toInstant();
+	}
+
+	/** 회원 행 잠금 뒤 직전에 확정된 포인트 내역 합계로 현재 잔액을 계산한다. */
+	private long currentBalance(UUID memberId) {
+		Long balance = jdbcOperations.queryForObject(
+				"SELECT COALESCE(SUM(amount), 0)::bigint FROM point_transactions WHERE member_id = ?", Long.class,
+				memberId);
+		return balance == null ? 0L : balance;
 	}
 
 	private DueSettlement mapDueSettlement(ResultSet resultSet, int rowNumber) throws SQLException {

--- a/src/main/java/com/buyeoon/point/application/PointSummaryService.java
+++ b/src/main/java/com/buyeoon/point/application/PointSummaryService.java
@@ -14,22 +14,27 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** 회원의 포인트 잔액 요약(잔액, 누적 적립, 만료 예정)을 조회하는 point 도메인의 공개 seam이다. */
 @Service
-@Transactional(readOnly = true)
+@Transactional
 public class PointSummaryService {
 
 	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
 
 	private final PointTransactionRepository pointTransactionRepository;
 	private final PointSettlementQueryRepository pointSettlementQueryRepository;
+	private final PointExpirationService pointExpirationService;
 
+	/** 포인트 조회 repository와 요청 시점 만료 확정 seam을 주입받는다. */
 	public PointSummaryService(PointTransactionRepository pointTransactionRepository,
-			PointSettlementQueryRepository pointSettlementQueryRepository) {
+			PointSettlementQueryRepository pointSettlementQueryRepository,
+			PointExpirationService pointExpirationService) {
 		this.pointTransactionRepository = pointTransactionRepository;
 		this.pointSettlementQueryRepository = pointSettlementQueryRepository;
+		this.pointExpirationService = pointExpirationService;
 	}
 
 	/** 잔액, `EARN` 누적 합계, 만료 시각 오름차순 만료 예정 목록을 조회한다. */
 	public PointSummaryView getSummary(UUID memberId) {
+		pointExpirationService.expireDueSettlementsForActiveMember(memberId);
 		long balance = pointTransactionRepository.sumAmountByMemberId(memberId);
 		long cumulativeEarned = pointTransactionRepository.sumAmountByMemberIdAndType(memberId,
 				PointTransactionType.EARN);

--- a/src/main/java/com/buyeoon/point/application/PointTransactionQueryService.java
+++ b/src/main/java/com/buyeoon/point/application/PointTransactionQueryService.java
@@ -12,19 +12,24 @@ import org.springframework.transaction.annotation.Transactional;
 
 /** 회원의 포인트 내역을 발생 시각 최신순으로 커서 페이지네이션 조회하는 point 도메인의 공개 seam이다. */
 @Service
-@Transactional(readOnly = true)
+@Transactional
 public class PointTransactionQueryService {
 
 	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
 
 	private final PointTransactionRepository pointTransactionRepository;
+	private final PointExpirationService pointExpirationService;
 
-	public PointTransactionQueryService(PointTransactionRepository pointTransactionRepository) {
+	/** 포인트 내역 repository와 요청 시점 만료 확정 seam을 주입받는다. */
+	public PointTransactionQueryService(PointTransactionRepository pointTransactionRepository,
+			PointExpirationService pointExpirationService) {
 		this.pointTransactionRepository = pointTransactionRepository;
+		this.pointExpirationService = pointExpirationService;
 	}
 
 	/** 발생 시각 최신순, 동일 시각은 내역 ID 순으로 정렬된 한 페이지를 balanceAfter와 함께 조회한다. */
 	public PointTransactionListView list(UUID memberId, PointTransactionCursor cursor, int size) {
+		pointExpirationService.expireDueSettlementsForActiveMember(memberId);
 		List<PointTransactionRow> rows = cursor == null
 				? pointTransactionRepository.findFromStart(memberId, size + 1)
 				: pointTransactionRepository.findAfter(memberId, cursor.occurredAt(), cursor.transactionId(), size + 1);

--- a/src/test/java/com/buyeoon/mission/MissionSubmissionIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionSubmissionIntegrationTests.java
@@ -7,7 +7,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.buyeoon.member.auth.AccessTokenService;
 import com.buyeoon.mission.application.MissionCompleted;
+import com.buyeoon.point.application.PointExpirationService;
 import com.buyeoon.trip.VisitRecorded;
+import com.jayway.jsonpath.JsonPath;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -71,6 +73,9 @@ class MissionSubmissionIntegrationTests {
 	@Autowired
 	private ApplicationEvents applicationEvents;
 
+	@Autowired
+	private PointExpirationService pointExpirationService;
+
 	private AuthenticatedMember member;
 
 	@BeforeEach
@@ -81,6 +86,7 @@ class MissionSubmissionIntegrationTests {
 	@AfterEach
 	void cleanUp() {
 		jdbcTemplate.update("DELETE FROM idempotency_requests");
+		jdbcTemplate.update("DELETE FROM point_settlements");
 		jdbcTemplate.update("DELETE FROM point_transactions");
 		jdbcTemplate.update("DELETE FROM visit_records");
 		jdbcTemplate.update("DELETE FROM mission_submissions");
@@ -125,6 +131,124 @@ class MissionSubmissionIntegrationTests {
 
 		assertThat(applicationEvents.stream(MissionCompleted.class)).hasSize(1);
 		assertThat(applicationEvents.stream(VisitRecorded.class)).hasSize(1);
+	}
+
+	/** 미션 보상은 만료 도래 이월분을 먼저 EXPIRE로 확정한 뒤 EARN과 갱신 잔액을 반환한다. */
+	@Test
+	@DisplayName("만료 도래 이월분을 먼저 확정한 뒤 미션 보상과 갱신 잔액을 반환한다")
+	void expiresDueCarryOverBeforeGrantingMissionReward() throws Exception {
+		insertPointTransaction(member.memberId(), 300, Instant.now().minus(241, ChronoUnit.HOURS));
+		UUID settledTripId = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(settledTripId, 200, Instant.now().minus(1, ChronoUnit.MINUTES));
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("만료 후 보상 장소", 50);
+		UUID missionId = insertOxMission(place, "만료 후 보상 미션", 100, null, true);
+
+		mockMvc.perform(submit(missionId, "expire-before-reward", oxRequest(tripId, true))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.rewardPoints").value(100))
+				.andExpect(jsonPath("$.data.pointBalance").value(200));
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM point_transactions WHERE member_id = ? AND type = 'EXPIRE'", Integer.class,
+				member.memberId())).isEqualTo(1);
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM point_transactions WHERE member_id = ? AND type = 'EARN'", Integer.class,
+				member.memberId())).isEqualTo(2);
+	}
+
+	/** 미션 보상과 scheduler가 경합해도 만료 후 EARN 순서로 한 번씩 확정하고 음수 잔액을 만들지 않는다. */
+	@Test
+	@DisplayName("미션 보상과 scheduler 경합에도 만료 후 EARN 잔액을 직렬화한다")
+	void missionRewardAndSchedulerSerializeExpirationBeforeEarn() throws Exception {
+		insertPointTransaction(member.memberId(), 300, Instant.now().minus(241, ChronoUnit.HOURS));
+		UUID settledTripId = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(settledTripId, 200, Instant.now().minus(1, ChronoUnit.MINUTES));
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("동시 만료 보상 장소", 50);
+		UUID missionId = insertOxMission(place, "동시 만료 보상 미션", 100, null, true);
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+
+		try {
+			Future<MvcResult> reward = executor.submit(() -> concurrentSubmit(missionId, "concurrent-expire-reward",
+					oxRequest(tripId, true), ready, start));
+			Future<Integer> scheduler = executor.submit(() -> {
+				ready.countDown();
+				if (!start.await(5, TimeUnit.SECONDS)) {
+					throw new IllegalStateException("동시 실행 시작 신호를 받지 못했습니다.");
+				}
+				return pointExpirationService.expireAllDue();
+			});
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			MvcResult result = reward.get(10, TimeUnit.SECONDS);
+			scheduler.get(10, TimeUnit.SECONDS);
+			assertThat(result.getResponse().getStatus()).isEqualTo(200);
+			assertThat(JsonPath.<Integer>read(result.getResponse().getContentAsString(), "$.data.pointBalance"))
+					.isEqualTo(200);
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM point_transactions WHERE member_id = ? AND type = 'EXPIRE'", Integer.class,
+				member.memberId())).isEqualTo(1);
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT COALESCE(SUM(amount), 0)::bigint FROM point_transactions WHERE member_id = ?", Long.class,
+				member.memberId())).isEqualTo(200L);
+		assertThat(jdbcTemplate.queryForObject("""
+				SELECT MIN(balance_after)::bigint
+				FROM (
+				    SELECT SUM(amount) OVER (ORDER BY occurred_at, id) AS balance_after
+				    FROM point_transactions
+				    WHERE member_id = ?
+				) balances
+				""", Long.class, member.memberId())).isGreaterThanOrEqualTo(0L);
+	}
+
+	/** 미션 제출이 실패하면 같은 transaction에서 선반영한 만료도 함께 롤백한다. */
+	@Test
+	@DisplayName("미션 제출 실패는 선반영한 만료와 미션 변경을 함께 롤백한다")
+	void failedMissionSubmissionRollsBackExpiration() throws Exception {
+		insertPointTransaction(member.memberId(), 300, Instant.now().minus(241, ChronoUnit.HOURS));
+		UUID settledTripId = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(settledTripId, 200, Instant.now().minus(1, ChronoUnit.MINUTES));
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("먼 만료 보상 장소", 100.1);
+		UUID missionId = insertOxMission(place, "실패하는 만료 보상 미션", 100, null, true);
+
+		mockMvc.perform(submit(missionId, "rollback-expiration", oxRequest(tripId, true)))
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.data.code").value("LOCATION_VERIFICATION_FAILED"));
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM point_transactions WHERE member_id = ? AND type = 'EXPIRE'", Integer.class,
+				member.memberId())).isZero();
+		assertThat(jdbcTemplate.queryForObject("SELECT expired_at IS NULL FROM point_settlements WHERE trip_id = ?",
+				Boolean.class, settledTripId)).isTrue();
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM mission_participations WHERE trip_id = ?",
+				Integer.class, tripId)).isZero();
+	}
+
+	/** 탈퇴가 먼저 확정된 회원은 기존 토큰으로 미션 보상을 요청할 수 없다. */
+	@Test
+	@DisplayName("탈퇴가 먼저 확정되면 미션 보상을 거부하고 WITHDRAWN을 유지한다")
+	void rejectsMissionRewardAfterWithdrawalCompleted() throws Exception {
+		jdbcTemplate.update("""
+				UPDATE members
+				SET status = 'WITHDRAWN', withdrawn_at = CURRENT_TIMESTAMP,
+				    purge_after = CURRENT_TIMESTAMP + INTERVAL '30 days'
+				WHERE id = ?
+				""", member.memberId());
+
+		mockMvc.perform(submit(UUID.randomUUID(), "withdrawn-reward", oxRequest(UUID.randomUUID(), true)))
+				.andExpect(status().isUnauthorized()).andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+
+		assertThat(jdbcTemplate.queryForObject("SELECT status::text FROM members WHERE id = ?", String.class,
+				member.memberId())).isEqualTo("WITHDRAWN");
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM point_transactions WHERE member_id = ?",
+				Integer.class, member.memberId())).isZero();
 	}
 
 	/** 객관식 미션에 정답을 제출하면 완료 처리된다. */
@@ -417,6 +541,32 @@ class MissionSubmissionIntegrationTests {
 		UUID tripId = UUID.randomUUID();
 		jdbcTemplate.update("INSERT INTO trips (id, member_id, status) VALUES (?, ?, 'IN_PROGRESS')", tripId, memberId);
 		return tripId;
+	}
+
+	/** 만료 선반영 fixture의 기존 잔액을 만드는 EARN 내역을 저장한다. */
+	private void insertPointTransaction(UUID memberId, long amount, Instant occurredAt) {
+		jdbcTemplate.update("""
+				INSERT INTO point_transactions (id, member_id, type, amount, description, occurred_at)
+				VALUES (?, ?, 'EARN', ?, '기존 미션 보상', ?)
+				""", UUID.randomUUID(), memberId, amount, Timestamp.from(occurredAt));
+	}
+
+	/** 만료 정산 fixture가 참조할 회원 소유의 정산 완료 여행을 만든다. */
+	private UUID insertSettledTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO trips (id, member_id, status, ended_at, settled_at) VALUES (?, ?, 'SETTLED', now(), now())",
+				tripId, memberId);
+		return tripId;
+	}
+
+	/** 지정한 시각에 만료되는 CARRY_OVER 정산 fixture를 만든다. */
+	private void insertCarryOverSettlement(UUID tripId, long settledPoints, Instant expiresAt) {
+		jdbcTemplate.update("""
+				INSERT INTO point_settlements (id, trip_id, choice, settled_points, expires_at, settled_at)
+				VALUES (?, ?, 'CARRY_OVER', ?, ?, ?)
+				""", UUID.randomUUID(), tripId, settledPoints, Timestamp.from(expiresAt),
+				Timestamp.from(expiresAt.minus(240, ChronoUnit.HOURS)));
 	}
 
 	private UUID insertPlace(String name, double latitude, double longitude) {

--- a/src/test/java/com/buyeoon/point/PointExpirationIntegrationTests.java
+++ b/src/test/java/com/buyeoon/point/PointExpirationIntegrationTests.java
@@ -1,6 +1,7 @@
 package com.buyeoon.point;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.buyeoon.point.application.PointExpirationService;
 import java.sql.Timestamp;
@@ -92,7 +93,7 @@ class PointExpirationIntegrationTests {
 
 		assertThat(expired).isZero();
 		assertThat(settlementRow(tripId).get("expired_at")).isNull();
-		assertThat(pointTransactionCount(memberId)).isZero();
+		assertThat(expireTransactionCount(memberId)).isZero();
 	}
 
 	@Test
@@ -107,7 +108,7 @@ class PointExpirationIntegrationTests {
 		Instant firstExpiredAt = ((Timestamp) settlementRow(tripId).get("expired_at")).toInstant();
 
 		assertThat(expirationService.expireDueSettlements(memberId)).isZero();
-		assertThat(pointTransactionCount(memberId)).isEqualTo(1);
+		assertThat(expireTransactionCount(memberId)).isEqualTo(1);
 		assertThat(((Timestamp) settlementRow(tripId).get("expired_at")).toInstant()).isEqualTo(firstExpiredAt);
 	}
 
@@ -136,7 +137,7 @@ class PointExpirationIntegrationTests {
 		int expired = expirationService.expireDueSettlements(memberId);
 
 		assertThat(expired).isEqualTo(2);
-		assertThat(pointTransactionCount(memberId)).isEqualTo(2);
+		assertThat(expireTransactionCount(memberId)).isEqualTo(2);
 		assertThat(settlementRow(firstTrip).get("expired_at")).isNotNull();
 		assertThat(settlementRow(secondTrip).get("expired_at")).isNotNull();
 	}
@@ -223,9 +224,27 @@ class PointExpirationIntegrationTests {
 			executor.shutdownNow();
 		}
 
-		assertThat(pointTransactionCount(memberId)).isEqualTo(1);
+		assertThat(expireTransactionCount(memberId)).isEqualTo(1);
 		Map<String, Object> transaction = onlyExpireTransaction(memberId);
 		assertThat(transaction.get("amount")).isEqualTo(-300L);
+	}
+
+	@Test
+	@DisplayName("만료액이 직전 확정 잔액보다 크면 만료 전체를 롤백하고 음수 잔액을 만들지 않는다")
+	void doesNotExpireMorePointsThanCurrentBalance() {
+		UUID memberId = insertActiveMember();
+		UUID tripId = insertTrip(memberId);
+		insertCarryOverSettlement(tripId, 200, Instant.now().minus(241, ChronoUnit.HOURS));
+		jdbcTemplate.update("UPDATE point_transactions SET amount = 100 WHERE trip_id = ? AND type = 'EARN'", tripId);
+
+		assertThatThrownBy(() -> expirationService.expireDueSettlements(memberId))
+				.isInstanceOf(IllegalStateException.class);
+
+		assertThat(expireTransactionCount(memberId)).isZero();
+		assertThat(settlementRow(tripId).get("expired_at")).isNull();
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT COALESCE(SUM(amount), 0)::bigint FROM point_transactions WHERE member_id = ?", Long.class,
+				memberId)).isEqualTo(100L);
 	}
 
 	private UUID insertActiveMember() {
@@ -251,6 +270,12 @@ class PointExpirationIntegrationTests {
 	}
 
 	private void insertCarryOverSettlement(UUID tripId, long settledPoints, Instant settledAt) {
+		UUID memberId = Objects.requireNonNull(
+				jdbcTemplate.queryForObject("SELECT member_id FROM trips WHERE id = ?", UUID.class, tripId));
+		jdbcTemplate.update("""
+				INSERT INTO point_transactions (member_id, trip_id, type, amount, description, occurred_at)
+				VALUES (?, ?, 'EARN', ?, '이월 전 적립', ?)
+				""", memberId, tripId, settledPoints, Timestamp.from(settledAt));
 		jdbcTemplate.update("""
 				INSERT INTO point_settlements (trip_id, choice, settled_points, expires_at, settled_at)
 				VALUES (?, 'CARRY_OVER', ?, ?, ?)
@@ -274,9 +299,10 @@ class PointExpirationIntegrationTests {
 		return rows.get(0);
 	}
 
-	private long pointTransactionCount(UUID memberId) {
-		return Objects.requireNonNull(jdbcTemplate
-				.queryForObject("SELECT count(*) FROM point_transactions WHERE member_id = ?", Long.class, memberId));
+	private long expireTransactionCount(UUID memberId) {
+		return Objects.requireNonNull(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM point_transactions WHERE member_id = ? AND type = 'EXPIRE'", Long.class,
+				memberId));
 	}
 
 	@DynamicPropertySource

--- a/src/test/java/com/buyeoon/point/PointSummaryIntegrationTests.java
+++ b/src/test/java/com/buyeoon/point/PointSummaryIntegrationTests.java
@@ -1,14 +1,22 @@
 package com.buyeoon.point;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.buyeoon.member.auth.AccessTokenService;
+import com.buyeoon.point.application.PointExpirationService;
+import com.jayway.jsonpath.JsonPath;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,6 +27,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -47,6 +56,9 @@ class PointSummaryIntegrationTests {
 
 	@Autowired
 	private AccessTokenService accessTokenService;
+
+	@Autowired
+	private PointExpirationService pointExpirationService;
 
 	private AuthenticatedMember member;
 
@@ -100,6 +112,7 @@ class PointSummaryIntegrationTests {
 		UUID soonTrip = insertSettledTrip(member.memberId());
 		insertCarryOverSettlement(soonTrip, 100, soon);
 		UUID pastTrip = insertSettledTrip(member.memberId());
+		insertTransaction(member.memberId(), "EARN", 999, "과거 이월 전 적립", past.minus(241, ChronoUnit.HOURS));
 		insertCarryOverSettlement(pastTrip, 999, past);
 		UUID leaveTrip = insertSettledTrip(member.memberId());
 		insertLeaveToBuyeoSettlement(leaveTrip, 300);
@@ -108,6 +121,97 @@ class PointSummaryIntegrationTests {
 				.andExpect(jsonPath("$.data.expirations.length()").value(2))
 				.andExpect(jsonPath("$.data.expirations[0].points").value(100))
 				.andExpect(jsonPath("$.data.expirations[1].points").value(200));
+	}
+
+	/** 만료 도래 이월분은 요약을 계산하기 전에 EXPIRE로 확정하고 감소한 잔액과 유효한 만료 예정만 반환한다. */
+	@Test
+	@DisplayName("만료 도래 이월분을 먼저 확정하고 감소한 잔액과 유효한 만료 예정만 반환한다")
+	void expiresDueCarryOverBeforeReturningSummary() throws Exception {
+		Instant expiresAt = Instant.now().minus(1, ChronoUnit.MINUTES);
+		insertTransaction(member.memberId(), "EARN", 400, "미션 보상", expiresAt.minus(241, ChronoUnit.HOURS));
+		UUID expiredTrip = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(expiredTrip, 300, expiresAt);
+		UUID activeTrip = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(activeTrip, 100, Instant.now().plus(1, ChronoUnit.DAYS));
+
+		mockMvc.perform(pointsRequest()).andExpect(status().isOk()).andExpect(jsonPath("$.data.balance").value(100))
+				.andExpect(jsonPath("$.data.cumulativeEarned").value(400))
+				.andExpect(jsonPath("$.data.expirations.length()").value(1))
+				.andExpect(jsonPath("$.data.expirations[0].points").value(100));
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM point_transactions WHERE member_id = ? AND type = 'EXPIRE'", Integer.class,
+				member.memberId())).isEqualTo(1);
+		assertThat(jdbcTemplate.queryForObject("SELECT expired_at IS NOT NULL FROM point_settlements WHERE trip_id = ?",
+				Boolean.class, expiredTrip)).isTrue();
+	}
+
+	/** 요약 조회와 scheduler가 경합해도 같은 만료분은 한 번만 차감하고 확정 잔액을 반환한다. */
+	@Test
+	@DisplayName("요약 조회와 scheduler 경합에도 EXPIRE를 한 번만 확정한다")
+	void summaryAndSchedulerExpireSameCarryOverExactlyOnce() throws Exception {
+		Instant expiresAt = Instant.now().minus(1, ChronoUnit.MINUTES);
+		insertTransaction(member.memberId(), "EARN", 300, "미션 보상", expiresAt.minus(241, ChronoUnit.HOURS));
+		UUID expiredTrip = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(expiredTrip, 200, expiresAt);
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+
+		try {
+			Future<MvcResult> summary = executor.submit(() -> {
+				ready.countDown();
+				if (!start.await(5, TimeUnit.SECONDS)) {
+					throw new IllegalStateException("동시 실행 시작 신호를 받지 못했습니다.");
+				}
+				return mockMvc.perform(pointsRequest()).andReturn();
+			});
+			Future<Integer> scheduler = executor.submit(() -> {
+				ready.countDown();
+				if (!start.await(5, TimeUnit.SECONDS)) {
+					throw new IllegalStateException("동시 실행 시작 신호를 받지 못했습니다.");
+				}
+				return pointExpirationService.expireAllDue();
+			});
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			MvcResult result = summary.get(10, TimeUnit.SECONDS);
+			scheduler.get(10, TimeUnit.SECONDS);
+			assertThat(result.getResponse().getStatus()).isEqualTo(200);
+			assertThat(JsonPath.<Integer>read(result.getResponse().getContentAsString(), "$.data.balance"))
+					.isEqualTo(100);
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM point_transactions WHERE member_id = ? AND type = 'EXPIRE'", Integer.class,
+				member.memberId())).isEqualTo(1);
+	}
+
+	/** 탈퇴가 먼저 확정된 회원은 기존 토큰으로 포인트를 조회하거나 만료를 확정하지 못한다. */
+	@Test
+	@DisplayName("탈퇴가 먼저 확정되면 포인트 조회와 만료 확정을 거부한다")
+	void rejectsPointSummaryAfterWithdrawalCompleted() throws Exception {
+		Instant expiresAt = Instant.now().minus(1, ChronoUnit.MINUTES);
+		insertTransaction(member.memberId(), "EARN", 100, "미션 보상", expiresAt.minus(241, ChronoUnit.HOURS));
+		UUID expiredTrip = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(expiredTrip, 100, expiresAt);
+		jdbcTemplate.update("""
+				UPDATE members
+				SET status = 'WITHDRAWN', withdrawn_at = CURRENT_TIMESTAMP,
+				    purge_after = CURRENT_TIMESTAMP + INTERVAL '30 days'
+				WHERE id = ?
+				""", member.memberId());
+
+		mockMvc.perform(pointsRequest()).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+
+		assertThat(jdbcTemplate.queryForObject("SELECT status::text FROM members WHERE id = ?", String.class,
+				member.memberId())).isEqualTo("WITHDRAWN");
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM point_transactions WHERE member_id = ? AND type = 'EXPIRE'", Integer.class,
+				member.memberId())).isZero();
 	}
 
 	/** 다른 회원의 내역과 정산은 조회 결과에 포함되지 않는다. */
@@ -149,10 +253,15 @@ class PointSummaryIntegrationTests {
 	}
 
 	private void insertTransaction(UUID memberId, String type, long amount, String description) {
+		insertTransaction(memberId, type, amount, description, Instant.now());
+	}
+
+	/** 지정한 발생 시각으로 포인트 내역 fixture를 저장한다. */
+	private void insertTransaction(UUID memberId, String type, long amount, String description, Instant occurredAt) {
 		jdbcTemplate.update(
-				"INSERT INTO point_transactions (id, member_id, type, amount, description) "
-						+ "VALUES (?, ?, ?::point_transaction_type, ?, ?)",
-				UUID.randomUUID(), memberId, type, amount, description);
+				"INSERT INTO point_transactions (id, member_id, type, amount, description, occurred_at) "
+						+ "VALUES (?, ?, ?::point_transaction_type, ?, ?, ?)",
+				UUID.randomUUID(), memberId, type, amount, description, Timestamp.from(occurredAt));
 	}
 
 	/** 정산 대상 여행. 여러 여행을 같은 회원에 만들기 위해 진행 중 상태 대신 정산 완료 상태로 만든다. */

--- a/src/test/java/com/buyeoon/point/PointTransactionListIntegrationTests.java
+++ b/src/test/java/com/buyeoon/point/PointTransactionListIntegrationTests.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.buyeoon.member.auth.AccessTokenService;
+import com.buyeoon.point.application.PointExpirationService;
 import com.jayway.jsonpath.JsonPath;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -14,6 +15,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,9 +59,14 @@ class PointTransactionListIntegrationTests {
 	@Autowired
 	private AccessTokenService accessTokenService;
 
+	@Autowired
+	private PointExpirationService pointExpirationService;
+
 	@AfterEach
 	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM point_settlements");
 		jdbcTemplate.update("DELETE FROM point_transactions");
+		jdbcTemplate.update("DELETE FROM trips");
 		jdbcTemplate.update("DELETE FROM auth_sessions");
 		jdbcTemplate.update("DELETE FROM members");
 	}
@@ -82,6 +93,74 @@ class PointTransactionListIntegrationTests {
 				.andExpect(jsonPath("$.data.items[1].balanceAfter").value(100))
 				.andExpect(jsonPath("$.data.page.hasNext").value(false))
 				.andExpect(jsonPath("$.data.page.nextCursor").doesNotExist());
+	}
+
+	/** 포인트 내역 조회는 만료 도래 이월분을 먼저 확정하고 새 EXPIRE 내역의 정확한 balanceAfter를 반환한다. */
+	@Test
+	@DisplayName("만료 도래 이월분을 먼저 확정하고 EXPIRE 내역과 정확한 balanceAfter를 반환한다")
+	void expiresDueCarryOverBeforeReturningTransactions() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant expiresAt = Instant.now().minus(1, ChronoUnit.MINUTES);
+		insertTransaction(member.memberId(), "EARN", 400, "미션 보상", expiresAt.minus(241, ChronoUnit.HOURS));
+		UUID tripId = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(tripId, 300, expiresAt);
+
+		mockMvc.perform(get("/members/me/point-transactions").header("Authorization", bearer(member)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.items", hasSize(2)))
+				.andExpect(jsonPath("$.data.items[0].type").value("EXPIRE"))
+				.andExpect(jsonPath("$.data.items[0].amount").value(-300))
+				.andExpect(jsonPath("$.data.items[0].balanceAfter").value(100))
+				.andExpect(jsonPath("$.data.items[1].type").value("EARN"))
+				.andExpect(jsonPath("$.data.items[1].balanceAfter").value(400));
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM point_transactions WHERE member_id = ? AND type = 'EXPIRE'", Integer.class,
+				member.memberId())).isEqualTo(1);
+	}
+
+	/** 내역 조회와 scheduler가 경합해도 같은 만료분은 한 번만 차감하고 EXPIRE 내역을 반환한다. */
+	@Test
+	@DisplayName("내역 조회와 scheduler 경합에도 EXPIRE를 한 번만 확정한다")
+	void transactionListAndSchedulerExpireSameCarryOverExactlyOnce() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant expiresAt = Instant.now().minus(1, ChronoUnit.MINUTES);
+		insertTransaction(member.memberId(), "EARN", 300, "미션 보상", expiresAt.minus(241, ChronoUnit.HOURS));
+		UUID tripId = insertSettledTrip(member.memberId());
+		insertCarryOverSettlement(tripId, 200, expiresAt);
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+
+		try {
+			Future<MvcResult> transactions = executor.submit(() -> {
+				ready.countDown();
+				if (!start.await(5, TimeUnit.SECONDS)) {
+					throw new IllegalStateException("동시 실행 시작 신호를 받지 못했습니다.");
+				}
+				return mockMvc.perform(get("/members/me/point-transactions").header("Authorization", bearer(member)))
+						.andReturn();
+			});
+			Future<Integer> scheduler = executor.submit(() -> {
+				ready.countDown();
+				if (!start.await(5, TimeUnit.SECONDS)) {
+					throw new IllegalStateException("동시 실행 시작 신호를 받지 못했습니다.");
+				}
+				return pointExpirationService.expireAllDue();
+			});
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			MvcResult result = transactions.get(10, TimeUnit.SECONDS);
+			scheduler.get(10, TimeUnit.SECONDS);
+			assertThat(result.getResponse().getStatus()).isEqualTo(200);
+			assertThat(JsonPath.<String>read(result.getResponse().getContentAsString(), "$.data.items[0].type"))
+					.isEqualTo("EXPIRE");
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM point_transactions WHERE member_id = ? AND type = 'EXPIRE'", Integer.class,
+				member.memberId())).isEqualTo(1);
 	}
 
 	/** 동일 발생 시각 내역은 내역 ID 내림차순으로 순서가 흔들리지 않고 balanceAfter도 그 순서로 누계된다. */
@@ -260,6 +339,24 @@ class PointTransactionListIntegrationTests {
 						+ "VALUES (?, ?, ?::point_transaction_type, ?, ?, ?)",
 				id, memberId, type, amount, description, Timestamp.from(occurredAt));
 		return id;
+	}
+
+	/** 만료 정산 fixture가 참조할 회원 소유의 정산 완료 여행을 만든다. */
+	private UUID insertSettledTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO trips (id, member_id, status, ended_at, settled_at) VALUES (?, ?, 'SETTLED', now(), now())",
+				tripId, memberId);
+		return tripId;
+	}
+
+	/** 지정한 시각에 만료되는 CARRY_OVER 정산 fixture를 만든다. */
+	private void insertCarryOverSettlement(UUID tripId, long settledPoints, Instant expiresAt) {
+		jdbcTemplate.update("""
+				INSERT INTO point_settlements (id, trip_id, choice, settled_points, expires_at, settled_at)
+				VALUES (?, ?, 'CARRY_OVER', ?, ?, ?)
+				""", UUID.randomUUID(), tripId, settledPoints, Timestamp.from(expiresAt),
+				Timestamp.from(expiresAt.minus(240, ChronoUnit.HOURS)));
 	}
 
 	private List<Map<String, Object>> transactions() {


### PR DESCRIPTION
## 요약

- 포인트 요약·내역 조회와 미션 포인트 보상 진입 시 활성 회원 행을 먼저 잠그고 만료 도래 이월분을 확정합니다.
- scheduler, 조회, 보상, 회원 탈퇴가 같은 회원 행 잠금 순서를 사용하도록 직렬화합니다.
- 만료 후 잔액·누적 적립·커서 결과를 유지하고, 현재 잔액보다 큰 만료는 전체 롤백해 음수 잔액을 방지합니다.
- 탈퇴 회원의 조회·보상 진입을 401로 처리하고 UC-24 context pack의 mission/API 의존성을 보완합니다.

## 검증

- [x] 관련 통합 테스트 4개 클래스, 47개 테스트 통과
- [x] `./scripts/test/format.sh` 통과
- [x] compile, Spotless, Checkstyle, SpotBugs 통과
- [x] Standards/Spec 코드 리뷰 통과
- [ ] 전체 `check`: 367개 중 `SchemaMappingTests.canonicalSchemaMatchesMigrationChain` 1개 실패. 기준점 `9fefa79`에서도 동일 재현되는 선행 DB 계약 충돌이며 #149로 분리했습니다.
- [ ] Docker build: 로컬 환경에 필수 `APPLE_TEAM_ID`가 없어 빌드 시작 전에 중단됩니다.

## 관련 이슈

- Closes #141
- Parent Epic: #138
- 선행 DB 계약 버그: #149