### PR TITLE
Stage 7: 운영 배포 파이프라인 구축 및 장소 저장 동시성 수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,15 +10,21 @@ JWT_SECRET=replace-with-base64-encoded-256-bit-secret
 # 카카오 토큰 정보 API가 반환하는 숫자형 앱 ID. Native App Key나 비밀 키가 아니다.
 KAKAO_APP_ID=1234
 
-# Sign in with Apple 설정. .p8 파일은 PKCS#8 DER 바이트를 Base64로 인코딩해 넣는다.
+# Sign in with Apple 설정. 비활성화하면 아래 네 값은 비워 둘 수 있다.
+APPLE_LOGIN_ENABLED=false
+# .p8 파일은 PKCS#8 DER 바이트를 Base64로 인코딩해 넣는다.
 APPLE_CLIENT_ID=com.example.buyeoon
 APPLE_TEAM_ID=ABCDEFGHIJ
 APPLE_KEY_ID=1234567890
 APPLE_PRIVATE_KEY_BASE64=replace-with-base64-encoded-p8-key
 
 # Private S3 Bucket. EC2 Instance Role provides credentials in production.
-IMAGE_BUCKET=buyeoon-prod-images
+IMAGE_BUCKET=buyeoon-images
 AWS_REGION=ap-northeast-2
+
+# TourAPI 장소 동기화와 /admin/** 호출에 사용하는 운영 비밀값.
+TOURAPI_SERVICE_KEY=replace-with-data-go-kr-service-key
+ADMIN_API_KEY=replace-with-random-admin-api-key
 
 # Docker Compose exposes Nginx on this host port.
 HTTP_PORT=8080

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -115,6 +115,14 @@ jobs:
         id: ecr
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64
 
+      - name: Set up QEMU for ARM64 emulation
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
       - name: Build and push immutable application image
         id: image
         shell: bash
@@ -122,8 +130,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.ecr.outputs.registry }}
         run: |
           image_uri="${ECR_REGISTRY}/${ECR_REPOSITORY}:${GITHUB_SHA}"
-          docker build --tag "${image_uri}" .
-          docker push "${image_uri}"
+          docker buildx build --platform linux/arm64 --tag "${image_uri}" --push .
           echo "uri=${image_uri}" >>"${GITHUB_OUTPUT}"
 
       - name: Deploy through Systems Manager

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,206 @@
+name: Deploy Production
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      deployment_mode:
+        description: Deploy only the app for Stage 7, or include TLS Nginx after Stage 8
+        required: true
+        default: app-only
+        type: choice
+        options:
+          - app-only
+          - full
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    if: github.event_name == 'workflow_dispatch' || vars.PRODUCTION_DEPLOY_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 30
+    env:
+      AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+      AWS_DEPLOY_ROLE_ARN: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+      AWS_REGION: ${{ vars.AWS_REGION || 'ap-northeast-2' }}
+      EC2_INSTANCE_ID: ${{ vars.EC2_INSTANCE_ID }}
+      ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY || 'buyeoon/app' }}
+      PUBLIC_HEALTH_URL: ${{ vars.PUBLIC_HEALTH_URL }}
+
+    steps:
+      - name: Select deployment mode
+        id: mode
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            mode="${{ inputs.deployment_mode }}"
+          else
+            mode="full"
+          fi
+          echo "value=${mode}" >>"${GITHUB_OUTPUT}"
+
+      - name: Validate deployment configuration
+        shell: bash
+        run: |
+          for required_name in AWS_ACCOUNT_ID AWS_DEPLOY_ROLE_ARN EC2_INSTANCE_ID ECR_REPOSITORY; do
+            if [[ -z "${!required_name}" ]]; then
+              echo "GitHub production variable ${required_name} is required" >&2
+              exit 1
+            fi
+          done
+          if [[ "${{ steps.mode.outputs.value }}" == "full" && -z "${PUBLIC_HEALTH_URL}" ]]; then
+            echo "PUBLIC_HEALTH_URL is required for a full deployment" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
+
+      - name: Run quality gate
+        run: ./gradlew check --no-daemon
+
+      - name: Validate deployment artifacts
+        shell: bash
+        run: |
+          bash -n scripts/deploy/*.sh scripts/ci/*.sh
+          scripts/ci/test-wait-for-ssm-command.sh
+          DB_URL=jdbc:postgresql://db:5432/buyeoon \
+          DB_USERNAME=buyeoon_app \
+          DB_PASSWORD=test \
+          JWT_SECRET=test \
+          KAKAO_APP_ID=1234 \
+          IMAGE_BUCKET=buyeoon-images \
+          TOURAPI_SERVICE_KEY=test \
+          ADMIN_API_KEY=test \
+          APP_IMAGE=example.invalid/buyeoon/app:${GITHUB_SHA} \
+          RELEASE_DIR=/tmp/buyeoon-release \
+            docker compose -f compose.prod.yaml config --quiet
+
+          nginx_test_directory=$(mktemp -d)
+          trap 'rm -rf "${nginx_test_directory}"' EXIT
+          openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+            -subj '/CN=origin.example.invalid' \
+            -keyout "${nginx_test_directory}/origin.key" \
+            -out "${nginx_test_directory}/origin.pem" >/dev/null 2>&1
+          docker run --rm \
+            --add-host app:127.0.0.1 \
+            -v "${PWD}/docker/nginx/nginx.prod.conf:/etc/nginx/nginx.conf:ro" \
+            -v "${nginx_test_directory}:/etc/nginx/tls:ro" \
+            nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de nginx -t
+
+      - name: Configure AWS credentials from GitHub OIDC
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_DEPLOY_ROLE_ARN }}
+          role-session-name: buyeoon-${{ github.run_id }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+
+      - name: Log in to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64
+
+      - name: Build and push immutable application image
+        id: image
+        shell: bash
+        env:
+          ECR_REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          image_uri="${ECR_REGISTRY}/${ECR_REPOSITORY}:${GITHUB_SHA}"
+          docker build --tag "${image_uri}" .
+          docker push "${image_uri}"
+          echo "uri=${image_uri}" >>"${GITHUB_OUTPUT}"
+
+      - name: Deploy through Systems Manager
+        id: deploy
+        shell: bash
+        env:
+          APP_IMAGE: ${{ steps.image.outputs.uri }}
+          DEPLOYMENT_MODE: ${{ steps.mode.outputs.value }}
+        run: |
+          bootstrap_base64=$(base64 --wrap=0 scripts/deploy/bootstrap-release.sh)
+          command="printf '%s' '${bootstrap_base64}' | base64 --decode | bash -s -- '${APP_IMAGE}' '${GITHUB_SHA}' '${DEPLOYMENT_MODE}'"
+          parameters=$(jq -cn --arg command "${command}" '{commands:[$command]}')
+          command_id=$(aws ssm send-command \
+            --instance-ids "${EC2_INSTANCE_ID}" \
+            --document-name AWS-RunShellScript \
+            --comment "Deploy Buyeo-On ${GITHUB_SHA}" \
+            --parameters "${parameters}" \
+            --region "${AWS_REGION}" \
+            --query 'Command.CommandId' \
+            --output text)
+          echo "command-id=${command_id}" >>"${GITHUB_OUTPUT}"
+
+          set +e
+          SSM_COMMAND_TIMEOUT_SECONDS=1200 \
+            scripts/ci/wait-for-ssm-command.sh "${command_id}" "${EC2_INSTANCE_ID}" "${AWS_REGION}"
+          poll_status=$?
+          set -e
+
+          invocation=$(aws ssm get-command-invocation \
+            --command-id "${command_id}" \
+            --instance-id "${EC2_INSTANCE_ID}" \
+            --region "${AWS_REGION}" \
+            --output json)
+          jq -r '.StandardOutputContent // empty' <<<"${invocation}"
+          jq -r '.StandardErrorContent // empty' <<<"${invocation}" >&2
+          status=$(jq -r '.Status' <<<"${invocation}")
+          if [[ ${poll_status} -ne 0 || "${status}" != "Success" ]]; then
+            echo "SSM deployment failed with status ${status}" >&2
+            exit 1
+          fi
+
+      - name: Verify public Cloudflare health
+        if: steps.mode.outputs.value == 'full'
+        shell: bash
+        run: |
+          curl --fail --silent --show-error \
+            --retry 5 --retry-delay 10 --retry-all-errors \
+            "${PUBLIC_HEALTH_URL}" >/dev/null
+
+      - name: Roll back after public health failure
+        if: failure() && steps.deploy.outcome == 'success' && steps.mode.outputs.value == 'full'
+        shell: bash
+        run: |
+          parameters=$(jq -cn --arg command '/opt/buyeoon/current/scripts/deploy/rollback.sh' '{commands:[$command]}')
+          command_id=$(aws ssm send-command \
+            --instance-ids "${EC2_INSTANCE_ID}" \
+            --document-name AWS-RunShellScript \
+            --comment "Rollback Buyeo-On after public health failure" \
+            --parameters "${parameters}" \
+            --region "${AWS_REGION}" \
+            --query 'Command.CommandId' \
+            --output text)
+          set +e
+          SSM_COMMAND_TIMEOUT_SECONDS=1200 \
+            scripts/ci/wait-for-ssm-command.sh "${command_id}" "${EC2_INSTANCE_ID}" "${AWS_REGION}"
+          poll_status=$?
+          set -e
+
+          invocation=$(aws ssm get-command-invocation \
+            --command-id "${command_id}" \
+            --instance-id "${EC2_INSTANCE_ID}" \
+            --region "${AWS_REGION}" \
+            --output json)
+          jq -r '.StandardOutputContent // empty' <<<"${invocation}"
+          jq -r '.StandardErrorContent // empty' <<<"${invocation}" >&2
+          status=$(jq -r '.Status' <<<"${invocation}")
+          if [[ ${poll_status} -ne 0 || "${status}" != "Success" ]]; then
+            echo "SSM rollback failed with status ${status}" >&2
+            exit 1
+          fi

--- a/.github/workflows/deploy-swagger.yml
+++ b/.github/workflows/deploy-swagger.yml
@@ -14,17 +14,17 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Create Cloudflare Pages project (if not exists)
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages project create buyeoon-api --production-branch=main
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jdk-alpine AS builder
+FROM eclipse-temurin:21-jdk-alpine@sha256:1ff763083f2993d57d0bf374ab10bb3e2cb873af6c13a04458ebbd3e0337dc76 AS builder
 
 WORKDIR /workspace
 
@@ -9,13 +9,16 @@ COPY src ./src
 RUN --mount=type=cache,target=/root/.gradle \
     chmod +x gradlew && ./gradlew bootJar --no-daemon
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jre-alpine@sha256:3f08b13888f595cc49edabea7250ba69499ba25602b267da591720769400e08c
 
-RUN addgroup -S spring && adduser -S spring -G spring
+RUN addgroup -g 10001 -S spring && adduser -u 10001 -S spring -G spring
 
 WORKDIR /app
 
 COPY --from=builder --chown=spring:spring /workspace/build/libs/*.jar app.jar
+COPY compose.prod.yaml /opt/buyeoon/deploy-bundle/compose.prod.yaml
+COPY docker/nginx/nginx.prod.conf /opt/buyeoon/deploy-bundle/docker/nginx/nginx.prod.conf
+COPY scripts/deploy /opt/buyeoon/deploy-bundle/scripts/deploy
 
 USER spring
 

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,75 @@
+name: buyeoon
+
+services:
+  app:
+    image: ${APP_IMAGE:?APP_IMAGE is required}
+    environment:
+      DB_URL: ${DB_URL:?DB_URL is required}
+      DB_USERNAME: ${DB_USERNAME:?DB_USERNAME is required}
+      DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
+      KAKAO_APP_ID: ${KAKAO_APP_ID:?KAKAO_APP_ID is required}
+      APPLE_LOGIN_ENABLED: ${APPLE_LOGIN_ENABLED:-false}
+      APPLE_CLIENT_ID: ${APPLE_CLIENT_ID:-}
+      APPLE_TEAM_ID: ${APPLE_TEAM_ID:-}
+      APPLE_KEY_ID: ${APPLE_KEY_ID:-}
+      APPLE_PRIVATE_KEY_BASE64: ${APPLE_PRIVATE_KEY_BASE64:-}
+      IMAGE_BUCKET: ${IMAGE_BUCKET:?IMAGE_BUCKET is required}
+      AWS_REGION: ${AWS_REGION:-ap-northeast-2}
+      TOURAPI_SERVICE_KEY: ${TOURAPI_SERVICE_KEY:?TOURAPI_SERVICE_KEY is required}
+      ADMIN_API_KEY: ${ADMIN_API_KEY:?ADMIN_API_KEY is required}
+      MISSION_PHOTO_MAX_UPLOAD_BYTES: ${MISSION_PHOTO_MAX_UPLOAD_BYTES:-10485760}
+      MEMBER_PURGE_BATCH_SIZE: ${MEMBER_PURGE_BATCH_SIZE:-100}
+      MEMBER_PURGE_INTERVAL: ${MEMBER_PURGE_INTERVAL:-PT1M}
+      MEMBER_PURGE_INITIAL_DELAY: ${MEMBER_PURGE_INITIAL_DELAY:-PT1M}
+      LOGGING_FILE_NAME: /var/log/buyeoon/app/application.json
+      LOGGING_STRUCTURED_FORMAT_CONSOLE: ecs
+      LOGGING_STRUCTURED_FORMAT_FILE: ecs
+      LOGGING_LOGBACK_ROLLINGPOLICY_MAX_HISTORY: 7
+      LOGGING_LOGBACK_ROLLINGPOLICY_MAX_FILE_SIZE: 20MB
+      LOGGING_LOGBACK_ROLLINGPOLICY_TOTAL_SIZE_CAP: 1GB
+      JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS:--XX:MaxRAMPercentage=75.0 -Duser.timezone=UTC}
+      TZ: UTC
+    ports:
+      - "127.0.0.1:18080:8080"
+    volumes:
+      - /var/log/buyeoon/app:/var/log/buyeoon/app
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    restart: unless-stopped
+    logging:
+      driver: local
+      options:
+        max-size: 10m
+        max-file: "3"
+
+  nginx:
+    image: nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
+    depends_on:
+      app:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:8080:80"
+      - "443:443"
+    volumes:
+      - ${RELEASE_DIR:?RELEASE_DIR is required}/docker/nginx/nginx.prod.conf:/etc/nginx/nginx.conf:ro
+      - ${TLS_DIR:-/opt/buyeoon/tls}/origin.pem:/etc/nginx/tls/origin.pem:ro
+      - ${TLS_DIR:-/opt/buyeoon/tls}/origin.key:/etc/nginx/tls/origin.key:ro
+      - /var/log/buyeoon/nginx:/var/log/nginx
+    read_only: true
+    tmpfs:
+      - /var/cache/nginx
+      - /var/run
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    logging:
+      driver: local
+      options:
+        max-size: 10m
+        max-file: "3"

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,19 +12,22 @@ services:
       DB_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       KAKAO_APP_ID: ${KAKAO_APP_ID:?KAKAO_APP_ID is required}
-      APPLE_CLIENT_ID: ${APPLE_CLIENT_ID:?APPLE_CLIENT_ID is required}
-      APPLE_TEAM_ID: ${APPLE_TEAM_ID:?APPLE_TEAM_ID is required}
-      APPLE_KEY_ID: ${APPLE_KEY_ID:?APPLE_KEY_ID is required}
-      APPLE_PRIVATE_KEY_BASE64: ${APPLE_PRIVATE_KEY_BASE64:?APPLE_PRIVATE_KEY_BASE64 is required}
+      APPLE_LOGIN_ENABLED: ${APPLE_LOGIN_ENABLED:-false}
+      APPLE_CLIENT_ID: ${APPLE_CLIENT_ID:-}
+      APPLE_TEAM_ID: ${APPLE_TEAM_ID:-}
+      APPLE_KEY_ID: ${APPLE_KEY_ID:-}
+      APPLE_PRIVATE_KEY_BASE64: ${APPLE_PRIVATE_KEY_BASE64:-}
       IMAGE_BUCKET: ${IMAGE_BUCKET:-}
       AWS_REGION: ${AWS_REGION:-ap-northeast-2}
+      TOURAPI_SERVICE_KEY: ${TOURAPI_SERVICE_KEY:-}
+      ADMIN_API_KEY: ${ADMIN_API_KEY:-}
       JAVA_TOOL_OPTIONS: ${JAVA_TOOL_OPTIONS:--XX:MaxRAMPercentage=75.0}
     expose:
       - "8080"
     restart: unless-stopped
 
   nginx:
-    image: nginx:1.29-alpine
+    image: nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de
     depends_on:
       app:
         condition: service_healthy

--- a/docker/nginx/nginx.prod.conf
+++ b/docker/nginx/nginx.prod.conf
@@ -1,0 +1,103 @@
+user nginx;
+worker_processes auto;
+
+error_log /var/log/nginx/error.log notice;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    server_tokens off;
+
+    log_format cloudwatch escape=json
+        '{"timestamp":"$time_iso8601",'
+        '"remote_addr":"$remote_addr",'
+        '"cf_connecting_ip":"$http_cf_connecting_ip",'
+        '"method":"$request_method",'
+        '"uri":"$uri",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"request_time":$request_time,'
+        '"upstream_response_time":"$upstream_response_time",'
+        '"request_id":"$request_id",'
+        '"cf_ray":"$http_cf_ray",'
+        '"user_agent":"$http_user_agent"}';
+
+    access_log /var/log/nginx/access.log cloudwatch;
+
+    map $http_cf_connecting_ip $forwarded_client_ip {
+        default $http_cf_connecting_ip;
+        "" $remote_addr;
+    }
+
+    upstream spring_boot {
+        server app:8080;
+        keepalive 32;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        location / {
+            proxy_pass http://spring_boot;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $forwarded_client_ip;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto http;
+            proxy_set_header X-Forwarded-Port 80;
+            proxy_set_header X-Request-ID $request_id;
+            proxy_set_header CF-Ray $http_cf_ray;
+            proxy_connect_timeout 5s;
+            proxy_read_timeout 30s;
+        }
+
+        location = /actuator/health {
+            access_log off;
+            proxy_pass http://spring_boot;
+            proxy_set_header Host $host;
+            proxy_set_header X-Request-ID $request_id;
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        http2 on;
+        server_name _;
+
+        ssl_certificate /etc/nginx/tls/origin.pem;
+        ssl_certificate_key /etc/nginx/tls/origin.key;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout 1d;
+        add_header Strict-Transport-Security "max-age=31536000" always;
+
+        location / {
+            proxy_pass http://spring_boot;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $forwarded_client_ip;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Port 443;
+            proxy_set_header X-Request-ID $request_id;
+            proxy_set_header CF-Ray $http_cf_ray;
+            proxy_connect_timeout 5s;
+            proxy_read_timeout 30s;
+        }
+
+        location = /actuator/health {
+            access_log off;
+            proxy_pass http://spring_boot;
+            proxy_set_header Host $host;
+            proxy_set_header X-Request-ID $request_id;
+        }
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,7 @@ iOS Flutter
 - 로그아웃·탈퇴 시 세션을 즉시 폐기한다.
 - FCM 등록 토큰은 현재 인증 세션과 1:1로 관리한다. 로그아웃·탈퇴 시 발송 대상에서 제외하고 FCM이 무효로 응답한 토큰은 삭제한다.
 - JWT 키와 OAuth 시크릿은 Parameter Store `SecureString`에서 읽는다.
+- Apple 로그인은 필요한 Apple 자격증명이 준비될 때만 활성화한다. 비활성화된 제공자로 로그인하면 소셜 인증 실패로 처리하고 다른 제공자와 애플리케이션 기동에는 영향을 주지 않는다.
 ## 데이터베이스
 - AWS RDS PostgreSQL과 PostGIS를 사용한다.
 - 장소는 `geography(Point, 4326)`와 GiST 인덱스로 저장한다.
@@ -92,6 +93,7 @@ iOS Flutter
 - EC2는 SSM 명령으로 이미지를 pull하고 Docker Compose를 실행하며 애플리케이션 시작 과정에서 Flyway를 적용한다.
 - 최초 운영 기준 SHA 이후 배포는 `/actuator/health`가 실패하면 직전 운영 SHA 이미지로 자동 롤백한다.
 - 배포가 끝나면 GitHub Actions가 Cloudflare를 경유해 공개 health endpoint를 확인한다.
+- Cloudflare 준비 전에는 수동 `app-only` 배포로 내부 health만 확인하고, production Environment의 자동 `full` 배포는 명시적 Repository Variable로 활성화한다.
 - AWS 인프라는 전용 IAM User로 접근한 운영 담당자가 [AWS Console 구성 Runbook](./aws-console-provisioning.md)에 따라 Console에서 생성·변경하고 리소스 목록과 변경 이력을 문서에 남긴다. IAM User는 MFA와 Console 비밀번호만 사용하고 Access Key를 만들지 않는다.
 - ECR push와 SSM 배포는 GitHub Actions만 수행하고 하나의 GitHub Automation OIDC IAM Role을 사용한다.
 - GitHub Automation Role과 EC2 Instance Role은 신뢰 주체가 다르므로 분리하며 장기 AWS Access Key를 사용하지 않는다.
@@ -106,7 +108,7 @@ iOS Flutter
 - 모든 검사를 통과한 `main`만 운영 배포
 ## 관측성과 복구
 - SLF4J 구조화 로그를 사용하고 개발은 일반 로그, 운영은 JSON 로그로 출력한다.
-- Spring과 Nginx 로그를 CloudWatch Logs에 전송해 30일 보관한다.
+- Spring ECS JSON 로그와 Nginx JSON access·error 로그를 호스트의 `/var/log/buyeoon`에 기록하고 CloudWatch Logs에 전송해 30일 보관한다.
 - 액세스 토큰, OAuth 코드, Presigned URL과 개인정보는 로그에 기록하지 않는다.
 - Docker `HEALTHCHECK`는 Actuator liveness를 확인한다.
 - 공개 헬스 응답은 내부 구성과 DB 상세정보를 노출하지 않는다.

--- a/docs/aws-console-provisioning.md
+++ b/docs/aws-console-provisioning.md
@@ -38,9 +38,9 @@ AWS resource는 먼저 생성할 수 있지만, 아래 항목이 준비되기 �
 | --- | --- | --- |
 | 운영 Domain | 확정 필요 | Production API 공개 |
 | Cloudflare zone·API hostname | 확정 필요 | DNS·Proxy·TLS 연결 |
-| Production Compose 파일 | 미구현 | EC2 애플리케이션 실행 |
-| Nginx 설정과 Origin Certificate 주입·갱신 절차 | 미구현 | HTTPS origin 공개 |
-| DB bootstrap과 Parameter Store 운영 값 | 미구현 | Spring Boot 최초 시작 |
+| Production Compose 파일 | `compose.prod.yaml` | EC2 애플리케이션 실행 |
+| Nginx 설정과 Origin Certificate 주입·갱신 절차 | `docker/nginx/nginx.prod.conf`, `scripts/deploy/restore-origin-tls.sh` | HTTPS origin 공개 |
+| DB bootstrap과 Parameter Store 운영 값 | DB bootstrap 완료, TourAPI·Admin 값 추가 필요 | Spring Boot 최초 시작 |
 
 ### C. 자동 배포 완료 조건
 
@@ -49,8 +49,8 @@ AWS resource는 먼저 생성할 수 있지만, 아래 항목이 준비되기 �
 | 입력·산출물 | 현재 값 | 차단되는 작업 |
 | --- | --- | --- |
 | GitHub organization/repository | `Buyeo-On/buyeo-on-be` | GitHub OIDC Trust Policy 생성 |
-| SSM 배포·rollback script 또는 Command Document | 미구현 | SSM 자동 배포·rollback |
-| GitHub Actions production 배포 Workflow | 미구현 | GitHub Actions 자동 배포 |
+| SSM 배포·rollback script 또는 Command Document | `scripts/deploy/` | SSM 자동 배포·rollback |
+| GitHub Actions production 배포 Workflow | `.github/workflows/deploy-production.yml` | GitHub Actions 자동 배포 |
 
 ## 리소스 목록
 
@@ -59,25 +59,25 @@ Console에서 생성한 직후 실제 ID, ARN 또는 Endpoint를 기록한다. �
 | 구분 | 권장 이름 | 실제 ID·ARN·Endpoint |
 | --- | --- | --- |
 | 운영 담당자 IAM User | `buyeoon-operator` | 미생성 |
-| GitHub OIDC Provider | `token.actions.githubusercontent.com` | 미생성 |
-| GitHub Automation Role | `buyeoon-prod-github-automation` | 미생성 |
-| EC2 Instance Role·Profile | `buyeoon-prod-ec2` | 미생성 |
-| VPC | `buyeoon-prod-vpc` | 미생성 |
-| Public Subnet | `buyeoon-prod-public-a` | 미생성 |
-| Private DB Subnet | `buyeoon-prod-db-a` | 미생성 |
-| Private DB Subnet | `buyeoon-prod-db-c` | 미생성 |
-| Internet Gateway | `buyeoon-prod-igw` | 미생성 |
-| Public Route Table | `buyeoon-prod-public-rt` | 미생성 |
-| EC2 Security Group | `buyeoon-prod-ec2-sg` | 미생성 |
-| RDS Security Group | `buyeoon-prod-rds-sg` | 미생성 |
-| RDS DB Subnet Group | `buyeoon-prod-db-subnets` | 미생성 |
-| RDS | `buyeoon-prod-db` | 미생성 |
-| EC2 | `buyeoon-prod-app` | 미생성 |
-| EIP | `buyeoon-prod-app-eip` | 미생성 |
-| ECR | `buyeoon/app` | 미생성 |
-| 이미지 S3 | 확정 필요 | 미생성 |
-| Parameter Store 경로 | `/buyeoon/prod/` | 미생성 |
-| CloudWatch Log Group | `/buyeoon/prod/app`, `/buyeoon/prod/nginx` | 미생성 |
+| GitHub OIDC Provider | `token.actions.githubusercontent.com` | 생성 완료 |
+| GitHub Automation Role | `buyeoon-github-deploy` | ARN은 GitHub `AWS_DEPLOY_ROLE_ARN` Variable로 관리 |
+| EC2 Instance Role·Profile | `buyeoon-ec2` | `buyeoon-ec2` |
+| VPC | `buyeoon-vpc` | Console ID 기록 필요 |
+| Public Subnet | `buyeoon-public-a` | Console ID 기록 필요 |
+| Private DB Subnet | `buyeoon-db-a` | Console ID 기록 필요 |
+| Private DB Subnet | `buyeoon-db-c` | Console ID 기록 필요 |
+| Internet Gateway | `buyeoon-igw` | Console ID 기록 필요 |
+| Public Route Table | `buyeoon-public-rt` | Console ID 기록 필요 |
+| EC2 Security Group | `buyeoon-ec2-sg` | Console ID 기록 필요 |
+| RDS Security Group | `buyeoon-rds-sg` | Console ID 기록 필요 |
+| RDS DB Subnet Group | `buyeoon-db-subnets` | Console ID 기록 필요 |
+| RDS | `buyeoon-db` | `buyeoon-db` |
+| EC2 | `buyeoon-app` | `i-02040f4aa55f0e233` |
+| EIP | `buyeoon-app-eip` | Console 주소 기록 필요 |
+| ECR | `buyeoon/app` | 생성 여부 확인 필요 |
+| 이미지 S3 | `buyeoon-images` | `buyeoon-images` |
+| Parameter Store 경로 | `/buyeoon/` | `/buyeoon/` |
+| CloudWatch Log Group | `/buyeoon/app`, `/buyeoon/nginx` | 9단계에서 생성 |
 
 모든 Tag 지원 리소스에는 다음 값을 적용한다.
 
@@ -136,7 +136,22 @@ Console에서 생성한 직후 실제 ID, ARN 또는 Endpoint를 기록한다. �
 10. Bucket Policy에서 `aws:SecureTransport=false`인 모든 요청을 거부한다.
 11. S3 Lifecycle에 1일이 지난 미완료 multipart upload를 중단하는 규칙을 추가한다.
 12. CloudWatch Log Group을 생성한다.
-13. `/buyeoon/prod/` 아래에 필요한 Parameter 이름을 생성하고 비밀값은 `SecureString`으로 저장한다.
+13. `/buyeoon/` 아래에 필요한 Parameter 이름을 생성하고 비밀값은 `SecureString`으로 저장한다.
+
+7단계 배포가 읽는 Parameter 계약은 다음과 같다. 값은 이 문서나 셸 이력에 기록하지 않는다.
+
+| Parameter | Type | 용도 |
+| --- | --- | --- |
+| `/buyeoon/aws/region` | String | AWS SDK·CLI Region |
+| `/buyeoon/db/url` | String | JDBC URL |
+| `/buyeoon/db/username`, `/buyeoon/db/password` | SecureString | 애플리케이션 DB Role |
+| `/buyeoon/jwt/secret-base64` | SecureString | HS256 서명 키 |
+| `/buyeoon/social/kakao/app-id` | String | 카카오 숫자형 앱 ID |
+| `/buyeoon/storage/image-bucket` | String | Private 이미지 Bucket 이름 |
+| `/buyeoon/tourapi/service-key` | SecureString | TourAPI 장소 동기화 |
+| `/buyeoon/admin/api-key` | SecureString | `/admin/**` 인증 |
+
+Apple 로그인은 기본적으로 비활성화한다. 활성화할 때만 `/buyeoon/social/apple/enabled=true`와 `client-id`, `team-id`, `key-id`, `private-key-base64`를 추가하며 비공개 키만 SecureString으로 저장한다. 8단계 TLS에서는 `/buyeoon/tls/origin-certificate`와 `/buyeoon/tls/origin-private-key`를 추가하고 비공개 키를 SecureString으로 저장한다.
 
 RDS 삭제는 일반 변경과 분리해 승인된 변경으로만 수행한다.
 
@@ -161,17 +176,20 @@ EC2 Instance Role은 다음 권한만 가진다.
 | --- | --- |
 | Systems Manager | `AmazonSSMManagedInstanceCore` 수준의 Managed Node 권한 |
 | ECR | 인증 토큰 조회와 `buyeoon/app` 이미지 pull |
-| Parameter Store | `/buyeoon/prod/*`의 필요한 Parameter 조회·복호화 |
+| Parameter Store | `/buyeoon/*`의 필요한 Parameter 조회·복호화 |
 | 이미지 S3 Bucket | prefix 범위의 `ListBucket`, 객체 `GetObject`, `PutObject`, `DeleteObject` |
 | CloudWatch Logs | 지정 Log Group의 Stream 생성과 이벤트 전송 |
 
 S3 `ListBucket`은 `public/*`, `private/*` prefix 조건으로 제한하고 객체 권한은 해당 객체 ARN으로 제한한다. 이 권한으로 애플리케이션이 Presigned PUT·GET을 생성하고 `HeadObject` 검증과 삭제 작업을 수행한다.
 
+현재 단일 EC2 Docker 구조에서는 애플리케이션이 Presigned URL을 만들기 위해 Instance Profile의 S3 권한을 사용한다. 따라서 Parameter Store 권한은 위에 열거한 운영 Parameter ARN만, S3 권한은 `buyeoon-images`의 필요한 prefix와 action만 허용한다. 컨테이너별 IAM 격리가 필요해지는 시점에는 ECS Task Role 구조로 이전한다.
+
 1. EC2 Instance Role과 Instance Profile을 생성한다.
 2. Public Subnet에 EC2를 생성하고 Instance Profile과 EC2 Security Group을 연결한다. 최초 package 설치와 SSM 등록을 위해 launch 시 public IPv4 자동 할당을 활성화한다.
 3. EC2가 Running이 되면 즉시 EIP를 생성해 연결하고 임시 public IPv4를 대체한다.
 4. SSM Agent가 포함된 승인 AMI를 사용하고 User data에는 Docker, Docker Compose Plugin과 CloudWatch Agent 설치만 둔다.
-5. 애플리케이션·Nginx 구성과 비밀값은 AMI와 User data에 넣지 않는다.
+5. Root EBS와 Snapshot 암호화를 활성화하고 IMDSv2를 Required, hop limit을 2로 설정한다.
+6. 애플리케이션·Nginx 구성과 비밀값은 AMI와 User data에 넣지 않는다.
 
 검증:
 
@@ -190,7 +208,7 @@ EC2가 준비된 뒤 Session Manager로 접속해 최초 한 번 수행한다.
 3. 로그나 명령 이력에 남기지 않는 방식으로 무작위 애플리케이션 DB 비밀번호를 생성한다.
 4. `buyeoon_app`을 `LOGIN`, 비 Superuser Role로 생성하고 생성한 비밀번호를 설정한다.
 5. `buyeoon_app`에 Flyway DDL과 애플리케이션 DML에 필요한 권한을 부여한다.
-6. `/buyeoon/prod/db/username`과 `/buyeoon/prod/db/password` SecureString을 애플리케이션 계정 값으로 갱신한다.
+6. `/buyeoon/db/username`과 `/buyeoon/db/password` SecureString을 애플리케이션 계정 값으로 갱신한다.
 7. RDS 관리자 자격증명을 애플리케이션 Parameter에 넣지 않는다.
 8. 기존 개발 DB의 `image_url` 값이 있으면 `public/` S3 객체 키로 먼저 교체하고 V5를 적용한다.
 9. V5가 적용된 앱 SHA를 최초 운영 기준 SHA로 기록한다. V5 이전 앱으로는 rollback하지 않는다.
@@ -239,19 +257,38 @@ Trust Policy 조건:
 
 다음 산출물이 Repository에 구현되고 검토되기 전에는 최초 배포를 진행하지 않는다.
 
-- Production Docker Compose 파일
-- Nginx 설정
-- Parameter Store 값을 root 전용 임시 환경 파일로 만드는 절차
-- Cloudflare Origin Certificate와 비공개 키를 Parameter Store에서 복원하는 절차
-- ECR pull, Compose 교체, health check와 이전 SHA 롤백을 수행하는 SSM 배포 스크립트 또는 Document
-- 현재·이전 배포 SHA를 기록하는 위치와 형식
-- `environment: production`, OIDC 권한, SHA 이미지 push, SSM SendCommand·결과 polling, Cloudflare 경유 공개 health 확인과 실패 시 이전 SHA 롤백을 포함한 GitHub Actions Workflow
+- `compose.prod.yaml`: SHA 이미지, localhost 내부 health 포트, 앱·Nginx 로그 볼륨
+- `docker/nginx/nginx.prod.conf`: Cloudflare Origin TLS와 query string을 제외한 JSON access log
+- `scripts/deploy/fetch-runtime-env.sh`: Parameter Store 값을 `/opt/buyeoon/runtime/runtime.env`에 root 전용 shell export 형식으로 복원
+- `scripts/deploy/restore-origin-tls.sh`: Origin Certificate와 비공개 키를 `/opt/buyeoon/tls`에 복원
+- `scripts/deploy/bootstrap-release.sh`: ECR SHA 이미지에서 같은 SHA의 배포 bundle을 추출
+- `scripts/deploy/deploy.sh`, `rollback.sh`: Compose 교체, 내부 health, 현재·이전 SHA 기록과 rollback
+- `.github/workflows/deploy-production.yml`: production Environment OIDC, ECR push, SSM polling과 공개 health 실패 rollback
+
+Workflow의 외부 Action과 운영 컨테이너 이미지는 검증한 commit SHA 또는 digest로 고정한다. SSM Command는 기본 waiter보다 긴 20분 제한으로 terminal status를 polling하고 제한을 넘으면 cancellation을 요청한다.
+
+호스트 상태는 `/opt/buyeoon/state/current-{sha,image,mode}`와 `previous-{sha,image,mode}`에 기록한다. 배포 bundle은 `/opt/buyeoon/releases/<commit-sha>`에 보관하며, EC2 디스크에는 RDS·S3의 영구 데이터를 저장하지 않는다.
+
+GitHub production Environment에는 다음 Variables를 설정한다.
+
+| Variable | 값 |
+| --- | --- |
+| `AWS_ACCOUNT_ID` | 운영 AWS Account ID |
+| `AWS_DEPLOY_ROLE_ARN` | 6단계 GitHub Automation Role ARN |
+| `AWS_REGION` | `ap-northeast-2` |
+| `EC2_INSTANCE_ID` | 운영 EC2 Instance ID |
+| `ECR_REPOSITORY` | `buyeoon/app` |
+| `PUBLIC_HEALTH_URL` | 8단계에서 확정할 `https://<api-host>/actuator/health` |
+| `PRODUCTION_DEPLOY_ENABLED` | 8단계 검증 전 `false`, 검증 후 `true` |
+
+Stage 7에서는 Workflow를 수동 실행하고 `app-only`를 선택한다. 이 모드는 Nginx와 인증서 없이 앱 컨테이너를 실행하고 EC2 localhost의 `127.0.0.1:18080/actuator/health`만 검증한다. Stage 8에서 Origin Certificate, DNS와 Cloudflare를 준비한 뒤 `full`을 실행해 Nginx와 공개 health 검증을 활성화한다. `main` push 자동 배포는 `PRODUCTION_DEPLOY_ENABLED=true`일 때만 실행된다.
 
 EC2 복구는 새 EC2를 같은 Public Subnet과 Instance Profile로 생성하고 EIP를 재연결한 뒤, 동일한 SSM 배포 산출물로 Nginx와 애플리케이션을 복원하는 방식으로 검증한다. 인증서와 애플리케이션 비밀값은 Parameter Store에서 다시 읽으며 EC2 디스크를 백업 원본으로 사용하지 않는다.
 
 검증:
 
-- [ ] 빈 EC2에서 SSM 배포만으로 Nginx와 앱을 시작할 수 있다.
+- [ ] 빈 EC2에서 수동 `app-only` Workflow만으로 앱과 Flyway를 시작할 수 있다.
+- [ ] 8단계 이후 빈 EC2에서 `full` Workflow만으로 Nginx와 앱을 시작할 수 있다.
 - [ ] 현재와 이전 app SHA가 모두 ECR에 존재한다.
 - [ ] health check 실패 시 이전 SHA로 재실행된다.
 - [ ] EC2 교체 후 RDS와 S3 데이터가 유지된다.
@@ -260,26 +297,28 @@ EC2 복구는 새 EC2를 같은 Public Subnet과 Instance Profile로 생성하�
 
 1. Cloudflare API DNS Record를 EIP로 연결하고 Proxy를 활성화한다.
 2. Nginx에 Origin Certificate를 복원하고 TLS를 `Full (strict)`로 설정한다.
-3. 테스트를 통과한 commit SHA 이미지를 ECR에 push한다.
-4. GitHub Actions가 SSM으로 운영 EC2에 배포 명령을 전달하고 Command 성공 여부를 확인한다.
-5. Spring Boot의 Flyway와 JPA validate가 성공한 뒤 GitHub Actions가 Cloudflare 경유 공개 health endpoint를 호출한다. 실패하면 Workflow가 실패하고 이전 SHA를 재배포한다.
-6. 공개 콘텐츠 API가 `public/` 객체의 10분 Presigned GET URL을 발급하는지 확인한다.
-7. 비공개 사진 API가 소유권 확인 후 `private/` 객체의 10분 Presigned GET URL을 발급하는지 확인한다.
+3. 군민증 캐릭터·테마·배지 등 앱이 관리할 공용 이미지 객체 키를 확정하고 `buyeoon-images/public/`에 실제 파일을 업로드한다.
+4. 같은 `public/` 객체 키를 저장하는 Flyway 시드를 작성하고 테스트한다. TourAPI 원본 장소 이미지는 `source_image_href`를 사용하므로 일괄 복사하지 않는다.
+5. GitHub Actions를 `full`로 실행해 테스트를 통과한 commit SHA 이미지를 ECR에 push하고 SSM Command 결과를 확인한다.
+6. Spring Boot의 Flyway와 JPA validate가 성공한 뒤 GitHub Actions가 Cloudflare 경유 공개 health endpoint를 호출한다. 실패하면 Workflow가 실패하고 이전 SHA를 재배포한다.
+7. 공개 콘텐츠 API가 `public/` 객체의 10분 Presigned GET URL을 발급하는지 확인한다.
 8. Presigned PUT 업로드 후 서버가 크기·MIME 타입·소유자를 검증하는지 확인한다.
+
+비공개 사진 Presigned GET과 다른 회원 접근 거부 검증은 현재 Repository에 조회 API가 없어 수행할 수 없다. 이 기능이 제품에 필요하면 인프라 배포 PR과 분리된 API 작업으로 구현한 뒤 아래 보류 체크를 활성화한다.
 
 검증:
 
 - [ ] Cloudflare 경유 HTTPS와 공개 health endpoint가 성공한다.
 - [ ] EIP 직접 HTTPS 접근은 Cloudflare 대역 외에서 차단된다.
 - [ ] S3 객체를 공개 S3 URL로 직접 조회할 수 없다.
-- [ ] 다른 회원은 API를 통해 해당 비공개 사진의 Presigned URL을 발급받을 수 없다.
+- [ ] 보류: 다른 회원은 API를 통해 해당 비공개 사진의 Presigned URL을 발급받을 수 없다.
 - [ ] Presigned URL은 HTTPS이며 만료 후 사용할 수 없다.
 - [ ] Presigned URL은 만료 전까지 소지자가 사용할 수 있는 bearer URL임을 클라이언트·로그 정책에 반영했다.
 - [ ] 실행 이미지 Tag가 배포 commit SHA와 일치한다.
 
 ### 9. 관측성과 복구
 
-1. Spring과 Nginx 로그를 CloudWatch Logs에 전송하고 30일 보관한다.
+1. `/var/log/buyeoon/app/application.json`, `/var/log/buyeoon/nginx/access.log`, `/var/log/buyeoon/nginx/error.log`를 CloudWatch Logs에 전송하고 30일 보관한다.
 2. RDS Snapshot 복원과 이전 app SHA 재배포를 비운영 복원 대상으로 검증한다.
 
 검증:

--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -1344,7 +1344,7 @@ components:
               newlyAwardedBadges:
                 - badgeId: 550e8400-e29b-41d4-a716-446655440020
                   name: 부소산성 탐험가
-                  imageUrl: https://buyeoon-prod-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
+                  imageUrl: https://buyeoon-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
                   condition: 부소산성 방문 기록 1회
                   earnedAt: '2026-08-06T11:20:00+09:00'
     PointSummarySuccess:
@@ -1375,7 +1375,7 @@ components:
                   category: EXPLORATION
                   name: 부소산성 탐험가
                   description: 부소산성 문화재 퀴즈를 완료한다.
-                  imageUrl: https://buyeoon-prod-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
+                  imageUrl: https://buyeoon-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
                   condition: 부소산성 방문 기록 1회
                   conditions:
                     - metricKey: HERITAGE_VISITED_COUNT
@@ -1397,7 +1397,7 @@ components:
               category: EXPLORATION
               name: 부소산성 탐험가
               description: 부소산성 문화재 퀴즈를 완료한다.
-              imageUrl: https://buyeoon-prod-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
+              imageUrl: https://buyeoon-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
               condition: 부소산성 방문 기록 1회
               conditions:
                 - metricKey: HERITAGE_VISITED_COUNT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/scripts/ci/test-wait-for-ssm-command.sh
+++ b/scripts/ci/test-wait-for-ssm-command.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+script_directory=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+test_directory=$(mktemp -d)
+trap 'rm -rf "${test_directory}"' EXIT
+mkdir -p "${test_directory}/bin" "${test_directory}/state"
+
+cat >"${test_directory}/bin/aws" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ " $* " == *" cancel-command "* ]]; then
+    touch "${FAKE_AWS_STATE_DIR}/cancelled"
+    exit 0
+fi
+
+count_file=${FAKE_AWS_STATE_DIR}/count
+count=0
+if [[ -f ${count_file} ]]; then
+    count=$(<"${count_file}")
+fi
+count=$((count + 1))
+printf '%s\n' "${count}" >"${count_file}"
+
+case "${FAKE_AWS_SCENARIO}" in
+    slow-success)
+        if ((count <= 21)); then echo InProgress; else echo Success; fi
+        ;;
+    missing-then-success)
+        if ((count == 1)); then echo InvocationDoesNotExist >&2; exit 254; else echo Success; fi
+        ;;
+    failed)
+        echo Failed
+        ;;
+    never)
+        echo InProgress
+        ;;
+    *)
+        echo "unknown fake scenario" >&2
+        exit 2
+        ;;
+esac
+EOF
+chmod +x "${test_directory}/bin/aws"
+
+export PATH="${test_directory}/bin:${PATH}"
+export FAKE_AWS_STATE_DIR="${test_directory}/state"
+export SSM_COMMAND_POLL_INTERVAL_SECONDS=0
+export SSM_COMMAND_TIMEOUT_SECONDS=30
+
+export FAKE_AWS_SCENARIO=slow-success
+"${script_directory}/wait-for-ssm-command.sh" command-1 instance-1 ap-northeast-2
+[[ $(<"${FAKE_AWS_STATE_DIR}/count") -eq 22 ]]
+
+rm -f "${FAKE_AWS_STATE_DIR}/count"
+export FAKE_AWS_SCENARIO=missing-then-success
+"${script_directory}/wait-for-ssm-command.sh" command-2 instance-1 ap-northeast-2
+
+rm -f "${FAKE_AWS_STATE_DIR}/count"
+export FAKE_AWS_SCENARIO=failed
+if "${script_directory}/wait-for-ssm-command.sh" command-3 instance-1 ap-northeast-2; then
+    echo "failed SSM status must return a non-zero exit code" >&2
+    exit 1
+fi
+
+rm -f "${FAKE_AWS_STATE_DIR}/count" "${FAKE_AWS_STATE_DIR}/cancelled"
+export FAKE_AWS_SCENARIO=never
+export SSM_COMMAND_POLL_INTERVAL_SECONDS=1
+export SSM_COMMAND_TIMEOUT_SECONDS=1
+set +e
+"${script_directory}/wait-for-ssm-command.sh" command-4 instance-1 ap-northeast-2
+timeout_status=$?
+set -e
+[[ ${timeout_status} -eq 124 ]]
+[[ -f ${FAKE_AWS_STATE_DIR}/cancelled ]]
+
+echo "SSM command polling tests passed"

--- a/scripts/ci/wait-for-ssm-command.sh
+++ b/scripts/ci/wait-for-ssm-command.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+command_id=${1:?command ID is required}
+instance_id=${2:?instance ID is required}
+aws_region=${3:?AWS region is required}
+timeout_seconds=${SSM_COMMAND_TIMEOUT_SECONDS:-900}
+poll_interval_seconds=${SSM_COMMAND_POLL_INTERVAL_SECONDS:-5}
+
+if [[ ! ${timeout_seconds} =~ ^[1-9][0-9]*$ ]]; then
+    echo "SSM_COMMAND_TIMEOUT_SECONDS must be a positive integer" >&2
+    exit 2
+fi
+if [[ ! ${poll_interval_seconds} =~ ^[0-9]+$ ]]; then
+    echo "SSM_COMMAND_POLL_INTERVAL_SECONDS must be a non-negative integer" >&2
+    exit 2
+fi
+
+deadline=$((SECONDS + timeout_seconds))
+while ((SECONDS < deadline)); do
+    if status=$(aws ssm get-command-invocation \
+        --command-id "${command_id}" \
+        --instance-id "${instance_id}" \
+        --region "${aws_region}" \
+        --query Status \
+        --output text 2>&1); then
+        case "${status}" in
+            Success)
+                exit 0
+                ;;
+            Pending | InProgress | Delayed)
+                sleep "${poll_interval_seconds}"
+                ;;
+            Cancelled | Cancelling | Failed | TimedOut)
+                echo "SSM command ${command_id} finished with status ${status}" >&2
+                exit 1
+                ;;
+            *)
+                echo "SSM command ${command_id} returned unknown status ${status}" >&2
+                exit 1
+                ;;
+        esac
+    elif [[ ${status} == *InvocationDoesNotExist* ]]; then
+        sleep "${poll_interval_seconds}"
+    else
+        printf '%s\n' "${status}" >&2
+        exit 1
+    fi
+done
+
+aws ssm cancel-command \
+    --command-id "${command_id}" \
+    --instance-ids "${instance_id}" \
+    --region "${aws_region}" >/dev/null 2>&1 || true
+echo "SSM command ${command_id} did not finish within ${timeout_seconds} seconds; cancellation requested" >&2
+exit 124

--- a/scripts/deploy/bootstrap-release.sh
+++ b/scripts/deploy/bootstrap-release.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+    echo "bootstrap-release.sh must run as root" >&2
+    exit 1
+fi
+
+image_uri=${1:?image URI is required}
+release_sha=${2:?release SHA is required}
+deployment_mode=${3:-full}
+buyeoon_home=${BUYEOON_HOME:-/opt/buyeoon}
+aws_region=${AWS_REGION:-ap-northeast-2}
+
+if [[ ! ${release_sha} =~ ^[0-9a-f]{40}$ ]]; then
+    echo "release SHA must be a 40-character lowercase Git SHA" >&2
+    exit 1
+fi
+if [[ ${image_uri} != *:"${release_sha}" ]]; then
+    echo "image tag must match the release SHA" >&2
+    exit 1
+fi
+case "${deployment_mode}" in
+    app-only | full) ;;
+    *)
+        echo "deployment mode must be app-only or full" >&2
+        exit 1
+        ;;
+esac
+
+registry=${image_uri%%/*}
+aws ecr get-login-password --region "${aws_region}" | \
+    docker login --username AWS --password-stdin "${registry}"
+docker pull "${image_uri}"
+
+release_directory=${buyeoon_home}/releases/${release_sha}
+install -d -m 0750 "${release_directory}"
+
+container_id=$(docker create "${image_uri}")
+trap 'docker rm -f "${container_id}" >/dev/null 2>&1 || true' EXIT
+docker cp "${container_id}:/opt/buyeoon/deploy-bundle/." "${release_directory}/"
+docker rm "${container_id}" >/dev/null
+trap - EXIT
+
+find "${release_directory}/scripts/deploy" -type f -name '*.sh' -exec chmod 0750 {} +
+touch "${release_directory}/.complete"
+
+exec "${release_directory}/scripts/deploy/deploy.sh" "${image_uri}" "${release_sha}" "${deployment_mode}"

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+    echo "deploy.sh must run as root" >&2
+    exit 1
+fi
+
+image_uri=${1:?image URI is required}
+release_sha=${2:?release SHA is required}
+deployment_mode=${3:-full}
+buyeoon_home=${BUYEOON_HOME:-/opt/buyeoon}
+release_directory=${buyeoon_home}/releases/${release_sha}
+compose_file=${release_directory}/compose.prod.yaml
+runtime_environment=${buyeoon_home}/runtime/runtime.env
+state_directory=${buyeoon_home}/state
+tls_directory=${TLS_DIR:-${buyeoon_home}/tls}
+
+if [[ ! -f ${compose_file} ]]; then
+    echo "Production Compose file is missing for ${release_sha}" >&2
+    exit 1
+fi
+case "${deployment_mode}" in
+    app-only | full) ;;
+    *)
+        echo "deployment mode must be app-only or full" >&2
+        exit 1
+        ;;
+esac
+
+install -d -m 0700 "$(dirname "${runtime_environment}")" "${state_directory}"
+install -d -m 0750 -o 10001 -g 10001 /var/log/buyeoon/app
+install -d -m 0750 /var/log/buyeoon/nginx
+
+"${release_directory}/scripts/deploy/fetch-runtime-env.sh" "${runtime_environment}"
+source "${runtime_environment}"
+
+export APP_IMAGE=${image_uri}
+export RELEASE_DIR=${release_directory}
+export TLS_DIR=${tls_directory}
+
+if [[ ${deployment_mode} == full ]]; then
+    "${release_directory}/scripts/deploy/restore-origin-tls.sh"
+fi
+
+current_sha=""
+current_image=""
+current_mode=""
+if [[ -f ${state_directory}/current-sha ]]; then
+    current_sha=$(<"${state_directory}/current-sha")
+    current_image=$(<"${state_directory}/current-image")
+    current_mode=$(<"${state_directory}/current-mode")
+fi
+
+wait_for_application() {
+    local compose_path=$1
+    local container_id
+    local health_status
+    container_id=$(docker compose -f "${compose_path}" ps -q app)
+    if [[ -z ${container_id} ]]; then
+        return 1
+    fi
+    for _ in $(seq 1 60); do
+        health_status=$(docker inspect --format '{{.State.Health.Status}}' "${container_id}" 2>/dev/null || true)
+        if [[ ${health_status} == healthy ]] && curl --fail --silent --show-error \
+            http://127.0.0.1:18080/actuator/health >/dev/null; then
+            return 0
+        fi
+        if [[ ${health_status} == unhealthy ]]; then
+            return 1
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+wait_for_nginx() {
+    for _ in $(seq 1 30); do
+        if curl --fail --silent --show-error http://127.0.0.1:8080/actuator/health >/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+start_release() {
+    local target_sha=$1
+    local target_image=$2
+    local target_mode=$3
+    local target_directory=${buyeoon_home}/releases/${target_sha}
+    local target_compose=${target_directory}/compose.prod.yaml
+
+    export APP_IMAGE=${target_image}
+    export RELEASE_DIR=${target_directory}
+    if [[ ${target_mode} == full ]]; then
+        docker compose -f "${target_compose}" up -d --remove-orphans
+    else
+        docker compose -f "${target_compose}" up -d app
+    fi
+    wait_for_application "${target_compose}"
+    if [[ ${target_mode} == full ]]; then
+        wait_for_nginx
+    fi
+}
+
+if ! start_release "${release_sha}" "${image_uri}" "${deployment_mode}"; then
+    echo "Release ${release_sha} failed its internal health check" >&2
+    if [[ -n ${current_sha} && -f ${buyeoon_home}/releases/${current_sha}/compose.prod.yaml ]]; then
+        echo "Rolling back to ${current_sha}" >&2
+        start_release "${current_sha}" "${current_image}" "${current_mode}" || {
+            echo "Automatic rollback to ${current_sha} also failed" >&2
+            exit 1
+        }
+    fi
+    exit 1
+fi
+
+if [[ -n ${current_sha} && ${current_sha} != "${release_sha}" ]]; then
+    printf '%s\n' "${current_sha}" >"${state_directory}/previous-sha"
+    printf '%s\n' "${current_image}" >"${state_directory}/previous-image"
+    printf '%s\n' "${current_mode}" >"${state_directory}/previous-mode"
+fi
+printf '%s\n' "${release_sha}" >"${state_directory}/current-sha"
+printf '%s\n' "${image_uri}" >"${state_directory}/current-image"
+printf '%s\n' "${deployment_mode}" >"${state_directory}/current-mode"
+ln -sfn "${release_directory}" "${buyeoon_home}/current"
+
+echo "Release ${release_sha} is healthy in ${deployment_mode} mode"

--- a/scripts/deploy/fetch-runtime-env.sh
+++ b/scripts/deploy/fetch-runtime-env.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+    echo "fetch-runtime-env.sh must run as root" >&2
+    exit 1
+fi
+
+parameter_prefix=${PARAMETER_PREFIX:-/buyeoon}
+lookup_region=${AWS_REGION:-ap-northeast-2}
+output_path=${1:-/run/buyeoon/runtime.env}
+
+install -d -m 0700 "$(dirname "${output_path}")"
+temporary_path=$(mktemp "${output_path}.XXXXXX")
+trap 'rm -f "${temporary_path}"' EXIT
+chmod 0600 "${temporary_path}"
+
+read_parameter() {
+    local parameter_name=$1
+    aws ssm get-parameter \
+        --name "${parameter_name}" \
+        --with-decryption \
+        --region "${lookup_region}" \
+        --query 'Parameter.Value' \
+        --output text
+}
+
+read_optional_parameter() {
+    local parameter_name=$1
+    aws ssm get-parameter \
+        --name "${parameter_name}" \
+        --with-decryption \
+        --region "${lookup_region}" \
+        --query 'Parameter.Value' \
+        --output text 2>/dev/null
+}
+
+write_export() {
+    local environment_name=$1
+    local value=$2
+    printf 'export %s=%q\n' "${environment_name}" "${value}" >>"${temporary_path}"
+}
+
+write_parameter() {
+    local environment_name=$1
+    local parameter_name=$2
+    local value
+    value=$(read_parameter "${parameter_name}")
+    write_export "${environment_name}" "${value}"
+}
+
+runtime_region=$(read_parameter "${parameter_prefix}/aws/region")
+lookup_region=${runtime_region}
+write_export AWS_REGION "${runtime_region}"
+write_export AWS_DEFAULT_REGION "${runtime_region}"
+
+write_parameter DB_URL "${parameter_prefix}/db/url"
+write_parameter DB_USERNAME "${parameter_prefix}/db/username"
+write_parameter DB_PASSWORD "${parameter_prefix}/db/password"
+write_parameter JWT_SECRET "${parameter_prefix}/jwt/secret-base64"
+write_parameter KAKAO_APP_ID "${parameter_prefix}/social/kakao/app-id"
+write_parameter IMAGE_BUCKET "${parameter_prefix}/storage/image-bucket"
+write_parameter TOURAPI_SERVICE_KEY "${parameter_prefix}/tourapi/service-key"
+write_parameter ADMIN_API_KEY "${parameter_prefix}/admin/api-key"
+
+apple_enabled=false
+if configured_apple_enabled=$(read_optional_parameter "${parameter_prefix}/social/apple/enabled"); then
+    apple_enabled=${configured_apple_enabled}
+fi
+
+case "${apple_enabled}" in
+    true)
+        write_export APPLE_LOGIN_ENABLED true
+        write_parameter APPLE_CLIENT_ID "${parameter_prefix}/social/apple/client-id"
+        write_parameter APPLE_TEAM_ID "${parameter_prefix}/social/apple/team-id"
+        write_parameter APPLE_KEY_ID "${parameter_prefix}/social/apple/key-id"
+        write_parameter APPLE_PRIVATE_KEY_BASE64 "${parameter_prefix}/social/apple/private-key-base64"
+        ;;
+    false)
+        write_export APPLE_LOGIN_ENABLED false
+        write_export APPLE_CLIENT_ID ""
+        write_export APPLE_TEAM_ID ""
+        write_export APPLE_KEY_ID ""
+        write_export APPLE_PRIVATE_KEY_BASE64 ""
+        ;;
+    *)
+        echo "${parameter_prefix}/social/apple/enabled must be true or false" >&2
+        exit 1
+        ;;
+esac
+
+mv "${temporary_path}" "${output_path}"
+trap - EXIT
+chmod 0600 "${output_path}"
+chown root:root "${output_path}"
+
+echo "Runtime environment written to ${output_path}"

--- a/scripts/deploy/restore-origin-tls.sh
+++ b/scripts/deploy/restore-origin-tls.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+    echo "restore-origin-tls.sh must run as root" >&2
+    exit 1
+fi
+
+parameter_prefix=${PARAMETER_PREFIX:-/buyeoon}
+aws_region=${AWS_REGION:-ap-northeast-2}
+tls_directory=${TLS_DIR:-/opt/buyeoon/tls}
+certificate_parameter=${ORIGIN_CERTIFICATE_PARAMETER:-${parameter_prefix}/tls/origin-certificate}
+private_key_parameter=${ORIGIN_PRIVATE_KEY_PARAMETER:-${parameter_prefix}/tls/origin-private-key}
+
+install -d -m 0700 -o root -g root "${tls_directory}"
+certificate_tmp=$(mktemp "${tls_directory}/.origin-cert.XXXXXX")
+private_key_tmp=$(mktemp "${tls_directory}/.origin-key.XXXXXX")
+trap 'rm -f "${certificate_tmp}" "${private_key_tmp}"' EXIT
+
+aws ssm get-parameter \
+    --name "${certificate_parameter}" \
+    --with-decryption \
+    --region "${aws_region}" \
+    --query 'Parameter.Value' \
+    --output text >"${certificate_tmp}"
+
+aws ssm get-parameter \
+    --name "${private_key_parameter}" \
+    --with-decryption \
+    --region "${aws_region}" \
+    --query 'Parameter.Value' \
+    --output text >"${private_key_tmp}"
+
+if ! grep -q -- 'BEGIN CERTIFICATE' "${certificate_tmp}"; then
+    echo "Origin certificate parameter is not PEM encoded" >&2
+    exit 1
+fi
+if ! grep -Eq -- 'BEGIN ([A-Z]+ )?PRIVATE KEY' "${private_key_tmp}"; then
+    echo "Origin private key parameter is not PEM encoded" >&2
+    exit 1
+fi
+
+chmod 0644 "${certificate_tmp}"
+chmod 0600 "${private_key_tmp}"
+mv "${certificate_tmp}" "${tls_directory}/origin.pem"
+mv "${private_key_tmp}" "${tls_directory}/origin.key"
+trap - EXIT
+
+echo "Cloudflare origin TLS material restored to ${tls_directory}"

--- a/scripts/deploy/rollback.sh
+++ b/scripts/deploy/rollback.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ ${EUID} -ne 0 ]]; then
+    echo "rollback.sh must run as root" >&2
+    exit 1
+fi
+
+buyeoon_home=${BUYEOON_HOME:-/opt/buyeoon}
+state_directory=${buyeoon_home}/state
+
+for state_file in previous-sha previous-image previous-mode; do
+    if [[ ! -s ${state_directory}/${state_file} ]]; then
+        echo "Rollback state ${state_file} is missing" >&2
+        exit 1
+    fi
+done
+
+previous_sha=$(<"${state_directory}/previous-sha")
+previous_image=$(<"${state_directory}/previous-image")
+previous_mode=$(<"${state_directory}/previous-mode")
+previous_deploy=${buyeoon_home}/releases/${previous_sha}/scripts/deploy/deploy.sh
+
+if [[ ! -x ${previous_deploy} ]]; then
+    echo "Rollback release ${previous_sha} is not available" >&2
+    exit 1
+fi
+
+exec "${previous_deploy}" "${previous_image}" "${previous_sha}" "${previous_mode}"

--- a/src/main/java/com/buyeoon/common/observability/RequestCorrelationFilter.java
+++ b/src/main/java/com/buyeoon/common/observability/RequestCorrelationFilter.java
@@ -1,0 +1,50 @@
+package com.buyeoon.common.observability;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public final class RequestCorrelationFilter extends OncePerRequestFilter {
+
+	private static final String REQUEST_ID_HEADER = "X-Request-ID";
+	private static final String CF_RAY_HEADER = "CF-Ray";
+	private static final Pattern SAFE_CORRELATION_VALUE = Pattern.compile("[A-Za-z0-9._:-]{1,128}");
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+		String requestId = safeHeader(request, REQUEST_ID_HEADER);
+		if (requestId == null) {
+			requestId = UUID.randomUUID().toString();
+		}
+		String cfRay = safeHeader(request, CF_RAY_HEADER);
+
+		response.setHeader(REQUEST_ID_HEADER, requestId);
+		MDC.put("request_id", requestId);
+		if (cfRay != null) {
+			MDC.put("cf_ray", cfRay);
+		}
+		try {
+			filterChain.doFilter(request, response);
+		} finally {
+			MDC.remove("request_id");
+			MDC.remove("cf_ray");
+		}
+	}
+
+	private String safeHeader(HttpServletRequest request, String headerName) {
+		String value = request.getHeader(headerName);
+		return value != null && SAFE_CORRELATION_VALUE.matcher(value).matches() ? value : null;
+	}
+}

--- a/src/main/java/com/buyeoon/member/auth/social/AppleSocialAuthenticationConfiguration.java
+++ b/src/main/java/com/buyeoon/member/auth/social/AppleSocialAuthenticationConfiguration.java
@@ -9,12 +9,14 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.Base64;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 @Configuration
+@ConditionalOnProperty(prefix = "social.apple", name = "enabled", havingValue = "true")
 public class AppleSocialAuthenticationConfiguration {
 
 	@Bean

--- a/src/main/java/com/buyeoon/place/application/PlaceCommandService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceCommandService.java
@@ -1,12 +1,11 @@
 package com.buyeoon.place.application;
 
-import com.buyeoon.place.entity.SavedPlaceEntity;
 import com.buyeoon.place.entity.SavedPlaceId;
 import com.buyeoon.place.repository.PlaceQueryRepository;
 import com.buyeoon.place.repository.SavedPlaceRepository;
 import com.buyeoon.trip.TripQueryService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.UUID;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +16,7 @@ public class PlaceCommandService {
 	private final SavedPlaceRepository savedPlaceRepository;
 	private final TripQueryService tripQueryService;
 
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
 	public PlaceCommandService(PlaceQueryRepository placeQueryRepository, SavedPlaceRepository savedPlaceRepository,
 			TripQueryService tripQueryService) {
 		this.placeQueryRepository = placeQueryRepository;
@@ -32,12 +32,7 @@ public class PlaceCommandService {
 		if (!placeQueryRepository.existsById(placeId)) {
 			throw new PlaceNotFoundException();
 		}
-		try {
-			savedPlaceRepository.save(SavedPlaceEntity.create(memberId, placeId));
-			savedPlaceRepository.flush();
-		} catch (DataIntegrityViolationException alreadySaved) {
-			// 회원-장소 유니크 제약 위반은 이미 저장된 상태라는 뜻이므로 성공으로 흡수한다.
-		}
+		savedPlaceRepository.insertIfAbsent(memberId, placeId);
 	}
 
 	@Transactional

--- a/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
@@ -8,6 +8,7 @@ import com.buyeoon.place.repository.PlaceQueryRepository;
 import com.buyeoon.place.repository.SavedPlaceProjection;
 import com.buyeoon.place.repository.SavedPlaceRepository;
 import com.buyeoon.trip.TripQueryService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -26,6 +27,7 @@ public class PlaceQueryService {
 	private final TripQueryService tripQueryService;
 	private final PublicImageUrlService imageUrls;
 
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
 	public PlaceQueryService(PlaceQueryRepository placeQueryRepository, SavedPlaceRepository savedPlaceRepository,
 			TripQueryService tripQueryService, PublicImageUrlService imageUrls) {
 		this.placeQueryRepository = placeQueryRepository;

--- a/src/main/java/com/buyeoon/place/repository/SavedPlaceRepository.java
+++ b/src/main/java/com/buyeoon/place/repository/SavedPlaceRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,6 +19,11 @@ import org.springframework.data.repository.query.Param;
  * 저장 시각순이며 거리는 표시용으로만 SELECT에 추가된다.
  */
 public interface SavedPlaceRepository extends JpaRepository<SavedPlaceEntity, SavedPlaceId> {
+
+	@Modifying
+	@Query(value = "INSERT INTO saved_places (member_id, place_id) VALUES (:memberId, :placeId) "
+			+ "ON CONFLICT (member_id, place_id) DO NOTHING", nativeQuery = true)
+	void insertIfAbsent(@Param("memberId") UUID memberId, @Param("placeId") UUID placeId);
 
 	/** 조회한 페이지의 장소만 한 번에 확인해 장소 수만큼 질의가 늘어나지 않게 한다. */
 	@Query("""

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,10 +19,11 @@ social.kakao.api-base-url=${KAKAO_API_BASE_URL:https://kapi.kakao.com}
 social.kakao.connect-timeout=${KAKAO_CONNECT_TIMEOUT:2s}
 social.kakao.read-timeout=${KAKAO_READ_TIMEOUT:3s}
 
-social.apple.client-id=${APPLE_CLIENT_ID}
-social.apple.team-id=${APPLE_TEAM_ID}
-social.apple.key-id=${APPLE_KEY_ID}
-social.apple.private-key-base64=${APPLE_PRIVATE_KEY_BASE64}
+social.apple.enabled=${APPLE_LOGIN_ENABLED:false}
+social.apple.client-id=${APPLE_CLIENT_ID:}
+social.apple.team-id=${APPLE_TEAM_ID:}
+social.apple.key-id=${APPLE_KEY_ID:}
+social.apple.private-key-base64=${APPLE_PRIVATE_KEY_BASE64:}
 social.apple.api-base-url=${APPLE_API_BASE_URL:https://appleid.apple.com}
 social.apple.client-secret-ttl=${APPLE_CLIENT_SECRET_TTL:5m}
 social.apple.connect-timeout=${APPLE_CONNECT_TIMEOUT:2s}

--- a/src/test/java/com/buyeoon/common/observability/RequestCorrelationFilterTests.java
+++ b/src/test/java/com/buyeoon/common/observability/RequestCorrelationFilterTests.java
@@ -1,0 +1,55 @@
+package com.buyeoon.common.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class RequestCorrelationFilterTests {
+
+	private final RequestCorrelationFilter filter = new RequestCorrelationFilter();
+
+	@AfterEach
+	void clearMdc() {
+		MDC.clear();
+	}
+
+	@Test
+	@DisplayName("Nginx와 Cloudflare 상관관계 값을 요청 처리 중 MDC에 넣고 응답에 요청 ID를 반환한다")
+	void exposesSafeCorrelationValuesDuringRequest() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("X-Request-ID", "nginx-request-123");
+		request.addHeader("CF-Ray", "cloudflare-ray-456-ICN");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain chain = (servletRequest, servletResponse) -> {
+			assertThat(MDC.get("request_id")).isEqualTo("nginx-request-123");
+			assertThat(MDC.get("cf_ray")).isEqualTo("cloudflare-ray-456-ICN");
+		};
+
+		filter.doFilter(request, response, chain);
+
+		assertThat(response.getHeader("X-Request-ID")).isEqualTo("nginx-request-123");
+		assertThat(MDC.get("request_id")).isNull();
+		assertThat(MDC.get("cf_ray")).isNull();
+	}
+
+	@Test
+	@DisplayName("로그 주입이 가능한 요청 ID는 새 서버 요청 ID로 교체한다")
+	void replacesUnsafeRequestId() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("X-Request-ID", "unsafe\nrequest-id");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, (servletRequest, servletResponse) -> {
+			assertThat(MDC.get("request_id")).doesNotContain("\n");
+			assertThat(MDC.get("request_id")).isNotEqualTo("unsafe\nrequest-id");
+		});
+
+		assertThat(response.getHeader("X-Request-ID")).matches("[0-9a-f-]{36}");
+	}
+}

--- a/src/test/java/com/buyeoon/member/DisabledAppleSocialLoginIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/DisabledAppleSocialLoginIntegrationTests.java
@@ -1,0 +1,31 @@
+package com.buyeoon.member;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = "social.apple.enabled=false")
+@AutoConfigureMockMvc
+class DisabledAppleSocialLoginIntegrationTests {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("Apple 로그인이 비활성화되면 Apple 자격증명 없이 기동하고 Apple 요청을 거부한다")
+	void disabledAppleLoginRejectsAppleRequest() throws Exception {
+		mockMvc.perform(post("/auth/social-login").contentType(MediaType.APPLICATION_JSON).content("""
+				{"provider":"APPLE","authorizationCode":"code","identityToken":"token","nonce":"nonce"}
+				""")).andExpect(status().isUnauthorized()).andExpect(content().json("""
+				{"success":false,"data":{"code":"SOCIAL_AUTHENTICATION_FAILED","message":"소셜 인증에 실패했습니다."}}
+				"""));
+	}
+}

--- a/src/test/java/com/buyeoon/member/auth/social/AppleSocialAuthenticationConfigurationTests.java
+++ b/src/test/java/com/buyeoon/member/auth/social/AppleSocialAuthenticationConfigurationTests.java
@@ -1,0 +1,22 @@
+package com.buyeoon.member.auth.social;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class AppleSocialAuthenticationConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withUserConfiguration(AppleSocialAuthenticationConfiguration.class);
+
+	@Test
+	@DisplayName("Apple 로그인이 비활성화되면 Apple 설정 없이 애플리케이션 구성을 만들 수 있다")
+	void disabledAppleLoginDoesNotRequireAppleConfiguration() {
+		contextRunner.withPropertyValues("social.apple.enabled=false").run(context -> {
+			assertThat(context).hasNotFailed();
+			assertThat(context).doesNotHaveBean("appleSocialCredentialVerifier");
+		});
+	}
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -15,6 +15,7 @@ social.kakao.api-base-url=https://kapi.kakao.test
 social.kakao.connect-timeout=2s
 social.kakao.read-timeout=3s
 
+social.apple.enabled=true
 social.apple.client-id=com.buyeoon.app
 social.apple.team-id=TEAMID1234
 social.apple.key-id=KEYID12345

--- a/swagger/openapi.yaml
+++ b/swagger/openapi.yaml
@@ -1171,7 +1171,7 @@ components:
               newlyAwardedBadges:
                 - badgeId: 550e8400-e29b-41d4-a716-446655440020
                   name: 부소산성 탐험가
-                  imageUrl: https://buyeoon-prod-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
+                  imageUrl: https://buyeoon-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
                   condition: 부소산성 방문 기록 1회
                   earnedAt: '2026-08-06T11:20:00+09:00'
     PointSummarySuccess:
@@ -1202,7 +1202,7 @@ components:
                   category: EXPLORATION
                   name: 부소산성 탐험가
                   description: 부소산성 문화재 퀴즈를 완료한다.
-                  imageUrl: https://buyeoon-prod-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
+                  imageUrl: https://buyeoon-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
                   condition: 부소산성 방문 기록 1회
                   conditions:
                     - metricKey: HERITAGE_VISITED_COUNT
@@ -1224,7 +1224,7 @@ components:
               category: EXPLORATION
               name: 부소산성 탐험가
               description: 부소산성 문화재 퀴즈를 완료한다.
-              imageUrl: https://buyeoon-prod-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
+              imageUrl: https://buyeoon-images.s3.ap-northeast-2.amazonaws.com/public/badges/example.png?X-Amz-Expires=600
               condition: 부소산성 방문 기록 1회
               conditions:
                 - metricKey: HERITAGE_VISITED_COUNT


### PR DESCRIPTION
## Summary
- GitHub OIDC → ECR → SSM 기반 EC2 자동 배포 워크플로 추가 (`deploy-production.yml`). `PRODUCTION_DEPLOY_ENABLED` 플래그로 의도치 않은 자동 배포 방지, SSM 명령 완료는 명시적 polling으로 대기(최대 20분)
- `compose.prod.yaml` + nginx TLS 리버스 프록시로 운영 컨테이너 구성
- Parameter Store(`/buyeoon/...`)에서 런타임 환경을 조회하는 배포/롤백 스크립트 추가
- Apple 로그인은 `social.apple.enabled` 플래그로 조건부 비활성화 가능하도록 변경(아직 미구현 기능이므로 기본 false)
- 요청별 Request ID를 전파하는 `RequestCorrelationFilter` 추가, ECS JSON 로그와 연계
- UC-08 장소 저장 동시 요청 시 트랜잭션 롤백되던 버그를 `INSERT ... ON CONFLICT DO NOTHING`으로 수정
- 문서(S3 버킷명, OIDC 상태 등)를 실제 인프라 상태에 맞춰 정합화
- gradle wrapper에 `distributionSha256Sum` 추가로 배포 무결성 검증 강화

## 실 배포 전 필요 사항
- SSM Parameter Store에 `/buyeoon/tourapi/service-key`, `/buyeoon/admin/api-key` 값 등록 필요
- GitHub Production Environment Variables(`AWS_DEPLOY_ROLE_ARN`, `EC2_INSTANCE_ID` 등) 및 ECR 저장소 사전 확인 필요

## Test plan
- [x] `./gradlew test`로 `SchemaMappingTests`, `BadgeReconciliationIntegrationTests` 재실행 통과 확인
- [x] Docker + PostGIS 로컬 실행 후 health UP 확인
- [x] nginx 설정(`nginx -t`), compose, 셸 스크립트, workflow YAML 검증
- [ ] 실제 AWS 환경에서 SSM 배포 워크플로 종단 검증 (Parameter Store 값 등록 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)