### PR TITLE
chore: disable FCM in production deployment configuration

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -112,7 +112,7 @@ jobs:
           ADMIN_API_KEY=test \
           APP_IMAGE=example.invalid/buyeoon/app:${GITHUB_SHA} \
           RELEASE_DIR=/tmp/buyeoon-release \
-          FCM_ENABLED=true \
+          FCM_ENABLED=false \
           GOOGLE_APPLICATION_CREDENTIALS=/opt/buyeoon/fcm/service-account.json \
             docker compose -f compose.prod.yaml config --quiet
 


### PR DESCRIPTION
## Summary
- FCM을 production 배포 설정에서 비활성화