### PR TITLE
fix: point settlement CHECK 계약 동기화 (#149)

### DIFF
--- a/src/main/resources/db/migration/V13__add_no_points_settlement_choice.sql
+++ b/src/main/resources/db/migration/V13__add_no_points_settlement_choice.sql
@@ -1,0 +1,1 @@
+ALTER TYPE settlement_choice ADD VALUE 'NO_POINTS';

--- a/src/main/resources/db/migration/V14__align_point_settlement_constraints.sql
+++ b/src/main/resources/db/migration/V14__align_point_settlement_constraints.sql
@@ -1,0 +1,30 @@
+ALTER TABLE point_settlements
+    DROP CONSTRAINT point_settlements_check;
+
+UPDATE point_settlements
+SET choice = 'NO_POINTS',
+    expires_at = NULL,
+    expired_at = NULL
+WHERE settled_points = 0;
+
+ALTER TABLE point_settlements
+    ADD CONSTRAINT point_settlements_check CHECK (
+        (
+            choice = 'LEAVE_TO_BUYEO'
+            AND settled_points > 0
+            AND expires_at IS NULL
+            AND expired_at IS NULL
+        )
+        OR (
+            choice = 'CARRY_OVER'
+            AND settled_points > 0
+            AND expires_at = settled_at + INTERVAL '240 hours'
+            AND (expired_at IS NULL OR expired_at >= expires_at)
+        )
+        OR (
+            choice = 'NO_POINTS'
+            AND settled_points = 0
+            AND expires_at IS NULL
+            AND expired_at IS NULL
+        )
+    );

--- a/src/test/java/com/buyeoon/badge/BadgeReconciliationIntegrationTests.java
+++ b/src/test/java/com/buyeoon/badge/BadgeReconciliationIntegrationTests.java
@@ -112,8 +112,8 @@ class BadgeReconciliationIntegrationTests {
 	}
 
 	@Test
-	@DisplayName("CARRY_OVER와 0 point settlement는 포인트 기부 조건에 포함되지 않는다")
-	void excludesCarryOverAndZeroPointSettlements() {
+	@DisplayName("CARRY_OVER와 NO_POINTS 정산은 포인트 기부 조건에 포함되지 않는다")
+	void excludesCarryOverAndNoPointsSettlements() {
 		UUID memberId = insertActiveMember();
 		UUID badgeId = insertBadge("기부천사");
 		insertCondition(badgeId, "POINT_DONATION_COUNT", 1);
@@ -121,7 +121,7 @@ class BadgeReconciliationIntegrationTests {
 		UUID carryOverTrip = insertTrip(memberId);
 		insertSettlement(carryOverTrip, "CARRY_OVER", 100, Instant.now().minus(2, ChronoUnit.DAYS));
 		UUID zeroTrip = insertTrip(memberId);
-		insertSettlement(zeroTrip, "LEAVE_TO_BUYEO", 0, Instant.now().minus(1, ChronoUnit.DAYS));
+		insertSettlement(zeroTrip, "NO_POINTS", 0, Instant.now().minus(1, ChronoUnit.DAYS));
 
 		reconciliationService.reconcile();
 

--- a/src/test/java/com/buyeoon/persistence/PostgresSchemaIntegrationTests.java
+++ b/src/test/java/com/buyeoon/persistence/PostgresSchemaIntegrationTests.java
@@ -17,6 +17,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
@@ -222,6 +223,63 @@ class PostgresSchemaIntegrationTests {
 		}
 	}
 
+	/** V12가 허용했던 0포인트 양수 선택을 최신 계약의 NO_POINTS로 보존하는지 검증한다. */
+	@Test
+	@DisplayName("V12의 0포인트 정산은 업그레이드 후 NO_POINTS로 정규화된다")
+	void zeroPointSettlementsAreNormalizedWhenUpgradingFromV12() throws Exception {
+		String schema = "point_settlement_upgrade_" + UUID.randomUUID().toString().replace("-", "");
+		String url = POSTGIS.getJdbcUrl();
+		String username = POSTGIS.getUsername();
+		String password = POSTGIS.getPassword();
+		Flyway flyway = Flyway.configure().dataSource(url, username, password).schemas(schema).defaultSchema(schema)
+				.target(MigrationVersion.fromVersion("12")).cleanDisabled(false).load();
+
+		try {
+			flyway.migrate();
+			try (Connection connection = DriverManager.getConnection(url, username, password);
+					Statement statement = connection.createStatement()) {
+				connection.setSchema(schema);
+				statement.executeUpdate("""
+						INSERT INTO members (id)
+						VALUES ('10000000-0000-0000-0000-000000000001');
+						INSERT INTO trips (id, member_id, status, ended_at)
+						VALUES ('10000000-0000-0000-0000-000000000002',
+						        '10000000-0000-0000-0000-000000000001', 'ENDED',
+						        TIMESTAMPTZ '2026-08-20 00:00:00Z'),
+						       ('10000000-0000-0000-0000-000000000003',
+						        '10000000-0000-0000-0000-000000000001', 'ENDED',
+						        TIMESTAMPTZ '2026-08-20 00:00:00Z');
+						INSERT INTO point_settlements (trip_id, choice, settled_points, settled_at, expires_at)
+						VALUES ('10000000-0000-0000-0000-000000000002', 'LEAVE_TO_BUYEO', 0,
+						        TIMESTAMPTZ '2026-08-20 00:00:00Z', NULL),
+						       ('10000000-0000-0000-0000-000000000003', 'CARRY_OVER', 0,
+						        TIMESTAMPTZ '2026-08-20 00:00:00Z', TIMESTAMPTZ '2026-08-30 00:00:00Z');
+						""");
+			}
+
+			Flyway.configure().dataSource(url, username, password).schemas(schema).defaultSchema(schema).load()
+					.migrate();
+
+			try (Connection connection = DriverManager.getConnection(url, username, password);
+					Statement statement = connection.createStatement()) {
+				connection.setSchema(schema);
+				try (ResultSet resultSet = statement.executeQuery("""
+						SELECT count(*)
+						FROM point_settlements
+						WHERE choice = 'NO_POINTS'
+						  AND settled_points = 0
+						  AND expires_at IS NULL
+						  AND expired_at IS NULL
+						""")) {
+					assertThat(resultSet.next()).isTrue();
+					assertThat(resultSet.getLong(1)).isEqualTo(2L);
+				}
+			}
+		} finally {
+			flyway.clean();
+		}
+	}
+
 	/** 실제 PostgreSQL enum에서 위치에 따라 계산되는 상태가 제거되고 영속 상태만 남았는지 검증한다. */
 	@Test
 	@DisplayName("DB 미션 상태 enum에는 위치와 무관한 영속 상태만 존재한다")
@@ -252,6 +310,56 @@ class PostgresSchemaIntegrationTests {
 				FROM pg_roles
 				WHERE rolname = current_user
 				""", Boolean.class)).isFalse();
+	}
+
+	/** 실제 마이그레이션 DB가 정산 선택별 포인트·만료 계약을 강제하는지 검증한다. */
+	@Test
+	@DisplayName("DB는 유효한 세 정산 선택만 허용하고 양수 정산의 0포인트를 거부한다")
+	void pointSettlementChoicesEnforcePointsAndExpirationContract() {
+		UUID memberId = UUID.randomUUID();
+		UUID leaveTripId = UUID.randomUUID();
+		UUID carryTripId = UUID.randomUUID();
+		UUID noPointsTripId = UUID.randomUUID();
+		UUID zeroLeaveTripId = UUID.randomUUID();
+		UUID zeroCarryTripId = UUID.randomUUID();
+		Instant settledAt = Instant.parse("2026-08-20T00:00:00Z");
+
+		jdbcTemplate.update("INSERT INTO members (id) VALUES (?)", memberId);
+		for (UUID tripId : new UUID[]{leaveTripId, carryTripId, noPointsTripId, zeroLeaveTripId, zeroCarryTripId}) {
+			jdbcTemplate.update("""
+					INSERT INTO trips (id, member_id, status, ended_at)
+					VALUES (?, ?, 'ENDED', ?)
+					""", tripId, memberId, Timestamp.from(settledAt));
+		}
+
+		try {
+			jdbcTemplate.update("""
+					INSERT INTO point_settlements (trip_id, choice, settled_points, settled_at)
+					VALUES (?, 'LEAVE_TO_BUYEO', 100, ?)
+					""", leaveTripId, Timestamp.from(settledAt));
+			jdbcTemplate.update("""
+					INSERT INTO point_settlements (trip_id, choice, settled_points, settled_at, expires_at)
+					VALUES (?, 'CARRY_OVER', 100, ?, ?)
+					""", carryTripId, Timestamp.from(settledAt), Timestamp.from(settledAt.plus(240, ChronoUnit.HOURS)));
+			jdbcTemplate.update("""
+					INSERT INTO point_settlements (trip_id, choice, settled_points, settled_at)
+					VALUES (?, 'NO_POINTS', 0, ?)
+					""", noPointsTripId, Timestamp.from(settledAt));
+
+			assertThatThrownBy(() -> jdbcTemplate.update("""
+					INSERT INTO point_settlements (trip_id, choice, settled_points, settled_at)
+					VALUES (?, 'LEAVE_TO_BUYEO', 0, ?)
+					""", zeroLeaveTripId, Timestamp.from(settledAt)))
+					.isInstanceOf(DataIntegrityViolationException.class);
+			assertThatThrownBy(() -> jdbcTemplate.update("""
+					INSERT INTO point_settlements (trip_id, choice, settled_points, settled_at, expires_at)
+					VALUES (?, 'CARRY_OVER', 0, ?, ?)
+					""", zeroCarryTripId, Timestamp.from(settledAt),
+					Timestamp.from(settledAt.plus(240, ChronoUnit.HOURS))))
+					.isInstanceOf(DataIntegrityViolationException.class);
+		} finally {
+			jdbcTemplate.update("DELETE FROM members WHERE id = ?", memberId);
+		}
 	}
 
 	/** 애플리케이션 검증을 우회한 입력도 DB가 유형별 시도 횟수 규칙에 따라 최종적으로 방어하는지 검증한다. */

--- a/src/test/java/com/buyeoon/persistence/SchemaMappingTests.java
+++ b/src/test/java/com/buyeoon/persistence/SchemaMappingTests.java
@@ -35,6 +35,10 @@ class SchemaMappingTests {
 			.of("src/main/resources/db/migration/V9.1__add_location_term_type.sql");
 	private static final Path POINT_SETTLEMENT_EXPIRATION_MIGRATION = Path
 			.of("src/main/resources/db/migration/V12__track_point_settlement_expiration.sql");
+	private static final Path NO_POINTS_SETTLEMENT_CHOICE_MIGRATION = Path
+			.of("src/main/resources/db/migration/V13__add_no_points_settlement_choice.sql");
+	private static final Path POINT_SETTLEMENT_CONSTRAINTS_MIGRATION = Path
+			.of("src/main/resources/db/migration/V14__align_point_settlement_constraints.sql");
 	private static final Pattern CREATE_TABLE = Pattern.compile("CREATE TABLE ([a-z_]+) ");
 
 	/** 초기 스키마에 후속 마이그레이션을 적용한 정의가 기준 DB 스키마와 같음을 보장한다. */
@@ -45,6 +49,8 @@ class SchemaMappingTests {
 		String canonicalSchema = Files.readString(SCHEMA_SOURCE, StandardCharsets.UTF_8);
 		String legacyTermType = "CREATE TYPE term_type AS ENUM ('SERVICE', 'PRIVACY', 'MARKETING');";
 		String currentTermType = "CREATE TYPE term_type AS ENUM ('SERVICE', 'PRIVACY', 'LOCATION', 'MARKETING');";
+		String legacySettlementChoice = "CREATE TYPE settlement_choice AS ENUM ('LEAVE_TO_BUYEO', 'CARRY_OVER');";
+		String currentSettlementChoice = "CREATE TYPE settlement_choice AS ENUM ('LEAVE_TO_BUYEO', 'CARRY_OVER', 'NO_POINTS');";
 		String legacyMissionStatus = "CREATE TYPE mission_status AS ENUM ('LOCKED', 'AVAILABLE', 'EXHAUSTED', 'COMPLETED');";
 		String currentMissionStatus = "CREATE TYPE mission_status AS ENUM ('AVAILABLE', 'EXHAUSTED', 'COMPLETED');";
 		String placeSourceColumns = String.join("\n", "    source_name text, -- 관광데이터 제공처",
@@ -88,6 +94,56 @@ class SchemaMappingTests {
 		String authSessionIndex = "CREATE INDEX auth_sessions_member_idx ON auth_sessions (member_id, expires_at);";
 		String memberPurgeIndexes = String.join("\n", authSessionIndex, "CREATE INDEX members_due_purge_idx",
 				"    ON members (purge_after, id)", "    WHERE status = 'WITHDRAWN' AND purged_at IS NULL;");
+		String legacyPointSettlement = """
+				CREATE TABLE point_settlements (
+				    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), -- 정산 ID
+				    trip_id uuid NOT NULL UNIQUE REFERENCES trips(id) ON DELETE CASCADE, -- 정산 대상 여행 ID
+				    choice settlement_choice NOT NULL, -- 남기기·이월 선택
+				    settled_points bigint NOT NULL CHECK (settled_points >= 0), -- 이번 여행에서 정산한 포인트
+				    expires_at timestamptz, -- 이월 포인트 만료 시각
+				    settled_at timestamptz NOT NULL DEFAULT now(), -- 정산 완료 시각
+				    CHECK (
+				        (choice = 'LEAVE_TO_BUYEO' AND expires_at IS NULL)
+				        OR (choice = 'CARRY_OVER' AND expires_at = settled_at + INTERVAL '240 hours')
+				    )
+				);
+				""";
+		String currentPointSettlement = """
+				CREATE TABLE point_settlements (
+				    id uuid PRIMARY KEY DEFAULT gen_random_uuid(), -- 정산 ID
+				    trip_id uuid NOT NULL UNIQUE REFERENCES trips(id) ON DELETE CASCADE, -- 정산 대상 여행 ID
+				    choice settlement_choice NOT NULL, -- 남기기·이월 선택
+				    settled_points bigint NOT NULL CHECK (settled_points >= 0), -- 이번 여행에서 정산한 포인트
+				    expires_at timestamptz, -- 이월 포인트 만료 시각
+				    settled_at timestamptz NOT NULL DEFAULT now(), -- 정산 완료 시각
+				    expired_at timestamptz, -- 이월 포인트 만료 처리를 실제로 확정한 시각
+				    CHECK (
+				        (
+				            choice = 'LEAVE_TO_BUYEO'
+				            AND settled_points > 0
+				            AND expires_at IS NULL
+				            AND expired_at IS NULL
+				        )
+				        OR (
+				            choice = 'CARRY_OVER'
+				            AND settled_points > 0
+				            AND expires_at = settled_at + INTERVAL '240 hours'
+				            AND (expired_at IS NULL OR expired_at >= expires_at)
+				        )
+				        OR (
+				            choice = 'NO_POINTS'
+				            AND settled_points = 0
+				            AND expires_at IS NULL
+				            AND expired_at IS NULL
+				        )
+				    )
+				);
+				""";
+		String pointTransactionIndex = "CREATE INDEX point_transactions_member_idx ON point_transactions "
+				+ "(member_id, occurred_at DESC);";
+		String pointIndexes = String.join("\n", pointTransactionIndex,
+				"CREATE INDEX point_settlements_due_expiration_idx", "    ON point_settlements (expires_at, id)",
+				"    WHERE choice = 'CARRY_OVER' AND expired_at IS NULL;");
 		String privatePhotoObjectKey = "object_key text NOT NULL UNIQUE CHECK (object_key LIKE 'private/%'),"
 				+ " -- 비공개 스토리지 객체 키";
 		String publicImageKeySchema = baseline
@@ -124,7 +180,10 @@ class SchemaMappingTests {
 		assertThat(publicImageKeySchema.replace(placeSourceColumns, placeExternalIdentityColumns)
 				.replace(placeLocationIndex, placeIndexes).replace(legacyMissionStatus, currentMissionStatus)
 				.replace(legacyMissionConstraints, currentMissionConstraints).replace(legacyTermType, currentTermType)
-				.replace(placeExternalIdentityColumns, placeOperatingInfoColumns)).isEqualTo(canonicalSchema);
+				.replace(placeExternalIdentityColumns, placeOperatingInfoColumns)
+				.replace(legacySettlementChoice, currentSettlementChoice)
+				.replace(legacyPointSettlement, currentPointSettlement).replace(pointTransactionIndex, pointIndexes))
+				.isEqualTo(canonicalSchema);
 		assertThat(Files.readString(LOCATION_TERM_MIGRATION, StandardCharsets.UTF_8))
 				.contains("ALTER TYPE term_type ADD VALUE 'LOCATION' AFTER 'PRIVACY'");
 	}
@@ -148,6 +207,8 @@ class SchemaMappingTests {
 	void pointSettlementExpirationIsDefinedInSchemaAndMigration() throws IOException {
 		String canonicalSchema = Files.readString(SCHEMA_SOURCE, StandardCharsets.UTF_8);
 		String migration = Files.readString(POINT_SETTLEMENT_EXPIRATION_MIGRATION, StandardCharsets.UTF_8);
+		String choiceMigration = Files.readString(NO_POINTS_SETTLEMENT_CHOICE_MIGRATION, StandardCharsets.UTF_8);
+		String constraintsMigration = Files.readString(POINT_SETTLEMENT_CONSTRAINTS_MIGRATION, StandardCharsets.UTF_8);
 
 		assertThat(canonicalSchema).contains("expired_at timestamptz, -- 이월 포인트 만료 처리를 실제로 확정한 시각")
 				.contains("AND (expired_at IS NULL OR expired_at >= expires_at)")
@@ -159,6 +220,9 @@ class SchemaMappingTests {
 				.contains("CREATE INDEX point_settlements_due_expiration_idx")
 				.contains("ON point_settlements (expires_at, id)")
 				.contains("WHERE choice = 'CARRY_OVER' AND expired_at IS NULL;");
+		assertThat(choiceMigration).contains("ALTER TYPE settlement_choice ADD VALUE 'NO_POINTS'");
+		assertThat(constraintsMigration).contains("choice = 'LEAVE_TO_BUYEO'").contains("settled_points > 0")
+				.contains("choice = 'CARRY_OVER'").contains("choice = 'NO_POINTS'").contains("settled_points = 0");
 	}
 
 	/** 미션 상태와 시도 횟수 제약이 신규 설치용 스키마와 기존 DB 업그레이드에 모두 반영됐는지 검증한다. */


### PR DESCRIPTION
## Summary
- `settlement_choice` enum에 `NO_POINTS`를 추가합니다.
- 기존 0포인트 정산을 `NO_POINTS`로 정규화하고 `point_settlements` CHECK를 원본 스키마 계약과 동기화합니다.
- migration chain 및 PostgreSQL 업그레이드/제약 통합 테스트를 추가합니다.

## Test
- `./scripts/test/format.sh`
- `./scripts/test/static-check.sh`
- `./scripts/test/test.sh`
- `./scripts/test/docker-build.sh`

Parent: #138

Fixes #149