### PR TITLE
feat: UC-24 여행 포인트 정산 확정 구현 (#143)

### DIFF
--- a/src/main/java/com/buyeoon/point/api/PointController.java
+++ b/src/main/java/com/buyeoon/point/api/PointController.java
@@ -3,21 +3,29 @@ package com.buyeoon.point.api;
 import com.buyeoon.common.api.SuccessResponse;
 import com.buyeoon.point.application.PointSettlementPreviewService;
 import com.buyeoon.point.application.PointSettlementPreviewService.PointSettlementPreviewView;
+import com.buyeoon.point.application.PointSettlementService;
+import com.buyeoon.point.application.PointSettlementService.TripSettlementView;
 import com.buyeoon.point.application.PointSummaryService;
 import com.buyeoon.point.application.PointSummaryService.PointSummaryView;
 import com.buyeoon.point.application.PointTransactionCursor;
 import com.buyeoon.point.application.PointTransactionQueryService;
 import com.buyeoon.point.application.PointTransactionQueryService.PointTransactionListView;
+import com.buyeoon.point.entity.SettlementChoice;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Objects;
 import java.util.UUID;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import tools.jackson.databind.JsonNode;
 
-/** 로그인 회원의 포인트 잔액 요약, 내역과 여행 정산 미리보기 조회를 담당하는 컨트롤러다. */
+/** 로그인 회원의 포인트 잔액 요약, 내역, 여행 정산 미리보기 조회와 여행 포인트 정산 확정을 담당하는 컨트롤러다. */
 @RestController
 public class PointController {
 
@@ -28,13 +36,17 @@ public class PointController {
 	private final PointSummaryService pointSummaryService;
 	private final PointTransactionQueryService pointTransactionQueryService;
 	private final PointSettlementPreviewService pointSettlementPreviewService;
+	private final PointSettlementService pointSettlementService;
 
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
 	public PointController(PointSummaryService pointSummaryService,
 			PointTransactionQueryService pointTransactionQueryService,
-			PointSettlementPreviewService pointSettlementPreviewService) {
+			PointSettlementPreviewService pointSettlementPreviewService,
+			PointSettlementService pointSettlementService) {
 		this.pointSummaryService = pointSummaryService;
 		this.pointTransactionQueryService = pointTransactionQueryService;
 		this.pointSettlementPreviewService = pointSettlementPreviewService;
+		this.pointSettlementService = pointSettlementService;
 	}
 
 	@GetMapping("/members/me/points")
@@ -55,6 +67,40 @@ public class PointController {
 			@PathVariable UUID tripId) {
 		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
 		return SuccessResponse.of(pointSettlementPreviewService.preview(memberId, tripId));
+	}
+
+	@PutMapping("/trips/{tripId}/settlement")
+	public SuccessResponse<TripSettlementView> settleTripPoints(@AuthenticationPrincipal Jwt jwt,
+			@PathVariable UUID tripId, @RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey,
+			@RequestBody(required = false) JsonNode request) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		SettlementChoice choice = parseChoice(request);
+		return SuccessResponse.of(pointSettlementService.settle(memberId, tripId, idempotencyKey, choice));
+	}
+
+	private SettlementChoice parseChoice(JsonNode request) {
+		if (request == null || request.isNull()) {
+			return null;
+		}
+		if (!request.isObject() || !hasOnlyOptionalChoice(request)) {
+			throw new InvalidPointRequestException();
+		}
+		JsonNode choiceNode = request.get("choice");
+		if (choiceNode == null || choiceNode.isNull()) {
+			return null;
+		}
+		if (!choiceNode.isString()) {
+			throw new InvalidPointRequestException();
+		}
+		return switch (choiceNode.stringValue()) {
+			case "LEAVE_TO_BUYEO" -> SettlementChoice.LEAVE_TO_BUYEO;
+			case "CARRY_OVER" -> SettlementChoice.CARRY_OVER;
+			default -> throw new InvalidPointRequestException();
+		};
+	}
+
+	private boolean hasOnlyOptionalChoice(JsonNode node) {
+		return node.size() == 0 || (node.size() == 1 && node.has("choice"));
 	}
 
 	private PointTransactionCursor parseCursor(String cursor) {

--- a/src/main/java/com/buyeoon/point/api/PointExceptionHandler.java
+++ b/src/main/java/com/buyeoon/point/api/PointExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.buyeoon.point.api;
 
 import com.buyeoon.common.api.ErrorResponse;
+import com.buyeoon.member.application.IdempotencyKeyReusedException;
 import com.buyeoon.member.application.InvalidStateTransitionException;
 import com.buyeoon.member.application.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -12,10 +14,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(assignableTypes = PointController.class)
 public class PointExceptionHandler {
 
-	@ExceptionHandler(InvalidPointRequestException.class)
+	@ExceptionHandler({InvalidPointRequestException.class, HttpMessageNotReadableException.class})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ErrorResponse handleInvalidRequest() {
 		return ErrorResponse.invalidRequest();
+	}
+
+	@ExceptionHandler(IdempotencyKeyReusedException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ErrorResponse handleIdempotencyKeyReused() {
+		return ErrorResponse.idempotencyKeyReused();
 	}
 
 	@ExceptionHandler(ResourceNotFoundException.class)

--- a/src/main/java/com/buyeoon/point/application/PointSettlementService.java
+++ b/src/main/java/com/buyeoon/point/application/PointSettlementService.java
@@ -1,0 +1,227 @@
+package com.buyeoon.point.application;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.common.entity.IdempotencyRequestEntity;
+import com.buyeoon.common.entity.IdempotencyRequestId;
+import com.buyeoon.member.application.IdempotencyKeyReusedException;
+import com.buyeoon.member.application.InvalidStateTransitionException;
+import com.buyeoon.point.api.InvalidPointRequestException;
+import com.buyeoon.point.entity.PointSettlementEntity;
+import com.buyeoon.point.entity.PointTransactionType;
+import com.buyeoon.point.entity.SettlementChoice;
+import com.buyeoon.point.repository.PointIdempotencyRequestRepository;
+import com.buyeoon.point.repository.PointSettlementQueryRepository;
+import com.buyeoon.point.repository.PointTransactionRepository;
+import com.buyeoon.trip.TripSettlementService;
+import com.buyeoon.trip.entity.TripStatus;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.ObjectWriter;
+
+/**
+ * UC-24 여행 포인트 정산 확정 커맨드 서비스다. 해당 여행의 {@code EARN} 합계만 정산 대상으로 삼아
+ * {@code LEAVE_TO_BUYEO}, {@code CARRY_OVER} 또는 {@code NO_POINTS}로 정확히 한 번 정산하고
+ * 여행을 {@code SETTLED}로 전이한다. TripEndService·MissionSubmissionService의 멱등성/락 패턴을
+ * 재사용한다.
+ */
+@Service
+public class PointSettlementService {
+
+	private static final String OPERATION = "SETTLE_TRIP_POINTS";
+	private static final Duration RETENTION = Duration.ofHours(24);
+	private static final String LEAVE_TO_BUYEO_DESCRIPTION = "여행 포인트 정산: 부여에 남기기";
+
+	private final JdbcOperations jdbcOperations;
+	private final TransactionTemplate transactions;
+	private final TripSettlementService tripSettlementService;
+	private final PointExpirationService pointExpirationService;
+	private final PointTransactionRepository pointTransactions;
+	private final PointSettlementQueryRepository pointSettlements;
+	private final PointIdempotencyRequestRepository idempotencyRequests;
+	private final ObjectReader objectReader;
+	private final ObjectWriter objectWriter;
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public PointSettlementService(JdbcOperations jdbcOperations, PlatformTransactionManager transactionManager,
+			TripSettlementService tripSettlementService, PointExpirationService pointExpirationService,
+			PointTransactionRepository pointTransactions, PointSettlementQueryRepository pointSettlements,
+			PointIdempotencyRequestRepository idempotencyRequests, ObjectMapper objectMapper) {
+		this.jdbcOperations = jdbcOperations;
+		this.transactions = new TransactionTemplate(transactionManager);
+		this.tripSettlementService = tripSettlementService;
+		this.pointExpirationService = pointExpirationService;
+		this.pointTransactions = pointTransactions;
+		this.pointSettlements = pointSettlements;
+		this.idempotencyRequests = idempotencyRequests;
+		this.objectReader = objectMapper.reader();
+		this.objectWriter = objectMapper.writer();
+	}
+
+	public TripSettlementView settle(UUID memberId, UUID tripId, String idempotencyKey, SettlementChoice choice) {
+		validateIdempotencyKey(idempotencyKey);
+		String requestHash = requestHash(tripId, choice);
+		TripSettlementView result = transactions
+				.execute(status -> settleInTransaction(memberId, tripId, idempotencyKey, requestHash, choice));
+		return Objects.requireNonNull(result, "여행 포인트 정산 트랜잭션 결과가 없습니다.");
+	}
+
+	private TripSettlementView settleInTransaction(UUID memberId, UUID tripId, String idempotencyKey,
+			String requestHash, SettlementChoice choice) {
+		pointExpirationService.expireDueSettlementsForActiveMember(memberId);
+
+		TripStatus tripStatus = tripSettlementService.lockOwnedTripStatus(memberId, tripId);
+		long settleablePoints = pointTransactions.sumAmountByTripIdAndType(tripId, PointTransactionType.EARN);
+		Instant settledAt = clockTimestamp();
+
+		// 이미 정산이 확정돼 트립 상태가 더 이상 ENDED가 아니어도 같은 키의 replay는 성공해야 하므로 상태 검증보다 먼저
+		// 멱등성 결과를 확인한다.
+		IdempotencyRequestId idempotencyId = new IdempotencyRequestId(memberId, idempotencyKey);
+		Optional<IdempotencyRequestEntity> existingRequest = idempotencyRequests.findById(idempotencyId);
+		if (existingRequest.isPresent()) {
+			IdempotencyRequestEntity request = existingRequest.get();
+			if (!request.getExpiresAt().isAfter(settledAt)) {
+				idempotencyRequests.delete(request);
+			} else {
+				return replay(request, requestHash);
+			}
+		}
+
+		if (tripStatus != TripStatus.ENDED) {
+			throw new InvalidStateTransitionException();
+		}
+
+		if (settleablePoints > 0 && choice == null) {
+			throw new InvalidPointRequestException();
+		}
+		if (settleablePoints == 0 && choice != null) {
+			throw new InvalidPointRequestException();
+		}
+		SettlementChoice finalChoice = settleablePoints == 0 ? SettlementChoice.NO_POINTS : choice;
+
+		long balance = pointTransactions.sumAmountByMemberId(memberId);
+		if (balance < settleablePoints) {
+			throw new IllegalStateException("전체 잔액이 정산 대상 포인트보다 작습니다. tripId=" + tripId);
+		}
+
+		PointSettlementEntity settlement = PointSettlementEntity.create(tripId, finalChoice, settleablePoints,
+				settledAt);
+		pointSettlements.save(settlement);
+
+		if (finalChoice == SettlementChoice.LEAVE_TO_BUYEO) {
+			leaveToBuyeo(memberId, tripId, settleablePoints, settledAt);
+		}
+
+		tripSettlementService.settle(tripId, settledAt);
+
+		long remainingBalance = pointTransactions.sumAmountByMemberId(memberId);
+		TripSettlementView result = new TripSettlementView(tripId, finalChoice, settleablePoints, remainingBalance,
+				settlement.getExpiresAt(), settledAt, List.of());
+
+		String responseBody = writeResponse(result);
+		IdempotencyRequestEntity idempotencyRequest = IdempotencyRequestEntity.create(memberId, idempotencyKey,
+				OPERATION, requestHash, settledAt.plus(RETENTION));
+		idempotencyRequest.complete(200, responseBody);
+		idempotencyRequests.save(idempotencyRequest);
+		return result;
+	}
+
+	/** 여행 정산과 같은 확정 시각을 점유 시각으로 남기기 위해 JPA의 자동 발생 시각 생성을 우회해 직접 삽입한다. */
+	private void leaveToBuyeo(UUID memberId, UUID tripId, long settleablePoints, Instant settledAt) {
+		jdbcOperations.update("""
+				INSERT INTO point_transactions (member_id, trip_id, type, amount, description, occurred_at)
+				VALUES (?, ?, 'LEAVE_TO_BUYEO', ?, ?, ?)
+				""", memberId, tripId, -settleablePoints, LEAVE_TO_BUYEO_DESCRIPTION, Timestamp.from(settledAt));
+	}
+
+	private TripSettlementView replay(IdempotencyRequestEntity request, String requestHash) {
+		if (!OPERATION.equals(request.getOperation()) || !requestHash.equals(request.getRequestHash())) {
+			throw new IdempotencyKeyReusedException();
+		}
+		if (!Integer.valueOf(200).equals(request.getResponseStatus()) || request.getResponseBody() == null) {
+			throw new IllegalStateException("완료되지 않은 멱등성 요청이 남아 있습니다.");
+		}
+		return readResponse(request.getResponseBody());
+	}
+
+	private Instant clockTimestamp() {
+		return Objects.requireNonNull(jdbcOperations.queryForObject("SELECT clock_timestamp()", Timestamp.class))
+				.toInstant();
+	}
+
+	private void validateIdempotencyKey(String idempotencyKey) {
+		if (idempotencyKey == null || idempotencyKey.length() < 8 || idempotencyKey.length() > 128) {
+			throw new InvalidPointRequestException();
+		}
+	}
+
+	private String requestHash(UUID tripId, SettlementChoice choice) {
+		return tripId + ":" + (choice == null ? "null" : choice.name());
+	}
+
+	private String writeResponse(TripSettlementView result) {
+		try {
+			return objectWriter.writeValueAsString(SuccessResponse.of(result));
+		} catch (JacksonException exception) {
+			throw new IllegalStateException("여행 포인트 정산 응답을 저장할 수 없습니다.", exception);
+		}
+	}
+
+	private TripSettlementView readResponse(String responseBody) {
+		try {
+			JsonNode data = required(objectReader.readTree(responseBody), "data");
+			return new TripSettlementView(UUID.fromString(requiredText(data, "tripId")),
+					SettlementChoice.valueOf(requiredText(data, "choice")), requiredLong(data, "settledPoints"),
+					requiredLong(data, "remainingBalance"), nullableInstant(data, "expiresAt"),
+					Instant.parse(requiredText(data, "settledAt")), List.of());
+		} catch (JacksonException | IllegalArgumentException exception) {
+			throw new IllegalStateException("저장된 여행 포인트 정산 응답을 읽을 수 없습니다.", exception);
+		}
+	}
+
+	private Instant nullableInstant(JsonNode data, String field) {
+		JsonNode value = data.get(field);
+		return value == null || value.isNull() ? null : Instant.parse(value.stringValue());
+	}
+
+	private JsonNode required(JsonNode node, String field) {
+		JsonNode value = node == null ? null : node.get(field);
+		if (value == null) {
+			throw new IllegalStateException("저장된 여행 포인트 정산 응답 필드가 누락되었습니다: " + field);
+		}
+		return value;
+	}
+
+	private String requiredText(JsonNode node, String field) {
+		JsonNode value = required(node, field);
+		if (!value.isString()) {
+			throw new IllegalStateException("저장된 여행 포인트 정산 응답 필드가 문자열이 아닙니다: " + field);
+		}
+		return value.stringValue();
+	}
+
+	private long requiredLong(JsonNode node, String field) {
+		return required(node, field).longValue();
+	}
+
+	/** newlyAwardedBadges는 포인트 기부 배지 연동(#126) 전에는 항상 빈 배열이다. */
+	public record TripSettlementView(UUID tripId, SettlementChoice choice, long settledPoints, long remainingBalance,
+			Instant expiresAt, Instant settledAt, List<Object> newlyAwardedBadges) {
+		public TripSettlementView {
+			newlyAwardedBadges = List.copyOf(newlyAwardedBadges);
+		}
+	}
+}

--- a/src/main/java/com/buyeoon/point/entity/SettlementChoice.java
+++ b/src/main/java/com/buyeoon/point/entity/SettlementChoice.java
@@ -1,6 +1,5 @@
 package com.buyeoon.point.entity;
 
 public enum SettlementChoice {
-	LEAVE_TO_BUYEO,
-	CARRY_OVER
+	LEAVE_TO_BUYEO, CARRY_OVER, NO_POINTS
 }

--- a/src/main/java/com/buyeoon/point/repository/PointIdempotencyRequestRepository.java
+++ b/src/main/java/com/buyeoon/point/repository/PointIdempotencyRequestRepository.java
@@ -1,0 +1,16 @@
+package com.buyeoon.point.repository;
+
+import com.buyeoon.common.entity.IdempotencyRequestEntity;
+import com.buyeoon.common.entity.IdempotencyRequestId;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+public interface PointIdempotencyRequestRepository
+		extends
+			JpaRepository<IdempotencyRequestEntity, IdempotencyRequestId> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<IdempotencyRequestEntity> findById(IdempotencyRequestId id);
+}

--- a/src/main/java/com/buyeoon/trip/TripSettlementService.java
+++ b/src/main/java/com/buyeoon/trip/TripSettlementService.java
@@ -1,0 +1,35 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.member.application.ResourceNotFoundException;
+import com.buyeoon.trip.entity.TripEntity;
+import com.buyeoon.trip.entity.TripStatus;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** point 도메인이 여행 포인트 정산을 확정할 때 여행 상태를 잠그고 전이하기 위해 사용하는 trip 도메인의 공개 seam이다. */
+@Service
+public class TripSettlementService {
+
+	private final TripRepository trips;
+
+	public TripSettlementService(TripRepository trips) {
+		this.trips = trips;
+	}
+
+	/** 회원이 소유한 여행 행을 잠그고 현재 상태를 반환한다. 없거나 다른 회원 소유면 404다. */
+	@Transactional
+	public TripStatus lockOwnedTripStatus(UUID memberId, UUID tripId) {
+		TripEntity trip = trips.lockByIdAndMemberId(tripId, memberId).orElseThrow(ResourceNotFoundException::new);
+		return trip.getStatus();
+	}
+
+	/** 앞서 잠근 여행을 정산 완료 상태로 전이하고 정산 완료 시각을 기록한다. */
+	@Transactional
+	public void settle(UUID tripId, Instant settledAt) {
+		TripEntity trip = trips.findById(tripId)
+				.orElseThrow(() -> new IllegalStateException("정산할 여행을 찾을 수 없습니다. tripId=" + tripId));
+		trip.settle(settledAt);
+	}
+}

--- a/src/main/java/com/buyeoon/trip/entity/TripEntity.java
+++ b/src/main/java/com/buyeoon/trip/entity/TripEntity.java
@@ -54,4 +54,10 @@ public class TripEntity {
 		this.status = TripStatus.ENDED;
 		this.endedAt = endedAt;
 	}
+
+	/** 종료된 여행을 정산 완료 상태로 전이하고 정산 완료 시각을 기록한다. */
+	public void settle(Instant settledAt) {
+		this.status = TripStatus.SETTLED;
+		this.settledAt = settledAt;
+	}
 }

--- a/src/test/java/com/buyeoon/point/PointSettlementIntegrationTests.java
+++ b/src/test/java/com/buyeoon/point/PointSettlementIntegrationTests.java
@@ -1,0 +1,406 @@
+package com.buyeoon.point;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import com.buyeoon.point.application.PointSettlementService;
+import com.buyeoon.point.entity.SettlementChoice;
+import com.jayway.jsonpath.JsonPath;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class PointSettlementIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@Autowired
+	private PointSettlementService pointSettlementService;
+
+	private AuthenticatedMember member;
+
+	@BeforeEach
+	void setUpMember() {
+		member = insertAuthenticatedMember();
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM idempotency_requests");
+		jdbcTemplate.update("DELETE FROM point_settlements");
+		jdbcTemplate.update("DELETE FROM point_transactions");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 양수 정산 대상을 LEAVE_TO_BUYEO로 정산하면 해당 여행 적립분만 차감하고 다른 여행 이월분은 유지한다. */
+	@Test
+	@DisplayName("LEAVE_TO_BUYEO는 해당 여행 적립분만 차감하고 다른 여행 이월분은 유지한다")
+	void leaveToBuyeoDeductsOnlyThisTripsEarnings() throws Exception {
+		UUID otherTrip = insertEndedTrip(member.memberId());
+		insertTransaction(otherTrip, "EARN", 500, "다른 여행 적립");
+		insertCarryOverSettlement(otherTrip, 500, Instant.now().plus(5, ChronoUnit.DAYS));
+
+		UUID tripId = insertEndedTrip(member.memberId());
+		insertTransaction(tripId, "EARN", 300, "미션 보상");
+
+		performSettle(member, tripId, "leave-key-01", "LEAVE_TO_BUYEO").andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.tripId").value(tripId.toString()))
+				.andExpect(jsonPath("$.data.choice").value("LEAVE_TO_BUYEO"))
+				.andExpect(jsonPath("$.data.settledPoints").value(300))
+				.andExpect(jsonPath("$.data.remainingBalance").value(500))
+				.andExpect(jsonPath("$.data.expiresAt").isEmpty()).andExpect(jsonPath("$.data.settledAt").isString())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges").isArray())
+				.andExpect(jsonPath("$.data.newlyAwardedBadges.length()").value(0));
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT COALESCE(SUM(amount),0) FROM point_transactions WHERE member_id = ?", Long.class,
+				member.memberId())).isEqualTo(500L);
+		assertThat(jdbcTemplate.queryForObject("SELECT status::text FROM trips WHERE id = ?", String.class, tripId))
+				.isEqualTo("SETTLED");
+		assertThat(jdbcTemplate.queryForObject("SELECT settled_at IS NOT NULL FROM trips WHERE id = ?", Boolean.class,
+				tripId)).isTrue();
+	}
+
+	/**
+	 * 양수 정산 대상을 CARRY_OVER로 정산하면 잔액을 유지하고 settledAt부터 240시간 뒤를 expiresAt으로 기록한다.
+	 */
+	@Test
+	@DisplayName("CARRY_OVER는 잔액을 유지하고 settledAt부터 240시간 뒤를 expiresAt으로 기록한다")
+	void carryOverKeepsBalanceAndRecordsExpiry() throws Exception {
+		UUID tripId = insertEndedTrip(member.memberId());
+		insertTransaction(tripId, "EARN", 200, "미션 보상");
+
+		MvcResult result = performSettle(member, tripId, "carry-key-01", "CARRY_OVER").andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.choice").value("CARRY_OVER"))
+				.andExpect(jsonPath("$.data.settledPoints").value(200))
+				.andExpect(jsonPath("$.data.remainingBalance").value(200))
+				.andExpect(jsonPath("$.data.expiresAt").isString()).andReturn();
+
+		String settledAtText = JsonPath.read(result.getResponse().getContentAsString(), "$.data.settledAt");
+		String expiresAtText = JsonPath.read(result.getResponse().getContentAsString(), "$.data.expiresAt");
+		assertThat(Instant.parse(expiresAtText)).isEqualTo(Instant.parse(settledAtText).plus(240, ChronoUnit.HOURS));
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT COALESCE(SUM(amount),0) FROM point_transactions WHERE member_id = ?", Long.class,
+				member.memberId())).isEqualTo(200L);
+	}
+
+	/** 정산 대상이 0이면 선택 없이 NO_POINTS로 정산하고 포인트 내역을 만들지 않는다. */
+	@Test
+	@DisplayName("정산 대상이 0이면 선택 없이 NO_POINTS로 정산한다")
+	void settlesWithNoPointsWhenNothingToSettle() throws Exception {
+		UUID tripId = insertEndedTrip(member.memberId());
+
+		performSettle(member, tripId, "no-points-key-01", null).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.choice").value("NO_POINTS"))
+				.andExpect(jsonPath("$.data.settledPoints").value(0))
+				.andExpect(jsonPath("$.data.remainingBalance").value(0))
+				.andExpect(jsonPath("$.data.expiresAt").isEmpty());
+
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM point_transactions WHERE member_id = ?",
+				Integer.class, member.memberId())).isEqualTo(0);
+		assertThat(jdbcTemplate.queryForObject("SELECT status::text FROM trips WHERE id = ?", String.class, tripId))
+				.isEqualTo("SETTLED");
+	}
+
+	/** 정산 대상이 양수인데 선택이 없으면 400을 반환한다. */
+	@Test
+	@DisplayName("정산 대상이 양수인데 선택이 없으면 400을 반환한다")
+	void missingChoiceForPositiveSettleableReturnsBadRequest() throws Exception {
+		UUID tripId = insertEndedTrip(member.memberId());
+		insertTransaction(tripId, "EARN", 100, "미션 보상");
+
+		performSettle(member, tripId, "bad-choice-key-01", null).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	/** 정산 대상이 0인데 선택을 보내면 400을 반환한다. */
+	@Test
+	@DisplayName("정산 대상이 0인데 선택을 보내면 400을 반환한다")
+	void choiceForZeroSettleableReturnsBadRequest() throws Exception {
+		UUID tripId = insertEndedTrip(member.memberId());
+
+		performSettle(member, tripId, "bad-choice-key-02", "CARRY_OVER").andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	/** Idempotency-Key가 없으면 400을 반환한다. */
+	@Test
+	@DisplayName("Idempotency-Key가 없으면 400을 반환한다")
+	void missingIdempotencyKeyReturnsBadRequest() throws Exception {
+		UUID tripId = insertEndedTrip(member.memberId());
+
+		performSettleWithoutKey(member, tripId, "CARRY_OVER").andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	/** 존재하지 않는 여행은 404를 반환한다. */
+	@Test
+	@DisplayName("존재하지 않는 여행은 404를 반환한다")
+	void nonExistentTripReturnsNotFound() throws Exception {
+		performSettle(member, UUID.randomUUID(), "missing-trip-key", "CARRY_OVER").andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 다른 회원이 소유한 여행은 404를 반환한다. */
+	@Test
+	@DisplayName("다른 회원 소유 여행은 404를 반환한다")
+	void otherMembersTripReturnsNotFound() throws Exception {
+		AuthenticatedMember other = insertAuthenticatedMember();
+		UUID tripId = insertEndedTrip(other.memberId());
+
+		performSettle(member, tripId, "other-owner-key", "CARRY_OVER").andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 진행 중인 여행은 409를 반환한다. */
+	@Test
+	@DisplayName("진행 중인 여행은 409를 반환한다")
+	void inProgressTripReturnsConflict() throws Exception {
+		UUID tripId = insertInProgressTrip(member.memberId());
+
+		performSettle(member, tripId, "in-progress-key", "CARRY_OVER").andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("INVALID_STATE_TRANSITION"));
+	}
+
+	/** 인증하지 않으면 401을 받는다. */
+	@Test
+	@DisplayName("인증하지 않으면 401을 받는다")
+	void unauthenticatedRequestReturnsUnauthorized() throws Exception {
+		MockHttpServletRequestBuilder request = put("/trips/{tripId}/settlement", UUID.randomUUID())
+				.header("Idempotency-Key", "unauth-settle-key").contentType(MediaType.APPLICATION_JSON).content("{}");
+		mockMvc.perform(request).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** 같은 키·같은 선택 replay는 최초 semantic result를 반환하고 부작용을 반복하지 않는다. */
+	@Test
+	@DisplayName("같은 키의 재요청은 최초 응답을 재사용하고 부작용을 반복하지 않는다")
+	void sameIdempotentRequestReturnsFirstResponseWithoutSideEffects() throws Exception {
+		UUID tripId = insertEndedTrip(member.memberId());
+		insertTransaction(tripId, "EARN", 150, "미션 보상");
+		String key = "replay-key-01";
+
+		String first = performSettle(member, tripId, key, "LEAVE_TO_BUYEO").andExpect(status().isOk()).andReturn()
+				.getResponse().getContentAsString();
+		String retried = performSettle(member, tripId, key, "LEAVE_TO_BUYEO").andExpect(status().isOk()).andReturn()
+				.getResponse().getContentAsString();
+
+		assertThat(retried).isEqualTo(first);
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM point_transactions WHERE member_id = ? AND type = 'LEAVE_TO_BUYEO'",
+				Integer.class, member.memberId())).isEqualTo(1);
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM point_settlements WHERE trip_id = ?",
+				Integer.class, tripId)).isEqualTo(1);
+	}
+
+	/** 같은 키를 다른 선택으로 재사용하면 409를 반환한다. */
+	@Test
+	@DisplayName("같은 키를 다른 선택으로 재사용하면 409를 반환한다")
+	void reusingKeyWithDifferentChoiceReturnsConflict() throws Exception {
+		UUID tripId = insertEndedTrip(member.memberId());
+		insertTransaction(tripId, "EARN", 150, "미션 보상");
+		String key = "reuse-key-01";
+
+		performSettle(member, tripId, key, "LEAVE_TO_BUYEO").andExpect(status().isOk());
+		UUID anotherTrip = insertEndedTrip(member.memberId());
+		insertTransaction(anotherTrip, "EARN", 50, "미션 보상");
+
+		performSettle(member, anotherTrip, key, "CARRY_OVER").andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("IDEMPOTENCY_KEY_REUSED"));
+	}
+
+	/** 이미 정산된 여행을 다른 키로 재정산하면 409를 반환한다. */
+	@Test
+	@DisplayName("이미 정산된 여행을 다른 키로 재정산하면 409를 반환한다")
+	void resettlingSettledTripWithDifferentKeyReturnsConflict() throws Exception {
+		UUID tripId = insertEndedTrip(member.memberId());
+		insertTransaction(tripId, "EARN", 100, "미션 보상");
+		performSettle(member, tripId, "resettle-key-a", "LEAVE_TO_BUYEO").andExpect(status().isOk());
+
+		performSettle(member, tripId, "resettle-key-b", "LEAVE_TO_BUYEO").andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("INVALID_STATE_TRANSITION"));
+	}
+
+	/** 같은 여행의 동시 정산 요청은 하나만 확정한다. */
+	@Test
+	@DisplayName("동시 정산 요청은 하나만 성공한다")
+	void concurrentSettlementRequestsSucceedOnce() throws Exception {
+		UUID tripId = insertEndedTrip(member.memberId());
+		insertTransaction(tripId, "EARN", 100, "미션 보상");
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+
+		try {
+			Future<MvcResult> first = executor
+					.submit(() -> concurrentSettle(member, tripId, "concurrent-settle-a", ready, start));
+			Future<MvcResult> second = executor
+					.submit(() -> concurrentSettle(member, tripId, "concurrent-settle-b", ready, start));
+			assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+			start.countDown();
+			MvcResult firstResult = first.get(10, TimeUnit.SECONDS);
+			MvcResult secondResult = second.get(10, TimeUnit.SECONDS);
+			int[] statuses = {firstResult.getResponse().getStatus(), secondResult.getResponse().getStatus()};
+			assertThat(statuses).containsExactlyInAnyOrder(200, 409);
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertThat(jdbcTemplate.queryForObject("SELECT status::text FROM trips WHERE id = ?", String.class, tripId))
+				.isEqualTo("SETTLED");
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM point_settlements WHERE trip_id = ?",
+				Integer.class, tripId)).isEqualTo(1);
+	}
+
+	/** 전체 잔액이 정산 대상보다 작으면 다른 여행 포인트를 차감하지 않고 정산 전체를 실패시킨다. */
+	@Test
+	@DisplayName("전체 잔액이 정산 대상보다 작으면 정산 전체를 실패시키고 상태를 유지한다")
+	void insufficientBalanceFailsSettlementEntirely() throws Exception {
+		UUID tripId = insertEndedTrip(member.memberId());
+		insertTransaction(tripId, "EARN", 300, "미션 보상");
+		insertTransaction(tripId, "ADJUST", -250, "운영 조정");
+
+		assertThatThrownBy(() -> pointSettlementService.settle(member.memberId(), tripId, "insufficient-balance-key",
+				SettlementChoice.LEAVE_TO_BUYEO)).isInstanceOf(IllegalStateException.class);
+
+		assertThat(jdbcTemplate.queryForObject("SELECT status::text FROM trips WHERE id = ?", String.class, tripId))
+				.isEqualTo("ENDED");
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM point_settlements WHERE trip_id = ?",
+				Integer.class, tripId)).isEqualTo(0);
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM idempotency_requests WHERE member_id = ?",
+				Integer.class, member.memberId())).isEqualTo(0);
+	}
+
+	private MvcResult concurrentSettle(AuthenticatedMember member, UUID tripId, String key, CountDownLatch ready,
+			CountDownLatch start) throws Exception {
+		ready.countDown();
+		if (!start.await(5, TimeUnit.SECONDS)) {
+			throw new IllegalStateException("동시 요청 시작 신호를 받지 못했습니다.");
+		}
+		return performSettle(member, tripId, key, "LEAVE_TO_BUYEO").andReturn();
+	}
+
+	private ResultActions performSettle(AuthenticatedMember member, UUID tripId, String idempotencyKey, String choice)
+			throws Exception {
+		String body = choice == null ? "{}" : "{\"choice\":\"" + choice + "\"}";
+		MockHttpServletRequestBuilder request = put("/trips/{tripId}/settlement", tripId)
+				.header("Authorization", "Bearer " + member.accessToken()).header("Idempotency-Key", idempotencyKey)
+				.contentType(MediaType.APPLICATION_JSON).content(body);
+		return mockMvc.perform(request);
+	}
+
+	private ResultActions performSettleWithoutKey(AuthenticatedMember member, UUID tripId, String choice)
+			throws Exception {
+		String body = choice == null ? "{}" : "{\"choice\":\"" + choice + "\"}";
+		MockHttpServletRequestBuilder request = put("/trips/{tripId}/settlement", tripId)
+				.header("Authorization", "Bearer " + member.accessToken()).contentType(MediaType.APPLICATION_JSON)
+				.content(body);
+		return mockMvc.perform(request);
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private void insertTransaction(UUID tripId, String type, long amount, String description) {
+		jdbcTemplate.update(
+				"INSERT INTO point_transactions (id, member_id, trip_id, type, amount, description, occurred_at) "
+						+ "VALUES (?, ?, ?, ?::point_transaction_type, ?, ?, ?)",
+				UUID.randomUUID(), member.memberId(), tripId, type, amount, description, Timestamp.from(Instant.now()));
+	}
+
+	private UUID insertInProgressTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status) VALUES (?, ?, 'IN_PROGRESS')", tripId, memberId);
+		return tripId;
+	}
+
+	private UUID insertEndedTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status, ended_at) VALUES (?, ?, 'ENDED', now())", tripId,
+				memberId);
+		return tripId;
+	}
+
+	private void insertCarryOverSettlement(UUID tripId, long settledPoints, Instant expiresAt) {
+		Instant settledAt = expiresAt.minus(240, ChronoUnit.HOURS);
+		jdbcTemplate.update(
+				"INSERT INTO point_settlements (id, trip_id, choice, settled_points, expires_at, settled_at) "
+						+ "VALUES (?, ?, 'CARRY_OVER', ?, ?, ?)",
+				UUID.randomUUID(), tripId, settledPoints, Timestamp.from(expiresAt), Timestamp.from(settledAt));
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## Summary
- `PUT /trips/{tripId}/settlement`를 구현해 여행에서 적립하고 아직 정산하지 않은 포인트를 `LEAVE_TO_BUYEO`, `CARRY_OVER`, `NO_POINTS`로 정확히 한 번 정산하고 여행을 `SETTLED`로 전이한다.
- 회원 행을 먼저 잠근 뒤 여행 행을 잠그고, 잠금 후 구한 DB 시각 하나를 정산·여행 상태 전이·포인트 내역·멱등성 semantic result에 함께 사용한다(정책 문서의 잠금 순서·시각 공유 규칙 준수).
- 24시간 멱등성 기록으로 같은 키 replay는 최초 결과를 재사용하고, 다른 선택/여행 재사용은 409, 이미 정산된 여행의 다른 키 재정산은 409, 동시 정산은 하나만 확정한다.
- 전체 잔액이 정산 대상보다 작으면(불변식 위반) 다른 여행 포인트를 차감하지 않고 정산 전체를 롤백한다.
- 배지 판정(#126)은 범위 제외 — `newlyAwardedBadges`는 항상 빈 배열.
- DB CHECK 계약은 선행 PR #149에서 이미 원본 스키마와 동기화되어 있어 추가 Flyway migration은 필요 없었다.

## Test plan
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh` (checkstyle, spotbugs, `./gradlew check`)
- [x] `./scripts/test/test.sh` (전체 스위트)
- [x] `./scripts/test/docker-build.sh` (compose 빌드 + health check; 로컬 `.env`에 Apple 자격 증명 없어 확인 못한 부분 있음 — 코드/스키마 문제는 아님)
- [x] `PointSettlementIntegrationTests` 15개: LEAVE_TO_BUYEO/CARRY_OVER/NO_POINTS 정산, 400/404/409 분기, replay·키 재사용·재정산 멱등성, 동시 정산 직렬화, 잔액 불변식 위반 롤백

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFQ4BL3Hz7zrftVe2oMVzj