### PR TITLE
feat: UC-25 여행 발자취 조회 구현

### DIFF
--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -2630,7 +2630,7 @@ components:
           type: array
           description: 해당 여행에서 처음 획득한 배지
           items:
-            $ref: '#/components/schemas/Badge'
+            $ref: '#/components/schemas/AwardedBadge'
         photos:
           type: array
           items:

--- a/src/main/java/com/buyeoon/common/storage/PrivateImageGetUrlService.java
+++ b/src/main/java/com/buyeoon/common/storage/PrivateImageGetUrlService.java
@@ -1,0 +1,10 @@
+package com.buyeoon.common.storage;
+
+/**
+ * {@code private/} prefix 전용 GET Presigned URL 발급 seam이다(ADR-008). 발급 전 사진의 소유권
+ * 확인은 호출하는 도메인 서비스의 책임이다. 테스트는 실제 AWS 호출 없이 이 인터페이스를 대체한다.
+ */
+public interface PrivateImageGetUrlService {
+
+	String create(String objectKey);
+}

--- a/src/main/java/com/buyeoon/common/storage/S3PrivateImageGetUrlService.java
+++ b/src/main/java/com/buyeoon/common/storage/S3PrivateImageGetUrlService.java
@@ -1,0 +1,44 @@
+package com.buyeoon.common.storage;
+
+import jakarta.annotation.PreDestroy;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+@Service
+public class S3PrivateImageGetUrlService implements PrivateImageGetUrlService {
+
+	private static final Duration VALIDITY = Duration.ofMinutes(10);
+
+	private final String bucket;
+	private final S3Presigner presigner;
+
+	public S3PrivateImageGetUrlService(@Value("${storage.images.bucket:}") String bucket,
+			@Value("${storage.images.region:ap-northeast-2}") String region) {
+		this.bucket = bucket;
+		this.presigner = S3Presigner.builder().region(Region.of(region)).build();
+	}
+
+	@Override
+	public String create(String objectKey) {
+		if (bucket.isBlank()) {
+			throw new IllegalStateException("IMAGE_BUCKET 설정이 필요합니다.");
+		}
+		if (!objectKey.startsWith("private/")) {
+			throw new IllegalArgumentException("비공개 이미지 객체 키가 아닙니다.");
+		}
+		GetObjectRequest objectRequest = GetObjectRequest.builder().bucket(bucket).key(objectKey).build();
+		return presigner.presignGetObject(
+				GetObjectPresignRequest.builder().signatureDuration(VALIDITY).getObjectRequest(objectRequest).build())
+				.url().toExternalForm();
+	}
+
+	@PreDestroy
+	void close() {
+		presigner.close();
+	}
+}

--- a/src/main/java/com/buyeoon/trip/EarnedBadgeProjection.java
+++ b/src/main/java/com/buyeoon/trip/EarnedBadgeProjection.java
@@ -1,0 +1,7 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.badge.entity.BadgeEntity;
+import java.time.Instant;
+
+public record EarnedBadgeProjection(BadgeEntity badge, Instant earnedAt) {
+}

--- a/src/main/java/com/buyeoon/trip/FootprintBadgeRepository.java
+++ b/src/main/java/com/buyeoon/trip/FootprintBadgeRepository.java
@@ -1,0 +1,23 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.badge.entity.MemberBadgeEntity;
+import com.buyeoon.badge.entity.MemberBadgeId;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** 발자취 조회가 해당 여행에서 처음 획득한 배지를 읽기 위한 trip 도메인 소유의 읽기 전용 리포지토리다. */
+public interface FootprintBadgeRepository extends JpaRepository<MemberBadgeEntity, MemberBadgeId> {
+
+	/** 해당 여행에서 처음 획득한 배지만 조회한다({@code member_badges.trip_id} 단일 조건, ADR-003). */
+	@Query("""
+			SELECT new com.buyeoon.trip.EarnedBadgeProjection(b, mb.earnedAt)
+			FROM MemberBadgeEntity mb JOIN BadgeEntity b ON b.id = mb.id.badgeId
+			WHERE mb.id.memberId = :memberId AND mb.tripId = :tripId
+			ORDER BY mb.earnedAt ASC
+			""")
+	List<EarnedBadgeProjection> findBadgesByMemberIdAndTripId(@Param("memberId") UUID memberId,
+			@Param("tripId") UUID tripId);
+}

--- a/src/main/java/com/buyeoon/trip/FootprintPhotoRepository.java
+++ b/src/main/java/com/buyeoon/trip/FootprintPhotoRepository.java
@@ -1,0 +1,13 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.mission.entity.MissionPhotoEntity;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** 발자취 조회가 요청자 소유 여행의 미션 사진을 읽기 위한 trip 도메인 소유의 읽기 전용 리포지토리다. */
+public interface FootprintPhotoRepository extends JpaRepository<MissionPhotoEntity, UUID> {
+
+	/** 업로드 시각 오름차순으로 요청자 소유 여행의 사진만 조회한다. */
+	List<MissionPhotoEntity> findByMemberIdAndTripIdOrderByUploadedAtAsc(UUID memberId, UUID tripId);
+}

--- a/src/main/java/com/buyeoon/trip/FootprintPlaceRepository.java
+++ b/src/main/java/com/buyeoon/trip/FootprintPlaceRepository.java
@@ -1,0 +1,9 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.place.entity.PlaceEntity;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** 발자취 조회가 방문 기록의 장소 정보를 읽기 위한 trip 도메인 소유의 읽기 전용 리포지토리다. */
+public interface FootprintPlaceRepository extends JpaRepository<PlaceEntity, UUID> {
+}

--- a/src/main/java/com/buyeoon/trip/FootprintQueryService.java
+++ b/src/main/java/com/buyeoon/trip/FootprintQueryService.java
@@ -1,0 +1,165 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.badge.entity.BadgeEntity;
+import com.buyeoon.common.storage.PrivateImageGetUrlService;
+import com.buyeoon.common.storage.PublicImageUrlService;
+import com.buyeoon.member.application.InvalidStateTransitionException;
+import com.buyeoon.member.application.ResourceNotFoundException;
+import com.buyeoon.mission.entity.MissionPhotoEntity;
+import com.buyeoon.place.entity.PlaceCategory;
+import com.buyeoon.place.entity.PlaceEntity;
+import com.buyeoon.point.application.PointSummaryService;
+import com.buyeoon.point.application.PointSummaryService.PointSummaryView;
+import com.buyeoon.trip.TripQueryService.TripStatisticsView;
+import com.buyeoon.trip.entity.TripEntity;
+import com.buyeoon.trip.entity.TripStatus;
+import com.buyeoon.trip.entity.VisitRecordEntity;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+
+/**
+ * UC-25 발자취 조회 서비스다. 여러 도메인의 공개 seam을 조합해 하나의 응답으로 반환한다. {@code points}가 호출하는
+ * {@code PointExpirationService}는 만료 확정을 위해 활성 회원 행에 쓰기 트랜잭션을 열어야 하므로, 이 서비스는
+ * {@code @Transactional(readOnly = true)}로 감싸지 않고 각 하위 조회가 자체 트랜잭션 경계를 갖도록 둔다.
+ * SETTLED는 종단 상태라 trip·visits·badges·photos는 조회 중 값이 바뀌지 않으며, points는 여행이 아닌 회원
+ * 전체 잔액이라 나머지 조각과 원자적으로 일치할 필요가 없다.
+ */
+@Service
+public class FootprintQueryService {
+
+	private final TripRepository tripRepository;
+	private final TripQueryService tripQueryService;
+	private final VisitRecordRepository visitRepository;
+	private final FootprintPlaceRepository placeRepository;
+	private final FootprintSavedPlaceRepository savedPlaceRepository;
+	private final PointSummaryService pointSummaryService;
+	private final FootprintBadgeRepository badgeRepository;
+	private final FootprintPhotoRepository photoRepository;
+	private final PublicImageUrlService publicImageUrls;
+	private final PrivateImageGetUrlService privateImageUrls;
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public FootprintQueryService(TripRepository tripRepository, TripQueryService tripQueryService,
+			VisitRecordRepository visitRepository, FootprintPlaceRepository placeRepository,
+			FootprintSavedPlaceRepository savedPlaceRepository, PointSummaryService pointSummaryService,
+			FootprintBadgeRepository badgeRepository, FootprintPhotoRepository photoRepository,
+			PublicImageUrlService publicImageUrls, PrivateImageGetUrlService privateImageUrls) {
+		this.tripRepository = tripRepository;
+		this.tripQueryService = tripQueryService;
+		this.visitRepository = visitRepository;
+		this.placeRepository = placeRepository;
+		this.savedPlaceRepository = savedPlaceRepository;
+		this.pointSummaryService = pointSummaryService;
+		this.badgeRepository = badgeRepository;
+		this.photoRepository = photoRepository;
+		this.publicImageUrls = publicImageUrls;
+		this.privateImageUrls = privateImageUrls;
+	}
+
+	/**
+	 * 정산 완료(SETTLED)된 본인 소유 여행의 발자취를 조회한다. 존재하지 않거나 타 회원 소유면 404, 정산 완료 전이면 409다.
+	 */
+	public FootprintView getFootprint(UUID memberId, UUID tripId) {
+		TripEntity trip = tripRepository.findByIdAndMemberId(tripId, memberId)
+				.orElseThrow(ResourceNotFoundException::new);
+		if (trip.getStatus() != TripStatus.SETTLED) {
+			throw new InvalidStateTransitionException();
+		}
+
+		FootprintTripView tripView = FootprintTripView.from(trip);
+		TripStatisticsView statistics = tripQueryService.getStatistics(memberId, tripId);
+		List<VisitView> visits = visits(memberId, tripId);
+		PointSummaryView points = pointSummaryService.getSummary(memberId);
+		List<BadgeView> badges = badges(memberId, tripId);
+		List<PhotoView> photos = photos(memberId, tripId);
+		return new FootprintView(tripView, statistics, visits, points, badges, photos);
+	}
+
+	private List<VisitView> visits(UUID memberId, UUID tripId) {
+		List<VisitRecordEntity> visitRecords = visitRepository.findByTripIdOrderByVisitedAtAsc(tripId);
+		if (visitRecords.isEmpty()) {
+			return List.of();
+		}
+		List<UUID> placeIds = visitRecords.stream().map(VisitRecordEntity::getPlaceId).toList();
+		Map<UUID, PlaceEntity> places = placeRepository.findAllById(placeIds).stream()
+				.collect(Collectors.toMap(PlaceEntity::getId, Function.identity()));
+		Set<UUID> savedPlaceIds = Set.copyOf(savedPlaceRepository.findSavedPlaceIds(memberId, placeIds));
+		return visitRecords.stream().map(visitRecord -> toVisitView(visitRecord, places, savedPlaceIds)).toList();
+	}
+
+	private VisitView toVisitView(VisitRecordEntity visitRecord, Map<UUID, PlaceEntity> places,
+			Set<UUID> savedPlaceIds) {
+		PlaceEntity place = places.get(visitRecord.getPlaceId());
+		if (place == null) {
+			throw new IllegalStateException("방문 기록이 참조하는 장소를 찾을 수 없습니다. placeId=" + visitRecord.getPlaceId());
+		}
+		boolean saved = savedPlaceIds.contains(place.getId());
+		return new VisitView(visitRecord.getId(), visitRecord.getMissionId(), toPlaceView(place, saved),
+				visitRecord.getVisitedAt());
+	}
+
+	private PlaceView toPlaceView(PlaceEntity place, boolean saved) {
+		String imageUrl = place.getImageKey() != null
+				? publicImageUrls.create(place.getImageKey())
+				: place.getSourceImageHref();
+		return new PlaceView(place.getId(), place.getCategory(), place.getName(), place.getSummary(),
+				place.getDescription(), place.getAddress(), imageUrl, place.getLocation().getY(),
+				place.getLocation().getX(), saved);
+	}
+
+	private List<BadgeView> badges(UUID memberId, UUID tripId) {
+		return badgeRepository.findBadgesByMemberIdAndTripId(memberId, tripId).stream().map(this::toBadgeView).toList();
+	}
+
+	private BadgeView toBadgeView(EarnedBadgeProjection projection) {
+		BadgeEntity badge = projection.badge();
+		String imageUrl = badge.getImageKey() != null ? publicImageUrls.create(badge.getImageKey()) : null;
+		return new BadgeView(badge.getId(), badge.getName(), imageUrl, badge.getConditionText(), projection.earnedAt());
+	}
+
+	private List<PhotoView> photos(UUID memberId, UUID tripId) {
+		return photoRepository.findByMemberIdAndTripIdOrderByUploadedAtAsc(memberId, tripId).stream()
+				.map(this::toPhotoView).toList();
+	}
+
+	private PhotoView toPhotoView(MissionPhotoEntity photo) {
+		return new PhotoView(photo.getId(), privateImageUrls.create(photo.getObjectKey()), photo.getUploadedAt());
+	}
+
+	public record FootprintView(FootprintTripView trip, TripStatisticsView statistics, List<VisitView> visits,
+			PointSummaryView points, List<BadgeView> badges, List<PhotoView> photos) {
+		public FootprintView {
+			visits = List.copyOf(visits);
+			badges = List.copyOf(badges);
+			photos = List.copyOf(photos);
+		}
+	}
+
+	public record FootprintTripView(UUID tripId, TripStatus status, Instant startedAt, Instant endedAt,
+			Instant settledAt) {
+		static FootprintTripView from(TripEntity trip) {
+			return new FootprintTripView(trip.getId(), trip.getStatus(), trip.getStartedAt(), trip.getEndedAt(),
+					trip.getSettledAt());
+		}
+	}
+
+	public record VisitView(UUID visitId, UUID missionId, PlaceView place, Instant visitedAt) {
+	}
+
+	public record PlaceView(UUID placeId, PlaceCategory category, String name, String summary, String description,
+			String address, String imageUrl, double latitude, double longitude, boolean saved) {
+	}
+
+	public record BadgeView(UUID badgeId, String name, String imageUrl, String condition, Instant earnedAt) {
+	}
+
+	public record PhotoView(UUID photoId, String url, Instant uploadedAt) {
+	}
+}

--- a/src/main/java/com/buyeoon/trip/FootprintSavedPlaceRepository.java
+++ b/src/main/java/com/buyeoon/trip/FootprintSavedPlaceRepository.java
@@ -1,0 +1,23 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.place.entity.SavedPlaceEntity;
+import com.buyeoon.place.entity.SavedPlaceId;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** 발자취 조회가 방문 장소의 저장 여부를 읽기 위한 trip 도메인 소유의 읽기 전용 리포지토리다. */
+public interface FootprintSavedPlaceRepository extends JpaRepository<SavedPlaceEntity, SavedPlaceId> {
+
+	/** 조회한 방문 장소만 한 번에 확인해 장소 수만큼 질의가 늘어나지 않게 한다. */
+	@Query("""
+			SELECT s.id.placeId
+			FROM SavedPlaceEntity s
+			WHERE s.id.memberId = :memberId
+			  AND s.id.placeId IN :placeIds
+			""")
+	List<UUID> findSavedPlaceIds(@Param("memberId") UUID memberId, @Param("placeIds") Collection<UUID> placeIds);
+}

--- a/src/main/java/com/buyeoon/trip/TripController.java
+++ b/src/main/java/com/buyeoon/trip/TripController.java
@@ -1,12 +1,21 @@
 package com.buyeoon.trip;
 
 import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.place.entity.PlaceCategory;
+import com.buyeoon.point.application.PointSummaryService.PointSummaryView;
+import com.buyeoon.trip.FootprintQueryService.BadgeView;
+import com.buyeoon.trip.FootprintQueryService.FootprintView;
+import com.buyeoon.trip.FootprintQueryService.PhotoView;
+import com.buyeoon.trip.FootprintQueryService.VisitView;
 import com.buyeoon.trip.TripQueryService.TripStatisticsView;
 import com.buyeoon.trip.TripStartService.LocationCommand;
 import com.buyeoon.trip.TripStartService.TripStartCommand;
 import com.buyeoon.trip.TripStartService.TripView;
+import com.buyeoon.trip.entity.TripStatus;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -28,11 +37,14 @@ public class TripController {
 	private final TripStarter tripStart;
 	private final TripEnder tripEnd;
 	private final TripQueryService tripQuery;
+	private final FootprintQueryService footprintQuery;
 
-	public TripController(TripStarter tripStart, TripEnder tripEnd, TripQueryService tripQuery) {
+	public TripController(TripStarter tripStart, TripEnder tripEnd, TripQueryService tripQuery,
+			FootprintQueryService footprintQuery) {
 		this.tripStart = tripStart;
 		this.tripEnd = tripEnd;
 		this.tripQuery = tripQuery;
+		this.footprintQuery = footprintQuery;
 	}
 
 	@PostMapping("/trips")
@@ -60,12 +72,77 @@ public class TripController {
 		return ResponseEntity.ok(SuccessResponse.of(TripStatisticsResponse.from(statistics)));
 	}
 
+	@GetMapping("/trips/{tripId}/footprint")
+	public ResponseEntity<SuccessResponse<FootprintResponse>> footprint(@AuthenticationPrincipal Jwt jwt,
+			@PathVariable UUID tripId) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		FootprintView footprint = footprintQuery.getFootprint(memberId, tripId);
+		return ResponseEntity.ok(SuccessResponse.of(FootprintResponse.from(footprint)));
+	}
+
 	/** 이동 거리·소모 칼로리는 MVP에서 계산하지 않으므로 항상 null이다. */
 	private record TripStatisticsResponse(UUID tripId, Double distanceKm, long visitedPlaceCount, long durationMinutes,
 			Integer caloriesKcal) {
 		static TripStatisticsResponse from(TripStatisticsView statistics) {
 			return new TripStatisticsResponse(statistics.tripId(), null, statistics.visitedPlaceCount(),
 					statistics.durationMinutes(), null);
+		}
+	}
+
+	private record FootprintResponse(FootprintTripResponse trip, TripStatisticsResponse statistics,
+			List<FootprintVisitResponse> visits, PointSummaryView points, List<FootprintBadgeResponse> badges,
+			List<FootprintPhotoResponse> photos) {
+		static FootprintResponse from(FootprintView footprint) {
+			TripStatisticsResponse statistics = new TripStatisticsResponse(footprint.statistics().tripId(), null,
+					footprint.statistics().visitedPlaceCount(), footprint.statistics().durationMinutes(), null);
+			List<FootprintVisitResponse> visits = footprint.visits().stream().map(FootprintVisitResponse::from)
+					.toList();
+			List<FootprintBadgeResponse> badges = footprint.badges().stream().map(FootprintBadgeResponse::from)
+					.toList();
+			List<FootprintPhotoResponse> photos = footprint.photos().stream().map(FootprintPhotoResponse::from)
+					.toList();
+			return new FootprintResponse(FootprintTripResponse.from(footprint.trip()), statistics, visits,
+					footprint.points(), badges, photos);
+		}
+	}
+
+	private record FootprintTripResponse(UUID tripId, TripStatus status, Instant startedAt, Instant endedAt,
+			Instant settledAt) {
+		static FootprintTripResponse from(FootprintQueryService.FootprintTripView trip) {
+			return new FootprintTripResponse(trip.tripId(), trip.status(), trip.startedAt(), trip.endedAt(),
+					trip.settledAt());
+		}
+	}
+
+	private record FootprintPlaceResponse(UUID placeId, PlaceCategory category, String name, String summary,
+			String description, String address, String imageUrl, double latitude, double longitude,
+			Integer distanceMeters, Integer walkingMinutes, boolean saved) {
+		static FootprintPlaceResponse from(FootprintQueryService.PlaceView place) {
+			return new FootprintPlaceResponse(place.placeId(), place.category(), place.name(), place.summary(),
+					place.description(), place.address(), place.imageUrl(), place.latitude(), place.longitude(), null,
+					null, place.saved());
+		}
+	}
+
+	private record FootprintVisitResponse(UUID visitId, UUID missionId, FootprintPlaceResponse place,
+			Instant visitedAt) {
+		static FootprintVisitResponse from(VisitView visit) {
+			return new FootprintVisitResponse(visit.visitId(), visit.missionId(),
+					FootprintPlaceResponse.from(visit.place()), visit.visitedAt());
+		}
+	}
+
+	private record FootprintBadgeResponse(UUID badgeId, String name, String imageUrl, String condition,
+			Instant earnedAt) {
+		static FootprintBadgeResponse from(BadgeView badge) {
+			return new FootprintBadgeResponse(badge.badgeId(), badge.name(), badge.imageUrl(), badge.condition(),
+					badge.earnedAt());
+		}
+	}
+
+	private record FootprintPhotoResponse(UUID photoId, String url, Instant uploadedAt) {
+		static FootprintPhotoResponse from(PhotoView photo) {
+			return new FootprintPhotoResponse(photo.photoId(), photo.url(), photo.uploadedAt());
 		}
 	}
 

--- a/src/main/java/com/buyeoon/trip/VisitRecordRepository.java
+++ b/src/main/java/com/buyeoon/trip/VisitRecordRepository.java
@@ -17,6 +17,9 @@ public interface VisitRecordRepository extends JpaRepository<VisitRecordEntity, 
 
 	long countByTripId(UUID tripId);
 
+	/** 방문 시각 오름차순으로 여행의 방문 기록을 조회한다. */
+	List<VisitRecordEntity> findByTripIdOrderByVisitedAtAsc(UUID tripId);
+
 	/**
 	 * 회원이 전체 여행에서 방문한 고유 문화재 수를 센다({@code HERITAGE_VISITED_COUNT}, ADR-003).
 	 */

--- a/src/test/java/com/buyeoon/trip/FootprintIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/FootprintIntegrationTests.java
@@ -1,0 +1,318 @@
+package com.buyeoon.trip;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.common.storage.PrivateImageGetUrlService;
+import com.buyeoon.member.auth.AccessTokenService;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class FootprintIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@MockitoBean
+	private PrivateImageGetUrlService privateImageGetUrlService;
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM mission_photos");
+		jdbcTemplate.update("DELETE FROM member_badges");
+		jdbcTemplate.update("DELETE FROM badges");
+		jdbcTemplate.update("DELETE FROM point_settlements");
+		jdbcTemplate.update("DELETE FROM point_transactions");
+		jdbcTemplate.update("DELETE FROM visit_records");
+		jdbcTemplate.update("DELETE FROM missions");
+		jdbcTemplate.update("DELETE FROM places");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 정산 완료 여행은 방문 장소, 통계, 포인트, 배지, 사진을 조합한 응답을 반환한다. */
+	@Test
+	@DisplayName("정산 완료된 여행은 방문 장소·통계·포인트·배지·사진을 포함한 발자취를 반환한다")
+	void settledTripReturnsFullFootprint() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(2, ChronoUnit.HOURS);
+		Instant endedAt = startedAt.plus(50, ChronoUnit.MINUTES);
+		UUID tripId = insertTrip(member.memberId(), "SETTLED", startedAt, endedAt);
+		UUID placeId = insertPlace("정림사지");
+		UUID missionId = insertMission(placeId, "미션 A");
+		insertSavedPlace(member.memberId(), placeId);
+		insertVisitRecord(tripId, missionId, placeId);
+		insertPointTransaction(member.memberId(), tripId, 100);
+		UUID badgeId = insertBadge("첫 발걸음");
+		insertMemberBadge(member.memberId(), badgeId, tripId);
+		insertMissionPhoto(member.memberId(), tripId, missionId);
+
+		when(privateImageGetUrlService.create(anyString())).thenReturn("https://signed-url.example.com/photo");
+
+		performGet(member, tripId).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.trip.tripId").value(tripId.toString()))
+				.andExpect(jsonPath("$.data.trip.status").value("SETTLED"))
+				.andExpect(jsonPath("$.data.statistics.visitedPlaceCount").value(1))
+				.andExpect(jsonPath("$.data.statistics.durationMinutes").value(50))
+				.andExpect(jsonPath("$.data.visits.length()").value(1))
+				.andExpect(jsonPath("$.data.visits[0].missionId").value(missionId.toString()))
+				.andExpect(jsonPath("$.data.visits[0].place.placeId").value(placeId.toString()))
+				.andExpect(jsonPath("$.data.visits[0].place.name").value("정림사지"))
+				.andExpect(jsonPath("$.data.visits[0].place.saved").value(true))
+				.andExpect(jsonPath("$.data.visits[0].place.distanceMeters").isEmpty())
+				.andExpect(jsonPath("$.data.visits[0].place.walkingMinutes").isEmpty())
+				.andExpect(jsonPath("$.data.points.balance").value(100))
+				.andExpect(jsonPath("$.data.badges.length()").value(1))
+				.andExpect(jsonPath("$.data.badges[0].badgeId").value(badgeId.toString()))
+				.andExpect(jsonPath("$.data.badges[0].name").value("첫 발걸음"))
+				.andExpect(jsonPath("$.data.badges[0].condition").value("조건"))
+				.andExpect(jsonPath("$.data.badges[0].earnedAt").exists())
+				.andExpect(jsonPath("$.data.photos.length()").value(1))
+				.andExpect(jsonPath("$.data.photos[0].photoId").exists())
+				.andExpect(jsonPath("$.data.photos[0].uploadedAt").exists())
+				.andExpect(jsonPath("$.data.photos[0].url").value("https://signed-url.example.com/photo"));
+	}
+
+	/** IN_PROGRESS 상태의 여행을 조회하면 409를 반환한다. */
+	@Test
+	@DisplayName("IN_PROGRESS 상태 여행은 409를 반환한다")
+	void inProgressTripReturnsConflict() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId(), "IN_PROGRESS", Instant.now(), null);
+
+		performGet(member, tripId).andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("INVALID_STATE_TRANSITION"));
+	}
+
+	/** ENDED(정산 전) 상태의 여행을 조회하면 409를 반환한다. */
+	@Test
+	@DisplayName("ENDED 상태 여행은 409를 반환한다")
+	void endedTripReturnsConflict() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(1, ChronoUnit.HOURS);
+		UUID tripId = insertTrip(member.memberId(), "ENDED", startedAt, startedAt.plus(30, ChronoUnit.MINUTES));
+
+		performGet(member, tripId).andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("INVALID_STATE_TRANSITION"));
+	}
+
+	/** 존재하지 않는 tripId로 조회하면 404를 반환한다. */
+	@Test
+	@DisplayName("존재하지 않는 tripId는 404를 반환한다")
+	void nonExistentTripReturnsNotFound() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+
+		performGet(member, UUID.randomUUID()).andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 다른 회원 소유의 tripId로 조회하면 404를 반환한다. */
+	@Test
+	@DisplayName("타 회원 소유 tripId는 404를 반환한다")
+	void otherMembersTripReturnsNotFound() throws Exception {
+		AuthenticatedMember owner = insertAuthenticatedMember();
+		AuthenticatedMember requester = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(1, ChronoUnit.HOURS);
+		UUID tripId = insertTrip(owner.memberId(), "SETTLED", startedAt, startedAt.plus(10, ChronoUnit.MINUTES));
+
+		performGet(requester, tripId).andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 인증되지 않은 요청은 401을 반환한다. */
+	@Test
+	@DisplayName("인증되지 않은 요청은 401을 반환한다")
+	void unauthenticatedRequestReturnsUnauthorized() throws Exception {
+		mockMvc.perform(get("/trips/" + UUID.randomUUID() + "/footprint")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** 방문 기록, 배지, 사진이 없으면 각각 빈 배열을 반환한다. */
+	@Test
+	@DisplayName("방문·배지·사진이 없으면 빈 배열을 반환한다")
+	void emptyCollectionsReturnEmptyArrays() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(1, ChronoUnit.HOURS);
+		UUID tripId = insertTrip(member.memberId(), "SETTLED", startedAt, startedAt.plus(20, ChronoUnit.MINUTES));
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.visits").isArray())
+				.andExpect(jsonPath("$.data.visits.length()").value(0)).andExpect(jsonPath("$.data.badges").isArray())
+				.andExpect(jsonPath("$.data.badges.length()").value(0)).andExpect(jsonPath("$.data.photos").isArray())
+				.andExpect(jsonPath("$.data.photos.length()").value(0));
+	}
+
+	/** 다른 여행에서 획득한 배지는 포함하지 않는다. */
+	@Test
+	@DisplayName("다른 여행에서 획득한 배지는 포함하지 않는다")
+	void badgesFromOtherTripAreExcluded() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(3, ChronoUnit.HOURS);
+		UUID otherTripId = insertTrip(member.memberId(), "SETTLED", startedAt, startedAt.plus(20, ChronoUnit.MINUTES));
+		UUID tripId = insertTrip(member.memberId(), "SETTLED", startedAt.plus(1, ChronoUnit.HOURS),
+				startedAt.plus(90, ChronoUnit.MINUTES));
+		UUID badgeId = insertBadge("다른 여행 배지");
+		insertMemberBadge(member.memberId(), badgeId, otherTripId);
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.badges.length()").value(0));
+	}
+
+	/** 사진 presigned URL은 요청자 소유 여행의 사진에 대해서만 발급하며 타 회원 사진은 새지 않는다. */
+	@Test
+	@DisplayName("사진 presigned URL은 요청자 소유 여행의 사진에만 발급한다")
+	void photoPresignedUrlOnlyForOwnedTripPhotos() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(1, ChronoUnit.HOURS);
+		UUID tripId = insertTrip(member.memberId(), "SETTLED", startedAt, startedAt.plus(20, ChronoUnit.MINUTES));
+		UUID placeId = insertPlace("장소");
+		UUID missionId = insertMission(placeId, "미션");
+		UUID myPhotoId = insertMissionPhoto(member.memberId(), tripId, missionId);
+
+		AuthenticatedMember otherMember = insertAuthenticatedMember();
+		UUID otherTripId = insertTrip(otherMember.memberId(), "SETTLED", startedAt,
+				startedAt.plus(20, ChronoUnit.MINUTES));
+		insertMissionPhoto(otherMember.memberId(), otherTripId, missionId);
+
+		when(privateImageGetUrlService.create(anyString())).thenReturn("https://signed-url.example.com/only-mine");
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.photos.length()").value(1))
+				.andExpect(jsonPath("$.data.photos[0].photoId").value(myPhotoId.toString()))
+				.andExpect(jsonPath("$.data.photos[0].url").value("https://signed-url.example.com/only-mine"));
+	}
+
+	private ResultActions performGet(AuthenticatedMember member, UUID tripId) throws Exception {
+		return mockMvc.perform(
+				get("/trips/" + tripId + "/footprint").header("Authorization", "Bearer " + member.accessToken()));
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private UUID insertTrip(UUID memberId, String status, Instant startedAt, Instant endedAt) {
+		UUID tripId = UUID.randomUUID();
+		Instant settledAt = "SETTLED".equals(status) ? endedAt : null;
+		jdbcTemplate.update(
+				"INSERT INTO trips (id, member_id, status, started_at, ended_at, settled_at) "
+						+ "VALUES (?, ?, ?::trip_status, ?, ?, ?)",
+				tripId, memberId, status, Timestamp.from(startedAt == null ? Instant.now() : startedAt),
+				endedAt == null ? null : Timestamp.from(endedAt), settledAt == null ? null : Timestamp.from(settledAt));
+		return tripId;
+	}
+
+	private UUID insertPlace(String name) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate
+				.update("INSERT INTO places (id, category, name, location) VALUES (?, 'HERITAGE'::place_category, ?, "
+						+ "ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography)", id, name, 126.9, 36.2);
+		return id;
+	}
+
+	private UUID insertMission(UUID placeId, String title) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO missions (id, place_id, type, title, description, reward_points, ox_correct_answer) "
+						+ "VALUES (?, ?, 'OX'::mission_type, ?, '설명', 10, true)",
+				id, placeId, title);
+		return id;
+	}
+
+	private void insertSavedPlace(UUID memberId, UUID placeId) {
+		jdbcTemplate.update("INSERT INTO saved_places (member_id, place_id) VALUES (?, ?)", memberId, placeId);
+	}
+
+	private void insertVisitRecord(UUID tripId, UUID missionId, UUID placeId) {
+		jdbcTemplate.update("INSERT INTO visit_records (id, trip_id, mission_id, place_id) VALUES (?, ?, ?, ?)",
+				UUID.randomUUID(), tripId, missionId, placeId);
+	}
+
+	private void insertPointTransaction(UUID memberId, UUID tripId, long amount) {
+		jdbcTemplate.update(
+				"INSERT INTO point_transactions (id, member_id, trip_id, type, amount, description) "
+						+ "VALUES (?, ?, ?, 'EARN'::point_transaction_type, ?, '적립')",
+				UUID.randomUUID(), memberId, tripId, amount);
+	}
+
+	private UUID insertBadge(String name) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO badges (id, category, name, description, condition_text) "
+				+ "VALUES (?, 'EXPLORATION'::badge_category, ?, '설명', '조건')", id, name);
+		return id;
+	}
+
+	private void insertMemberBadge(UUID memberId, UUID badgeId, UUID tripId) {
+		jdbcTemplate.update("INSERT INTO member_badges (member_id, badge_id, trip_id) VALUES (?, ?, ?)", memberId,
+				badgeId, tripId);
+	}
+
+	private UUID insertMissionPhoto(UUID memberId, UUID tripId, UUID missionId) {
+		UUID photoId = UUID.randomUUID();
+		String objectKey = "private/missions/" + tripId + "/" + missionId + "/" + photoId;
+		jdbcTemplate.update(
+				"INSERT INTO mission_photos (id, member_id, trip_id, mission_id, object_key, content_type, "
+						+ "file_size_bytes) VALUES (?, ?, ?, ?, ?, 'image/jpeg', 1024)",
+				photoId, memberId, tripId, missionId, objectKey);
+		return photoId;
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## Summary
- `GET /trips/{tripId}/footprint`를 추가해 정산 완료(SETTLED)된 여행의 방문 장소, 통계, 포인트, 배지, 사진을 조합해 반환한다
- badge/mission/place 도메인 조회는 trip 패키지 소유의 읽기 전용 리포지토리로 캡슐화해 도메인 경계를 지킨다 (`FootprintBadgeRepository`, `FootprintPhotoRepository`, `FootprintPlaceRepository`, `FootprintSavedPlaceRepository`)
- 비공개 미션 사진 조회용 `PrivateImageGetUrlService`(10분 유효 GET presigned URL, ADR-008)를 신규 추가
- `points`는 여행이 아닌 회원 전체 잔액, `badges`는 `member_badges.trip_id` 단일 조건으로 해당 여행 최초 획득 배지만 필터링
- openapi.yaml의 `FootprintData.badges` 스키마를 `Badge` → `AwardedBadge`로 정정 (실제 응답 형태와 계약 일치)

## Test plan
- [x] `./gradlew test` 전체 408개 테스트 통과 (회귀 없음)
- [x] `FootprintIntegrationTests` 9개: SETTLED 전체 응답 조합, IN_PROGRESS/ENDED 409, 존재하지 않는 tripId 404, 타 회원 소유 404, 미인증 401, 방문·배지·사진 없음(빈 배열), 다른 여행 배지 미포함, 사진 presigned URL 소유권 검증
- [x] compileJava, spotlessCheck, checkstyle, spotbugs 모두 통과
- [ ] docker-build.sh는 공유 Supabase pooler 커넥션 풀 소진으로 로컬 검증 스킵 (이번 변경과 무관한 인프라 이슈)

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)