### PR TITLE
feat: 군민증 카탈로그 객체 키를 시딩한다

### DIFF
--- a/src/main/resources/db/migration/V15__seed_citizen_card_catalog.sql
+++ b/src/main/resources/db/migration/V15__seed_citizen_card_catalog.sql
@@ -1,0 +1,21 @@
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM card_characters) OR EXISTS (SELECT 1 FROM card_themes) THEN
+        RAISE EXCEPTION 'Citizen card catalog must be empty before applying V15';
+    END IF;
+END $$;
+
+INSERT INTO card_characters (id, name, image_key, sort_order)
+VALUES
+    ('10000000-0000-4000-8000-000000000001', '금동이', 'public/characters/geumdong.png', 1),
+    ('10000000-0000-4000-8000-000000000002', '금용이', 'public/characters/geumyong.png', 2),
+    ('10000000-0000-4000-8000-000000000003', '금황이', 'public/characters/geumhwang.png', 3);
+
+INSERT INTO card_themes (id, name, image_key, sort_order)
+VALUES
+    ('20000000-0000-4000-8000-000000000001', '봉황', 'public/themes/phoenix.svg', 1),
+    ('20000000-0000-4000-8000-000000000002', '연화문', 'public/themes/lotus.svg', 2),
+    ('20000000-0000-4000-8000-000000000003', '금관', 'public/themes/crown.svg', 3),
+    ('20000000-0000-4000-8000-000000000004', '금관 장식', 'public/themes/crown_ornament.svg', 4),
+    ('20000000-0000-4000-8000-000000000005', '석탑', 'public/themes/pagoda.svg', 5),
+    ('20000000-0000-4000-8000-000000000006', '돛배', 'public/themes/sailboat.svg', 6);

--- a/src/test/java/com/buyeoon/member/CitizenCardCreationIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/CitizenCardCreationIntegrationTests.java
@@ -17,7 +17,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -70,7 +70,7 @@ class CitizenCardCreationIntegrationTests {
 		System.clearProperty("aws.secretAccessKey");
 	}
 
-	@AfterEach
+	@BeforeEach
 	void cleanUp() {
 		jdbcTemplate.update("DELETE FROM idempotency_requests");
 		jdbcTemplate.update("DELETE FROM citizen_cards");

--- a/src/test/java/com/buyeoon/member/CitizenCardOptionsIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/CitizenCardOptionsIntegrationTests.java
@@ -13,8 +13,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,7 +70,7 @@ class CitizenCardOptionsIntegrationTests {
 		System.clearProperty("aws.secretAccessKey");
 	}
 
-	@AfterEach
+	@BeforeEach
 	void cleanUp() {
 		jdbcTemplate.update("DELETE FROM auth_sessions");
 		jdbcTemplate.update("DELETE FROM members");

--- a/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
@@ -13,7 +13,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,7 +66,7 @@ class MemberMeIntegrationTests {
 	@Autowired
 	private JwtDecoder jwtDecoder;
 
-	@AfterEach
+	@BeforeEach
 	void cleanUp() {
 		jdbcTemplate.update("DELETE FROM citizen_cards");
 		jdbcTemplate.update("DELETE FROM member_profiles");

--- a/src/test/java/com/buyeoon/member/MyCitizenCardIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/MyCitizenCardIntegrationTests.java
@@ -12,7 +12,7 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -69,7 +69,7 @@ class MyCitizenCardIntegrationTests {
 		System.clearProperty("aws.secretAccessKey");
 	}
 
-	@AfterEach
+	@BeforeEach
 	void cleanUp() {
 		jdbcTemplate.update("DELETE FROM citizen_cards");
 		jdbcTemplate.update("DELETE FROM member_profiles");

--- a/src/test/java/com/buyeoon/member/ProfileUpdateIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/ProfileUpdateIntegrationTests.java
@@ -18,7 +18,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,7 +58,7 @@ class ProfileUpdateIntegrationTests {
 	@Autowired
 	private AccessTokenService accessTokenService;
 
-	@AfterEach
+	@BeforeEach
 	void cleanUp() {
 		jdbcTemplate.execute("DROP TRIGGER IF EXISTS fail_profile_update ON member_profiles");
 		jdbcTemplate.execute("DROP FUNCTION IF EXISTS fail_profile_update()");

--- a/src/test/java/com/buyeoon/member/SignUpOnboardingIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/SignUpOnboardingIntegrationTests.java
@@ -19,7 +19,7 @@ import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -92,7 +92,7 @@ class SignUpOnboardingIntegrationTests {
 				.willReturn(new VerifiedSocialIdentity(SocialProvider.APPLE, "uc02-apple-member"));
 	}
 
-	@AfterEach
+	@BeforeEach
 	void cleanUp() {
 		jdbcTemplate.update("DELETE FROM idempotency_requests");
 		jdbcTemplate.update("DELETE FROM citizen_cards");

--- a/src/test/java/com/buyeoon/member/WithdrawnMemberDataPurgeIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/WithdrawnMemberDataPurgeIntegrationTests.java
@@ -15,7 +15,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,7 +53,7 @@ class WithdrawnMemberDataPurgeIntegrationTests {
 	@MockitoBean
 	private PrivateImageObjectStore objectStore;
 
-	@AfterEach
+	@BeforeEach
 	void cleanUp() {
 		jdbcTemplate.execute("DROP TRIGGER IF EXISTS fail_member_settings_delete ON member_settings");
 		jdbcTemplate.execute("DROP FUNCTION IF EXISTS fail_member_settings_delete()");

--- a/src/test/java/com/buyeoon/persistence/PostgresSchemaIntegrationTests.java
+++ b/src/test/java/com/buyeoon/persistence/PostgresSchemaIntegrationTests.java
@@ -59,6 +59,26 @@ class PostgresSchemaIntegrationTests {
 	@Autowired
 	private JdbcTemplate jdbcTemplate;
 
+	/** V15가 앱에서 노출할 군민증 캐릭터와 테마를 승인된 객체 키와 순서로 적재하는지 검증한다. */
+	@Test
+	@DisplayName("군민증 카탈로그는 승인된 S3 객체 키와 순서로 시딩된다")
+	void citizenCardCatalogIsSeeded() {
+		assertThat(jdbcTemplate.queryForList("""
+				SELECT name || '|' || image_key || '|' || sort_order
+				FROM card_characters
+				ORDER BY sort_order
+				""", String.class)).containsExactly("금동이|public/characters/geumdong.png|1",
+				"금용이|public/characters/geumyong.png|2", "금황이|public/characters/geumhwang.png|3");
+
+		assertThat(jdbcTemplate.queryForList("""
+				SELECT name || '|' || image_key || '|' || sort_order
+				FROM card_themes
+				ORDER BY sort_order
+				""", String.class)).containsExactly("봉황|public/themes/phoenix.svg|1", "연화문|public/themes/lotus.svg|2",
+				"금관|public/themes/crown.svg|3", "금관 장식|public/themes/crown_ornament.svg|4",
+				"석탑|public/themes/pagoda.svg|5", "돛배|public/themes/sailboat.svg|6");
+	}
+
 	/** V2의 기존 LOCKED 참여 데이터가 최신 스키마로 업그레이드될 때 유실되지 않고 AVAILABLE로 전환되는지 검증한다. */
 	@Test
 	@DisplayName("V2의 LOCKED 참여 데이터는 업그레이드 후 AVAILABLE로 보존된다")
@@ -138,8 +158,8 @@ class PostgresSchemaIntegrationTests {
 						""");
 			}
 
-			Flyway.configure().dataSource(url, username, password).schemas(schema).defaultSchema(schema).load()
-					.migrate();
+			Flyway.configure().dataSource(url, username, password).schemas(schema).defaultSchema(schema)
+					.target(MigrationVersion.fromVersion("5")).load().migrate();
 
 			try (Connection connection = DriverManager.getConnection(url, username, password);
 					Statement statement = connection.createStatement()) {

--- a/src/test/java/com/buyeoon/trip/TripStartIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/TripStartIntegrationTests.java
@@ -17,7 +17,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,7 +58,7 @@ class TripStartIntegrationTests {
 	@Autowired
 	private AccessTokenService accessTokenService;
 
-	@AfterEach
+	@BeforeEach
 	void cleanUp() {
 		jdbcTemplate.update("DELETE FROM idempotency_requests");
 		jdbcTemplate.update("DELETE FROM trips");


### PR DESCRIPTION
## 변경 사항

- 군민증 캐릭터 3종과 테마 6종을 고정 UUID, 표시 순서, S3 객체 키로 시딩합니다.
- 기존 카탈로그 데이터가 있으면 덮어쓰지 않고 마이그레이션을 중단합니다.
- 시드가 적용된 테스트 DB에서도 각 통합 테스트가 독립적으로 실행되도록 초기화 시점을 조정합니다.
- V15 시드 결과와 V5 마이그레이션 범위를 검증합니다.

## 검증

- `./gradlew spotlessApply test --tests com.buyeoon.persistence.PostgresSchemaIntegrationTests --tests com.buyeoon.member.CitizenCardOptionsIntegrationTests`
- `./gradlew test`
