### PR TITLE
fix: ECR push 실패 시 immutable tag 충돌만 재확인하도록 수정

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -140,11 +140,13 @@ jobs:
           ECR_REGISTRY: ${{ steps.ecr.outputs.registry }}
         run: |
           image_uri="${ECR_REGISTRY}/${ECR_REPOSITORY}:${GITHUB_SHA}"
-          if aws ecr describe-images --repository-name "${ECR_REPOSITORY}" \
-              --image-ids imageTag="${GITHUB_SHA}" --region "${AWS_REGION}" >/dev/null 2>&1; then
-            echo "Image tag ${GITHUB_SHA} already exists in ${ECR_REPOSITORY}; reusing it."
-          else
-            docker buildx build --platform linux/arm64 --tag "${image_uri}" --push .
+          build_log=$(mktemp)
+          if ! docker buildx build --platform linux/arm64 --tag "${image_uri}" --push . 2>&1 | tee "${build_log}"; then
+            if grep -q "already exists in the '${ECR_REPOSITORY}' repository and cannot be overwritten because the tag is immutable" "${build_log}"; then
+              echo "Image tag ${GITHUB_SHA} already exists in ${ECR_REPOSITORY}; reusing it."
+            else
+              exit 1
+            fi
           fi
           echo "uri=${image_uri}" >>"${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
## Summary
- 기존 `describe-images` 사전 체크 방식은 체크 시점과 push 시점 사이에 다른 워크플로우 실행이 먼저 push를 완료하면 여전히 immutable tag 충돌 에러가 발생하는 TOCTOU 버그였음 (실제로 4번째 배포 시도에서 재현됨)
- push를 항상 시도하고, 실패 시 에러 메시지가 immutable tag 충돌인 경우에만 성공으로 간주하도록 수정

## Test plan
- [x] YAML 문법 검증 (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] 머지 후 실제 배포 워크플로우 재실행으로 확인

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>