### PR TITLE
ci: production 배포 게이트에서 checkstyle·spotbugs 제외

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -71,8 +71,8 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb
 
-      - name: Run quality gate
-        run: ./gradlew check --no-daemon
+      - name: Run test gate
+        run: ./gradlew test --no-daemon
 
       - name: Upload spring test report
         if: always()


### PR DESCRIPTION
## Summary
- Production 배포 파이프라인(`.github/workflows/deploy-production.yml`)의 게이트를 `./gradlew check`(test + checkstyle + spotbugs)에서 `./gradlew test`로 축소
- checkstyle·spotbugs 같은 정적 분석은 `scripts/test/format.sh`, `scripts/test/static-check.sh`로 개발 단계에서 이미 사람이 확인하므로, 배포 게이트는 기능 회귀를 막는 테스트 통과 여부만 확인

## Test plan
- [x] 워크플로 YAML 문법 검증 (`yaml.safe_load`)
- [ ] 실제 Actions 실행 결과는 이 PR의 CI에서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szi5XzYR8PoX9upETfacF6
