### PR TITLE
fix: 만료 정산 테스트의 타임스탬프 정밀도 flaky 수정

### DIFF
--- a/src/test/java/com/buyeoon/point/PointExpirationIntegrationTests.java
+++ b/src/test/java/com/buyeoon/point/PointExpirationIntegrationTests.java
@@ -73,9 +73,10 @@ class PointExpirationIntegrationTests {
 		Instant after = currentDbTime();
 
 		assertThat(expired).isEqualTo(1);
+		Instant storedExpiresAt = ((Timestamp) settlementRow(tripId).get("expires_at")).toInstant();
 		Map<String, Object> transaction = onlyExpireTransaction(memberId);
 		assertThat(transaction.get("amount")).isEqualTo(-300L);
-		assertThat(((Timestamp) transaction.get("occurred_at")).toInstant()).isEqualTo(expiresAt);
+		assertThat(((Timestamp) transaction.get("occurred_at")).toInstant()).isEqualTo(storedExpiresAt);
 
 		Map<String, Object> settlement = settlementRow(tripId);
 		Instant expiredAt = ((Timestamp) settlement.get("expired_at")).toInstant();


### PR DESCRIPTION
## Summary
- `PointExpirationIntegrationTests.expiresDueCarryOverExactlyOnce`가 `Instant.now()` 원본 값(나노초 정밀도)과 DB round-trip 결과를 직접 비교해 CI(Linux) 환경에서 실패했다. PostgreSQL `timestamptz`는 마이크로초까지만 저장하므로, 나노초 정밀도가 실제로 존재하는 러너에서는 값이 어긋난다.
- macOS 로컬 클럭은 나노초 단위가 항상 0이라 로컬에서는 재현되지 않았다.
- 검증 대상을 "서비스가 저장된 `expires_at` 값을 그대로 EXPIRE 내역의 `occurred_at`으로 옮겨 쓰는가"로 명확히 하고, 비교 기준을 원본 `Instant`가 아니라 DB에 실제 저장된 `expires_at` 값으로 변경했다.

## Context
Stage 7 배포 파이프라인(PR #153) 첫 workflow_dispatch 테스트에서 `./gradlew test` 퀄리티 게이트가 이 테스트로 실패해 발견됨. 배포 파이프라인 자체는 정상 동작했다.

## Test plan
- [x] `./gradlew test --tests "com.buyeoon.point.PointExpirationIntegrationTests"` 통과
- [x] `./gradlew check` 전체 통과 (5m59s, BUILD SUCCESSFUL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)