### PR TITLE
feat: 커밋 후 FCM push 비동기 발송 seam 추가 (#156)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ replay_pid*
 !*.env.example
 application-local.yml
 application-local.properties
+/secrets/
 
 # --- Log & Temp ---
 *.log

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'org.hibernate.orm:hibernate-spatial'
     implementation 'software.amazon.awssdk:s3:2.47.3'
+    implementation 'com.google.firebase:firebase-admin:9.10.0'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.10.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/buyeoon/notification/application/PushNotificationPublisher.java
+++ b/src/main/java/com/buyeoon/notification/application/PushNotificationPublisher.java
@@ -1,0 +1,76 @@
+package com.buyeoon.notification.application;
+
+import com.buyeoon.member.application.PushTargetQueryService;
+import com.buyeoon.notification.entity.NotificationType;
+import com.buyeoon.notification.push.FcmClient;
+import com.buyeoon.notification.push.PushMessage;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * 후속 알림 기능이 공통 FCM push 발송을 요청할 때 사용하는 notification 도메인의 공개 seam이다. 트랜잭션 안의 요청은
+ * commit 후에만, 트랜잭션 밖의 요청은 즉시 전용 bounded executor로 전달해 업무 트랜잭션과 분리된 비동기 발송을
+ * 수행한다.
+ */
+@Service
+public class PushNotificationPublisher {
+
+	private static final int MAX_TOKENS_PER_BATCH = 500;
+
+	private final PushTargetQueryService pushTargetQueryService;
+	private final FcmClient fcmClient;
+	private final Executor pushNotificationExecutor;
+
+	public PushNotificationPublisher(PushTargetQueryService pushTargetQueryService, FcmClient fcmClient,
+			Executor pushNotificationExecutor) {
+		this.pushTargetQueryService = pushTargetQueryService;
+		this.fcmClient = fcmClient;
+		this.pushNotificationExecutor = pushNotificationExecutor;
+	}
+
+	/** persistent notification ID나 target 정보가 없는 요청도 처리할 수 있도록 두 값 모두 선택적으로 받는다. */
+	public void publish(UUID memberId, NotificationType type, String title, String body, UUID notificationId,
+			String targetType, UUID targetId) {
+		PushMessage message = new PushMessage(type, title, body, notificationId, targetType, targetId);
+		if (TransactionSynchronizationManager.isSynchronizationActive()) {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+
+				@Override
+				public void afterCommit() {
+					dispatch(memberId, message);
+				}
+			});
+		} else {
+			dispatch(memberId, message);
+		}
+	}
+
+	private void dispatch(UUID memberId, PushMessage message) {
+		pushNotificationExecutor.execute(() -> send(memberId, message));
+	}
+
+	/** 발송 직전에 회원 도메인의 공개 seam으로 활성 기기 토큰을 조회하고 최대 500개씩 나누어 전송한다. */
+	private void send(UUID memberId, PushMessage message) {
+		List<String> tokens = pushTargetQueryService.findRegistrationTokens(memberId);
+		RuntimeException failure = null;
+		for (int start = 0; start < tokens.size(); start += MAX_TOKENS_PER_BATCH) {
+			List<String> batch = tokens.subList(start, Math.min(start + MAX_TOKENS_PER_BATCH, tokens.size()));
+			try {
+				fcmClient.sendMulticast(batch, message);
+			} catch (RuntimeException exception) {
+				if (failure == null) {
+					failure = exception;
+				} else {
+					failure.addSuppressed(exception);
+				}
+			}
+		}
+		if (failure != null) {
+			throw failure;
+		}
+	}
+}

--- a/src/main/java/com/buyeoon/notification/push/FcmClient.java
+++ b/src/main/java/com/buyeoon/notification/push/FcmClient.java
@@ -1,0 +1,10 @@
+package com.buyeoon.notification.push;
+
+import java.util.List;
+
+/** FCM 발송을 추상화한 seam이다. 활성화 여부에 따라 실제 Firebase 구현이나 no-op 구현으로 대체된다. */
+public interface FcmClient {
+
+	/** 주어진 등록 토큰 전체에 같은 메시지를 발송한다. 호출자가 토큰을 최대 500개 단위로 나눠 호출한다. */
+	void sendMulticast(List<String> registrationTokens, PushMessage message);
+}

--- a/src/main/java/com/buyeoon/notification/push/FcmClientConfiguration.java
+++ b/src/main/java/com/buyeoon/notification/push/FcmClientConfiguration.java
@@ -1,0 +1,45 @@
+package com.buyeoon.notification.push;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import java.io.IOException;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@code fcm.enabled} 값에 따라 실제 Firebase 구현이나 no-op 구현을 {@link FcmClient} 빈으로
+ * 등록한다.
+ */
+@Configuration
+public class FcmClientConfiguration {
+
+	/**
+	 * Firebase Admin Java SDK와 Application Default Credentials로 실제 FCM 클라이언트를 구성한다.
+	 */
+	@Configuration
+	@ConditionalOnProperty(prefix = "fcm", name = "enabled", havingValue = "true")
+	static class EnabledFcmClientConfiguration {
+
+		@Bean
+		FirebaseApp firebaseApp() throws IOException {
+			FirebaseOptions options = FirebaseOptions.builder()
+					.setCredentials(GoogleCredentials.getApplicationDefault()).build();
+			return FirebaseApp.initializeApp(options);
+		}
+
+		@Bean
+		FcmClient fcmClient(FirebaseApp firebaseApp) {
+			return new FirebaseFcmClient(FirebaseMessaging.getInstance(firebaseApp));
+		}
+	}
+
+	/** FCM이 비활성화된 기본 구성에서는 Firebase 자격증명 없이도 기동할 수 있도록 no-op 구현을 등록한다. */
+	@Bean
+	@ConditionalOnProperty(prefix = "fcm", name = "enabled", havingValue = "false", matchIfMissing = true)
+	FcmClient noOpFcmClient() {
+		return new NoOpFcmClient();
+	}
+}

--- a/src/main/java/com/buyeoon/notification/push/FirebaseFcmClient.java
+++ b/src/main/java/com/buyeoon/notification/push/FirebaseFcmClient.java
@@ -1,0 +1,43 @@
+package com.buyeoon.notification.push;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import java.util.List;
+
+/** Firebase Admin SDK로 실제 FCM 발송을 수행하는 구현이다. TTL과 collapse 정책은 별도로 지정하지 않는다. */
+public class FirebaseFcmClient implements FcmClient {
+
+	private final FirebaseMessaging firebaseMessaging;
+
+	public FirebaseFcmClient(FirebaseMessaging firebaseMessaging) {
+		this.firebaseMessaging = firebaseMessaging;
+	}
+
+	/** 제목·본문은 notification payload에, 유형과 선택 식별자는 data payload에 담아 발송한다. */
+	@Override
+	public void sendMulticast(List<String> registrationTokens, PushMessage message) {
+		try {
+			firebaseMessaging.sendEachForMulticast(toMulticastMessage(registrationTokens, message));
+		} catch (FirebaseMessagingException exception) {
+			throw new PushNotificationDeliveryException(exception);
+		}
+	}
+
+	MulticastMessage toMulticastMessage(List<String> registrationTokens, PushMessage message) {
+		MulticastMessage.Builder builder = MulticastMessage.builder().addAllTokens(registrationTokens)
+				.setNotification(Notification.builder().setTitle(message.title()).setBody(message.body()).build())
+				.putData("type", message.type().name());
+		if (message.notificationId() != null) {
+			builder.putData("notificationId", message.notificationId().toString());
+		}
+		if (message.targetType() != null) {
+			builder.putData("targetType", message.targetType());
+		}
+		if (message.targetId() != null) {
+			builder.putData("targetId", message.targetId().toString());
+		}
+		return builder.build();
+	}
+}

--- a/src/main/java/com/buyeoon/notification/push/NoOpFcmClient.java
+++ b/src/main/java/com/buyeoon/notification/push/NoOpFcmClient.java
@@ -1,0 +1,12 @@
+package com.buyeoon.notification.push;
+
+import java.util.List;
+
+/** {@code fcm.enabled=false}일 때 사용하는 비활성 구현이다. 어떤 발송 요청도 실제로 전달하지 않는다. */
+public class NoOpFcmClient implements FcmClient {
+
+	@Override
+	public void sendMulticast(List<String> registrationTokens, PushMessage message) {
+		// FCM이 비활성화된 구성이므로 의도적으로 아무 것도 하지 않는다.
+	}
+}

--- a/src/main/java/com/buyeoon/notification/push/PushMessage.java
+++ b/src/main/java/com/buyeoon/notification/push/PushMessage.java
@@ -1,0 +1,9 @@
+package com.buyeoon.notification.push;
+
+import com.buyeoon.notification.entity.NotificationType;
+import java.util.UUID;
+
+/** FCM으로 발송할 표시·이동 정보를 담는다. {@code notificationId}와 target 정보는 선택적이다. */
+public record PushMessage(NotificationType type, String title, String body, UUID notificationId, String targetType,
+		UUID targetId) {
+}

--- a/src/main/java/com/buyeoon/notification/push/PushNotificationDeliveryException.java
+++ b/src/main/java/com/buyeoon/notification/push/PushNotificationDeliveryException.java
@@ -1,0 +1,13 @@
+package com.buyeoon.notification.push;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+
+/** FCM 발송 요청이 실패했을 때 던지는 예외다. 비동기 executor에서 발생하며 업무 트랜잭션에는 영향을 주지 않는다. */
+public class PushNotificationDeliveryException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public PushNotificationDeliveryException(FirebaseMessagingException cause) {
+		super("FCM push 발송에 실패했습니다.", cause);
+	}
+}

--- a/src/main/java/com/buyeoon/notification/push/PushNotificationExecutorConfiguration.java
+++ b/src/main/java/com/buyeoon/notification/push/PushNotificationExecutorConfiguration.java
@@ -1,0 +1,24 @@
+package com.buyeoon.notification.push;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * 업무 트랜잭션과 분리된 FCM 발송 전용 bounded executor를 구성한다. worker 2개, queue 100을 사용한다.
+ */
+@Configuration
+public class PushNotificationExecutorConfiguration {
+
+	@Bean
+	Executor pushNotificationExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(2);
+		executor.setMaxPoolSize(2);
+		executor.setQueueCapacity(100);
+		executor.setThreadNamePrefix("push-notification-");
+		executor.initialize();
+		return executor;
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,6 +32,8 @@ social.apple.read-timeout=${APPLE_READ_TIMEOUT:3s}
 storage.images.bucket=${IMAGE_BUCKET:}
 storage.images.region=${AWS_REGION:ap-northeast-2}
 
+fcm.enabled=${FCM_ENABLED:false}
+
 tourapi.base-url=${TOURAPI_BASE_URL:https://apis.data.go.kr/B551011/KorService2}
 tourapi.service-key=${TOURAPI_SERVICE_KEY:}
 tourapi.area-code=${TOURAPI_AREA_CODE:34}

--- a/src/test/java/com/buyeoon/notification/application/PushNotificationPublisherIntegrationTests.java
+++ b/src/test/java/com/buyeoon/notification/application/PushNotificationPublisherIntegrationTests.java
@@ -1,0 +1,268 @@
+package com.buyeoon.notification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.buyeoon.notification.entity.NotificationType;
+import com.buyeoon.notification.push.FcmClient;
+import com.buyeoon.notification.push.PushMessage;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * 실제 PostgreSQL과 fake FCM client를 사용해 {@link PushNotificationPublisher}의 공개
+ * seam을 검증한다.
+ */
+@SpringBootTest
+@Testcontainers
+class PushNotificationPublisherIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private PushNotificationPublisher publisher;
+
+	@Autowired
+	private FakeFcmClient fakeFcmClient;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private PlatformTransactionManager transactionManager;
+
+	@BeforeEach
+	void resetFakeClient() {
+		fakeFcmClient.reset();
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM push_tokens");
+		jdbcTemplate.update("DELETE FROM member_settings");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	@Test
+	@DisplayName("트랜잭션이 commit되면 비동기 발송이 시작된다")
+	void dispatchesAfterCommit() throws Exception {
+		UUID memberId = insertActiveMemberWithToken("committed-token");
+		fakeFcmClient.expectInvocations(1);
+		TransactionTemplate transactions = new TransactionTemplate(transactionManager);
+
+		transactions.executeWithoutResult(
+				status -> publisher.publish(memberId, NotificationType.BADGE, "제목", "본문", null, null, null));
+
+		assertThat(fakeFcmClient.awaitInvocations(5, TimeUnit.SECONDS)).isTrue();
+		assertThat(fakeFcmClient.invocations()).singleElement()
+				.satisfies(invocation -> assertThat(invocation.tokens()).containsExactly("committed-token"));
+	}
+
+	@Test
+	@DisplayName("트랜잭션이 rollback되면 발송하지 않는다")
+	void doesNotDispatchAfterRollback() throws Exception {
+		UUID memberId = insertActiveMemberWithToken("rolled-back-token");
+		TransactionTemplate transactions = new TransactionTemplate(transactionManager);
+		fakeFcmClient.expectInvocations(1);
+
+		transactions.executeWithoutResult(status -> {
+			publisher.publish(memberId, NotificationType.BADGE, "제목", "본문", null, null, null);
+			status.setRollbackOnly();
+		});
+
+		assertThat(fakeFcmClient.awaitInvocations(1, TimeUnit.SECONDS)).isFalse();
+		assertThat(fakeFcmClient.invocations()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("트랜잭션 밖의 독립 요청도 같은 executor에서 비동기로 처리된다")
+	void dispatchesImmediatelyOutsideTransaction() throws Exception {
+		UUID memberId = insertActiveMemberWithToken("standalone-token");
+		fakeFcmClient.expectInvocations(1);
+
+		publisher.publish(memberId, NotificationType.BADGE, "제목", "본문", null, null, null);
+
+		assertThat(fakeFcmClient.awaitInvocations(5, TimeUnit.SECONDS)).isTrue();
+		assertThat(fakeFcmClient.invocations()).singleElement()
+				.satisfies(invocation -> assertThat(invocation.tokens()).containsExactly("standalone-token"));
+	}
+
+	@Test
+	@DisplayName("한 회원의 모든 활성 기기 토큰이 발송 대상이 되며 notification ID가 없는 요청도 처리된다")
+	void targetsAllActiveTokensWithoutNotificationId() throws Exception {
+		UUID memberId = insertActiveMember();
+		insertSessionWithToken(memberId, "device-1", null, 30);
+		insertSessionWithToken(memberId, "device-2", null, 30);
+		insertSessionWithToken(memberId, "revoked", Instant.now(), 30);
+		fakeFcmClient.expectInvocations(1);
+
+		publisher.publish(memberId, NotificationType.BADGE, "제목", "본문", null, null, null);
+
+		assertThat(fakeFcmClient.awaitInvocations(5, TimeUnit.SECONDS)).isTrue();
+		assertThat(fakeFcmClient.invocations()).singleElement().satisfies(
+				invocation -> assertThat(invocation.tokens()).containsExactlyInAnyOrder("device-1", "device-2"));
+	}
+
+	@Test
+	@DisplayName("제목·본문·유형과 notification ID·target 정보가 그대로 전달된다")
+	void deliversPayloadFieldsExactly() throws Exception {
+		UUID memberId = insertActiveMemberWithToken("payload-token");
+		UUID notificationId = UUID.randomUUID();
+		UUID targetId = UUID.randomUUID();
+		fakeFcmClient.expectInvocations(1);
+
+		publisher.publish(memberId, NotificationType.BADGE, "새로운 배지를 획득했어요!", "탐험가 배지를 획득했어요.", notificationId, "BADGE",
+				targetId);
+
+		assertThat(fakeFcmClient.awaitInvocations(5, TimeUnit.SECONDS)).isTrue();
+		PushMessage message = fakeFcmClient.invocations().get(0).message();
+		assertThat(message.type()).isEqualTo(NotificationType.BADGE);
+		assertThat(message.title()).isEqualTo("새로운 배지를 획득했어요!");
+		assertThat(message.body()).isEqualTo("탐험가 배지를 획득했어요.");
+		assertThat(message.notificationId()).isEqualTo(notificationId);
+		assertThat(message.targetType()).isEqualTo("BADGE");
+		assertThat(message.targetId()).isEqualTo(targetId);
+	}
+
+	@Test
+	@DisplayName("대상이 500개를 초과하면 최대 500개 단위로 나뉘어 모든 토큰이 한 번씩 요청된다")
+	void splitsIntoBatchesOfAtMost500Tokens() throws Exception {
+		UUID memberId = insertActiveMember();
+		List<String> expectedTokens = new ArrayList<>();
+		for (int i = 0; i < 750; i++) {
+			String token = "token-" + i;
+			expectedTokens.add(token);
+			insertSessionWithToken(memberId, token, null, 30);
+		}
+		fakeFcmClient.expectInvocations(2);
+
+		publisher.publish(memberId, NotificationType.BADGE, "제목", "본문", null, null, null);
+
+		assertThat(fakeFcmClient.awaitInvocations(10, TimeUnit.SECONDS)).isTrue();
+		List<FakeFcmClient.Invocation> invocations = fakeFcmClient.invocations();
+		assertThat(invocations).hasSize(2);
+		assertThat(invocations)
+				.allSatisfy(invocation -> assertThat(invocation.tokens().size()).isLessThanOrEqualTo(500));
+		List<String> allDeliveredTokens = new ArrayList<>();
+		invocations.forEach(invocation -> allDeliveredTokens.addAll(invocation.tokens()));
+		assertThat(allDeliveredTokens).containsExactlyInAnyOrderElementsOf(expectedTokens);
+	}
+
+	private UUID insertActiveMemberWithToken(String registrationToken) {
+		UUID memberId = insertActiveMember();
+		insertSessionWithToken(memberId, registrationToken, null, 30);
+		return memberId;
+	}
+
+	private UUID insertActiveMember() {
+		UUID memberId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO member_settings
+				    (member_id, nearby_quiz_notification_enabled, dark_mode_enabled, version)
+				VALUES (?, false, false, 0)
+				""", memberId);
+		return memberId;
+	}
+
+	private void insertSessionWithToken(UUID memberId, String registrationToken, Instant revokedAt,
+			long expiresInDays) {
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at, revoked_at)
+				VALUES (?, ?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(expiresInDays, ChronoUnit.DAYS)),
+				revokedAt == null ? null : Timestamp.from(revokedAt));
+		jdbcTemplate.update("""
+				INSERT INTO push_tokens (auth_session_id, registration_token)
+				VALUES (?, ?)
+				""", sessionId, registrationToken);
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	@TestConfiguration
+	static class FakeFcmClientConfiguration {
+
+		@Bean
+		@Primary
+		FakeFcmClient fakeFcmClient() {
+			return new FakeFcmClient();
+		}
+	}
+
+	/** 실제 FCM 대신 발송 요청을 기록하는 테스트 대역이다. */
+	static class FakeFcmClient implements FcmClient {
+
+		private final List<Invocation> invocations = new CopyOnWriteArrayList<>();
+		private volatile CountDownLatch latch = new CountDownLatch(0);
+
+		@Override
+		public void sendMulticast(List<String> registrationTokens, PushMessage message) {
+			invocations.add(new Invocation(List.copyOf(registrationTokens), message));
+			latch.countDown();
+		}
+
+		void reset() {
+			invocations.clear();
+			latch = new CountDownLatch(0);
+		}
+
+		void expectInvocations(int count) {
+			latch = new CountDownLatch(count);
+		}
+
+		boolean awaitInvocations(long timeout, TimeUnit unit) throws InterruptedException {
+			return latch.await(timeout, unit);
+		}
+
+		List<Invocation> invocations() {
+			return List.copyOf(invocations);
+		}
+
+		record Invocation(List<String> tokens, PushMessage message) {
+		}
+	}
+}

--- a/src/test/java/com/buyeoon/notification/push/FcmClientConfigurationTests.java
+++ b/src/test/java/com/buyeoon/notification/push/FcmClientConfigurationTests.java
@@ -1,0 +1,58 @@
+package com.buyeoon.notification.push;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+class FcmClientConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withUserConfiguration(FcmClientConfiguration.class);
+
+	@Test
+	@DisplayName("FCM_ENABLED=false이면 Firebase 자격증명 없이 no-op 구현으로 정상 기동한다")
+	void disabledFcmStartsWithNoOpClient() {
+		contextRunner.withPropertyValues("fcm.enabled=false").run(context -> {
+			assertThat(context).hasNotFailed();
+			assertThat(context).hasSingleBean(FcmClient.class);
+			assertThat(context.getBean(FcmClient.class)).isInstanceOf(NoOpFcmClient.class);
+			assertThat(context).doesNotHaveBean("firebaseApp");
+		});
+	}
+
+	@Test
+	@DisplayName("FCM_ENABLED 기본값은 false이며 Firebase 설정 없이 기동한다")
+	void defaultFcmDisabledStartsWithNoOpClient() {
+		contextRunner.run(context -> {
+			assertThat(context).hasNotFailed();
+			assertThat(context.getBean(FcmClient.class)).isInstanceOf(NoOpFcmClient.class);
+		});
+	}
+
+	@Test
+	@DisplayName("FCM_ENABLED=true인데 ADC 자격증명이 없으면 애플리케이션 시작이 실패한다")
+	void enabledFcmWithoutCredentialsFailsStartup() {
+		Assumptions.assumeFalse(adcCredentialsAvailable(), "이 머신에 ADC 자격증명이 구성되어 있어 자격증명 부재 상황을 재현할 수 없다");
+
+		contextRunner.withPropertyValues("fcm.enabled=true").run(context -> assertThat(context).hasFailed());
+	}
+
+	/**
+	 * {@link com.google.auth.oauth2.GoogleCredentials#getApplicationDefault()}가
+	 * 확인하는 ADC 소스가 이미 있는지 본다.
+	 */
+	private boolean adcCredentialsAvailable() {
+		String credentialsPath = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
+		if (credentialsPath != null && !credentialsPath.isBlank()) {
+			return true;
+		}
+		Path wellKnownPath = Path.of(System.getProperty("user.home"), ".config", "gcloud",
+				"application_default_credentials.json");
+		return Files.exists(wellKnownPath);
+	}
+}

--- a/src/test/java/com/buyeoon/notification/push/FirebaseFcmClientTests.java
+++ b/src/test/java/com/buyeoon/notification/push/FirebaseFcmClientTests.java
@@ -1,0 +1,66 @@
+package com.buyeoon.notification.push;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.buyeoon.notification.entity.NotificationType;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MulticastMessage;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** 실제 네트워크 호출 없이 FCM 메시지 구성 규칙만 검증한다. */
+class FirebaseFcmClientTests {
+
+	private final FirebaseFcmClient client = new FirebaseFcmClient(null);
+
+	@Test
+	@DisplayName("제목·본문은 notification payload에, 유형과 선택 식별자는 data payload에 담고 TTL·collapse 정책은 지정하지 않는다")
+	void buildsMessageWithoutTtlOrCollapsePolicy() throws Exception {
+		UUID notificationId = UUID.randomUUID();
+		UUID targetId = UUID.randomUUID();
+		PushMessage message = new PushMessage(NotificationType.BADGE, "새로운 배지를 획득했어요!", "탐험가 배지를 획득했어요.",
+				notificationId, "BADGE", targetId);
+
+		MulticastMessage multicastMessage = client.toMulticastMessage(List.of("token-1", "token-2"), message);
+
+		Message perTokenMessage = firstMessage(multicastMessage);
+		assertThat(call(perTokenMessage, "getNotification")).isNotNull();
+		assertThat(data(perTokenMessage)).containsEntry("type", "BADGE")
+				.containsEntry("notificationId", notificationId.toString()).containsEntry("targetType", "BADGE")
+				.containsEntry("targetId", targetId.toString());
+		assertThat(call(perTokenMessage, "getAndroidConfig")).isNull();
+		assertThat(call(perTokenMessage, "getApnsConfig")).isNull();
+		assertThat(call(perTokenMessage, "getWebpushConfig")).isNull();
+	}
+
+	@Test
+	@DisplayName("notification ID와 target 정보가 없으면 해당 data 키를 담지 않는다")
+	void omitsAbsentOptionalDataKeys() throws Exception {
+		PushMessage message = new PushMessage(NotificationType.POINT, "제목", "본문", null, null, null);
+
+		MulticastMessage multicastMessage = client.toMulticastMessage(List.of("token-1"), message);
+
+		Message perTokenMessage = firstMessage(multicastMessage);
+		assertThat(data(perTokenMessage)).containsEntry("type", "POINT").doesNotContainKeys("notificationId",
+				"targetType", "targetId");
+	}
+
+	@SuppressWarnings("unchecked")
+	private Message firstMessage(MulticastMessage multicastMessage) throws Exception {
+		return ((List<Message>) call(multicastMessage, "getMessageList")).get(0);
+	}
+
+	private Object call(Object target, String methodName) throws Exception {
+		Method method = target.getClass().getDeclaredMethod(methodName);
+		method.setAccessible(true);
+		return method.invoke(target);
+	}
+
+	@SuppressWarnings("unchecked")
+	private java.util.Map<String, String> data(Message message) throws Exception {
+		return (java.util.Map<String, String>) call(message, "getData");
+	}
+}


### PR DESCRIPTION
## Summary
- 회원 ID·알림 유형·제목·본문과 선택적 notification ID·target 정보를 받는 공통 `PushNotificationPublisher` application seam 추가
- 트랜잭션 안의 요청은 commit 후에만, 트랜잭션 밖의 요청은 즉시 worker 2개·queue 100의 전용 bounded executor로 비동기 FCM 발송
- 발송 직전 회원 도메인의 `PushTargetQueryService`(#155) 공개 seam으로 활성 기기 토큰을 조회, 최대 500개씩 나누어 전송 (한 batch 실패해도 나머지 batch는 계속 시도)
- Firebase Admin SDK `9.10.0` + Application Default Credentials 구성: `FCM_ENABLED=false`(기본값) → 자격증명 없이 no-op으로 기동, `FCM_ENABLED=true`인데 ADC가 없으면 기동 실패

## Test plan
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh` (checkstyle + spotbugs)
- [x] `./gradlew test` — 실제 PostgreSQL + fake FCM client로 commit/rollback/트랜잭션 외 발송, 대상 선정, payload 필드, 500개 batching 검증. FCM 자격증명 유무에 따른 애플리케이션 기동 테스트 포함 (로컬에 ADC가 구성돼 있으면 자격증명-부재 케이스는 자동으로 skip 처리됨)
- [x] `./scripts/test/docker-build.sh`

## Notes
- 배지·근처 퀴즈 등 실제 알림 유형과의 연결은 이 티켓 범위 제외 (Epic #154에 명시)
- Production 환경에서 FCM_ENABLED를 켜기 위한 SSM/배포 배선은 별도 이슈 #175로 분리함

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szi5XzYR8PoX9upETfacF6
