### PR TITLE
FCM 실패와 executor 포화를 격리·관측

### DIFF
--- a/src/main/java/com/buyeoon/member/application/PushTargetQueryService.java
+++ b/src/main/java/com/buyeoon/member/application/PushTargetQueryService.java
@@ -28,4 +28,13 @@ public class PushTargetQueryService {
 				  AND session.expires_at > CURRENT_TIMESTAMP
 				""", (resultSet, rowNumber) -> resultSet.getString("registration_token"), memberId);
 	}
+
+	/** FCM이 {@code UNREGISTERED}로 응답한 등록 토큰을 삭제하는 회원 도메인의 공개 seam이다. */
+	public void deleteRegistrationTokens(List<String> registrationTokens) {
+		if (registrationTokens.isEmpty()) {
+			return;
+		}
+		jdbcOperations.batchUpdate("DELETE FROM push_tokens WHERE registration_token = ?",
+				registrationTokens.stream().map(token -> new Object[]{token}).toList());
+	}
 }

--- a/src/main/java/com/buyeoon/notification/application/PushNotificationPublisher.java
+++ b/src/main/java/com/buyeoon/notification/application/PushNotificationPublisher.java
@@ -3,10 +3,16 @@ package com.buyeoon.notification.application;
 import com.buyeoon.member.application.PushTargetQueryService;
 import com.buyeoon.notification.entity.NotificationType;
 import com.buyeoon.notification.push.FcmClient;
+import com.buyeoon.notification.push.FcmSendResult;
 import com.buyeoon.notification.push.PushMessage;
+import com.buyeoon.notification.push.PushNotificationMetrics;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -14,22 +20,26 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 /**
  * 후속 알림 기능이 공통 FCM push 발송을 요청할 때 사용하는 notification 도메인의 공개 seam이다. 트랜잭션 안의 요청은
  * commit 후에만, 트랜잭션 밖의 요청은 즉시 전용 bounded executor로 전달해 업무 트랜잭션과 분리된 비동기 발송을
- * 수행한다.
+ * 수행한다. FCM 부분 실패와 executor 포화는 이미 commit된 업무나 호출 API의 성공에 영향을 주지 않으며 재시도하지
+ * 않는다.
  */
 @Service
 public class PushNotificationPublisher {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(PushNotificationPublisher.class);
 	private static final int MAX_TOKENS_PER_BATCH = 500;
 
 	private final PushTargetQueryService pushTargetQueryService;
 	private final FcmClient fcmClient;
 	private final Executor pushNotificationExecutor;
+	private final PushNotificationMetrics metrics;
 
 	public PushNotificationPublisher(PushTargetQueryService pushTargetQueryService, FcmClient fcmClient,
-			Executor pushNotificationExecutor) {
+			Executor pushNotificationExecutor, PushNotificationMetrics metrics) {
 		this.pushTargetQueryService = pushTargetQueryService;
 		this.fcmClient = fcmClient;
 		this.pushNotificationExecutor = pushNotificationExecutor;
+		this.metrics = metrics;
 	}
 
 	/** persistent notification ID나 target 정보가 없는 요청도 처리할 수 있도록 두 값 모두 선택적으로 받는다. */
@@ -49,28 +59,52 @@ public class PushNotificationPublisher {
 		}
 	}
 
+	/** executor가 포화 상태면 호출 thread에서 FCM을 실행하지 않고 새 요청을 drop한다. */
 	private void dispatch(UUID memberId, PushMessage message) {
-		pushNotificationExecutor.execute(() -> send(memberId, message));
+		try {
+			pushNotificationExecutor.execute(() -> send(memberId, message));
+		} catch (RejectedExecutionException exception) {
+			LOGGER.warn("FCM 발송 executor가 포화되어 새 발송 요청을 drop합니다.");
+			metrics.recordQueueDropped();
+		}
 	}
 
 	/** 발송 직전에 회원 도메인의 공개 seam으로 활성 기기 토큰을 조회하고 최대 500개씩 나누어 전송한다. */
 	private void send(UUID memberId, PushMessage message) {
 		List<String> tokens = pushTargetQueryService.findRegistrationTokens(memberId);
-		RuntimeException failure = null;
+		List<String> unregisteredTokens = new ArrayList<>();
 		for (int start = 0; start < tokens.size(); start += MAX_TOKENS_PER_BATCH) {
 			List<String> batch = tokens.subList(start, Math.min(start + MAX_TOKENS_PER_BATCH, tokens.size()));
-			try {
-				fcmClient.sendMulticast(batch, message);
-			} catch (RuntimeException exception) {
-				if (failure == null) {
-					failure = exception;
-				} else {
-					failure.addSuppressed(exception);
-				}
-			}
+			sendBatch(batch, message, unregisteredTokens);
 		}
-		if (failure != null) {
-			throw failure;
+		deleteUnregisteredTokens(unregisteredTokens);
+	}
+
+	/** FCM 예외는 애플리케이션에서 재시도하지 않고 실패로 관측만 남긴다. */
+	private void sendBatch(List<String> batch, PushMessage message, List<String> unregisteredTokens) {
+		try {
+			FcmSendResult result = fcmClient.sendMulticast(batch, message);
+			metrics.recordAccepted(result.acceptedCount());
+			metrics.recordFailed(result.failedCount());
+			unregisteredTokens.addAll(result.unregisteredTokens());
+			LOGGER.info("FCM 발송 결과. accepted={} failed={}", result.acceptedCount(), result.failedCount());
+		} catch (RuntimeException exception) {
+			metrics.recordFailed(batch.size());
+			LOGGER.warn("FCM 발송에 실패했습니다. tokenCount={}", batch.size(), exception);
+		}
+	}
+
+	/** 토큰 삭제 실패는 이미 접수된 발송 결과나 호출 업무에 영향을 주지 않는다. */
+	private void deleteUnregisteredTokens(List<String> unregisteredTokens) {
+		if (unregisteredTokens.isEmpty()) {
+			return;
+		}
+		try {
+			pushTargetQueryService.deleteRegistrationTokens(unregisteredTokens);
+			metrics.recordInvalidTokenDeleted(unregisteredTokens.size());
+			LOGGER.info("무효 등록 토큰을 삭제했습니다. count={}", unregisteredTokens.size());
+		} catch (RuntimeException exception) {
+			LOGGER.warn("무효 등록 토큰 삭제에 실패했습니다. count={}", unregisteredTokens.size(), exception);
 		}
 	}
 }

--- a/src/main/java/com/buyeoon/notification/push/FcmClient.java
+++ b/src/main/java/com/buyeoon/notification/push/FcmClient.java
@@ -5,6 +5,9 @@ import java.util.List;
 /** FCM 발송을 추상화한 seam이다. 활성화 여부에 따라 실제 Firebase 구현이나 no-op 구현으로 대체된다. */
 public interface FcmClient {
 
-	/** 주어진 등록 토큰 전체에 같은 메시지를 발송한다. 호출자가 토큰을 최대 500개 단위로 나눠 호출한다. */
-	void sendMulticast(List<String> registrationTokens, PushMessage message);
+	/**
+	 * 주어진 등록 토큰 전체에 같은 메시지를 발송한다. 호출자가 토큰을 최대 500개 단위로 나눠 호출한다. 반환하는
+	 * {@link FcmSendResult}는 토큰별 접수·실패 결과와 삭제 대상 무효 토큰을 담는다.
+	 */
+	FcmSendResult sendMulticast(List<String> registrationTokens, PushMessage message);
 }

--- a/src/main/java/com/buyeoon/notification/push/FcmClientConfiguration.java
+++ b/src/main/java/com/buyeoon/notification/push/FcmClientConfiguration.java
@@ -39,7 +39,7 @@ public class FcmClientConfiguration {
 	/** FCM이 비활성화된 기본 구성에서는 Firebase 자격증명 없이도 기동할 수 있도록 no-op 구현을 등록한다. */
 	@Bean
 	@ConditionalOnProperty(prefix = "fcm", name = "enabled", havingValue = "false", matchIfMissing = true)
-	FcmClient noOpFcmClient() {
-		return new NoOpFcmClient();
+	FcmClient noOpFcmClient(PushNotificationMetrics metrics) {
+		return new NoOpFcmClient(metrics);
 	}
 }

--- a/src/main/java/com/buyeoon/notification/push/FcmSendResult.java
+++ b/src/main/java/com/buyeoon/notification/push/FcmSendResult.java
@@ -1,0 +1,14 @@
+package com.buyeoon.notification.push;
+
+import java.util.List;
+
+/**
+ * 한 batch 발송 결과다. {@code acceptedCount}는 FCM이 접수한 토큰 수이며 기기 전달 완료를 의미하지 않는다.
+ * {@code unregisteredTokens}는 {@code UNREGISTERED} 오류가 반환돼 삭제 대상인 등록 토큰이다.
+ */
+public record FcmSendResult(int acceptedCount, int failedCount, List<String> unregisteredTokens) {
+
+	public FcmSendResult {
+		unregisteredTokens = List.copyOf(unregisteredTokens);
+	}
+}

--- a/src/main/java/com/buyeoon/notification/push/FirebaseFcmClient.java
+++ b/src/main/java/com/buyeoon/notification/push/FirebaseFcmClient.java
@@ -1,9 +1,13 @@
 package com.buyeoon.notification.push;
 
+import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.SendResponse;
+import java.util.ArrayList;
 import java.util.List;
 
 /** Firebase Admin SDK로 실제 FCM 발송을 수행하는 구현이다. TTL과 collapse 정책은 별도로 지정하지 않는다. */
@@ -15,14 +19,28 @@ public class FirebaseFcmClient implements FcmClient {
 		this.firebaseMessaging = firebaseMessaging;
 	}
 
-	/** 제목·본문은 notification payload에, 유형과 선택 식별자는 data payload에 담아 발송한다. */
+	/**
+	 * 제목·본문은 notification payload에, 유형과 선택 식별자는 data payload에 담아 발송한다. 응답을 토큰별로 해석해
+	 * {@code UNREGISTERED} 오류가 반환된 토큰만 삭제 대상으로 반환한다.
+	 */
 	@Override
-	public void sendMulticast(List<String> registrationTokens, PushMessage message) {
+	public FcmSendResult sendMulticast(List<String> registrationTokens, PushMessage message) {
+		BatchResponse response;
 		try {
-			firebaseMessaging.sendEachForMulticast(toMulticastMessage(registrationTokens, message));
+			response = firebaseMessaging.sendEachForMulticast(toMulticastMessage(registrationTokens, message));
 		} catch (FirebaseMessagingException exception) {
 			throw new PushNotificationDeliveryException(exception);
 		}
+		List<String> unregisteredTokens = new ArrayList<>();
+		List<SendResponse> responses = response.getResponses();
+		for (int i = 0; i < responses.size(); i++) {
+			SendResponse sendResponse = responses.get(i);
+			if (!sendResponse.isSuccessful()
+					&& sendResponse.getException().getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
+				unregisteredTokens.add(registrationTokens.get(i));
+			}
+		}
+		return new FcmSendResult(response.getSuccessCount(), response.getFailureCount(), unregisteredTokens);
 	}
 
 	MulticastMessage toMulticastMessage(List<String> registrationTokens, PushMessage message) {

--- a/src/main/java/com/buyeoon/notification/push/NoOpFcmClient.java
+++ b/src/main/java/com/buyeoon/notification/push/NoOpFcmClient.java
@@ -1,12 +1,24 @@
 package com.buyeoon.notification.push;
 
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** {@code fcm.enabled=false}일 때 사용하는 비활성 구현이다. 어떤 발송 요청도 실제로 전달하지 않는다. */
 public class NoOpFcmClient implements FcmClient {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(NoOpFcmClient.class);
+
+	private final PushNotificationMetrics metrics;
+
+	public NoOpFcmClient(PushNotificationMetrics metrics) {
+		this.metrics = metrics;
+	}
+
 	@Override
-	public void sendMulticast(List<String> registrationTokens, PushMessage message) {
-		// FCM이 비활성화된 구성이므로 의도적으로 아무 것도 하지 않는다.
+	public FcmSendResult sendMulticast(List<String> registrationTokens, PushMessage message) {
+		LOGGER.info("FCM이 비활성화되어 발송을 건너뜁니다. tokenCount={}", registrationTokens.size());
+		metrics.recordSkipped(registrationTokens.size());
+		return new FcmSendResult(0, 0, List.of());
 	}
 }

--- a/src/main/java/com/buyeoon/notification/push/PushNotificationMetrics.java
+++ b/src/main/java/com/buyeoon/notification/push/PushNotificationMetrics.java
@@ -1,0 +1,50 @@
+package com.buyeoon.notification.push;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+/**
+ * FCM 발송의 비활성 skip, accepted, 실패, 무효 토큰 삭제와 queue drop 결과를 메트릭으로 집계한다. 어떤 메트릭에도
+ * 등록 토큰, 회원 ID나 알림 제목·본문을 태그·값으로 담지 않는다.
+ */
+@Component
+public class PushNotificationMetrics {
+
+	private final Counter skipped;
+	private final Counter accepted;
+	private final Counter failed;
+	private final Counter invalidTokenDeleted;
+	private final Counter queueDropped;
+
+	public PushNotificationMetrics(MeterRegistry registry) {
+		this.skipped = Counter.builder("push_notification.skipped").description("FCM 비활성화로 건너뛴 발송 대상 토큰 수")
+				.register(registry);
+		this.accepted = Counter.builder("push_notification.accepted").description("FCM이 접수한 토큰 수").register(registry);
+		this.failed = Counter.builder("push_notification.failed").description("FCM 발송에 실패한 토큰 수").register(registry);
+		this.invalidTokenDeleted = Counter.builder("push_notification.invalid_token_deleted")
+				.description("UNREGISTERED로 삭제한 등록 토큰 수").register(registry);
+		this.queueDropped = Counter.builder("push_notification.queue_dropped").description("executor 포화로 drop한 발송 요청 수")
+				.register(registry);
+	}
+
+	public void recordSkipped(int count) {
+		skipped.increment(count);
+	}
+
+	public void recordAccepted(int count) {
+		accepted.increment(count);
+	}
+
+	public void recordFailed(int count) {
+		failed.increment(count);
+	}
+
+	public void recordInvalidTokenDeleted(int count) {
+		invalidTokenDeleted.increment(count);
+	}
+
+	public void recordQueueDropped() {
+		queueDropped.increment();
+	}
+}

--- a/src/test/java/com/buyeoon/notification/application/PushNotificationPublisherIntegrationTests.java
+++ b/src/test/java/com/buyeoon/notification/application/PushNotificationPublisherIntegrationTests.java
@@ -4,20 +4,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.buyeoon.notification.entity.NotificationType;
 import com.buyeoon.notification.push.FcmClient;
+import com.buyeoon.notification.push.FcmSendResult;
 import com.buyeoon.notification.push.PushMessage;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -61,6 +70,12 @@ class PushNotificationPublisherIntegrationTests {
 
 	@Autowired
 	private PlatformTransactionManager transactionManager;
+
+	@Autowired
+	private MeterRegistry meterRegistry;
+
+	@Autowired
+	private Executor pushNotificationExecutor;
 
 	@BeforeEach
 	void resetFakeClient() {
@@ -180,6 +195,150 @@ class PushNotificationPublisherIntegrationTests {
 		assertThat(allDeliveredTokens).containsExactlyInAnyOrderElementsOf(expectedTokens);
 	}
 
+	@Test
+	@DisplayName("부분 실패에서 UNREGISTERED가 반환된 등록 토큰만 삭제된다")
+	void deletesOnlyUnregisteredTokens() throws Exception {
+		UUID memberId = insertActiveMember();
+		insertSessionWithToken(memberId, "unregistered-token", null, 30);
+		insertSessionWithToken(memberId, "kept-token", null, 30);
+		fakeFcmClient.expectInvocations(1);
+		fakeFcmClient.respondWith((tokens, message) -> new FcmSendResult(1, 1, List.of("unregistered-token")));
+
+		publisher.publish(memberId, NotificationType.BADGE, "제목", "본문", null, null, null);
+
+		assertThat(fakeFcmClient.awaitInvocations(5, TimeUnit.SECONDS)).isTrue();
+		awaitRemainingTokens(memberId, Set.of("kept-token"));
+	}
+
+	@Test
+	@DisplayName("인증·일시 장애·내부 오류 등 UNREGISTERED 이외 오류가 반환된 등록 토큰은 유지된다")
+	void keepsTokensWithNonUnregisteredErrors() throws Exception {
+		UUID memberId = insertActiveMemberWithToken("temporarily-failed-token");
+		fakeFcmClient.expectInvocations(1);
+		fakeFcmClient.respondWith((tokens, message) -> new FcmSendResult(0, 1, List.of()));
+
+		publisher.publish(memberId, NotificationType.BADGE, "제목", "본문", null, null, null);
+
+		assertThat(fakeFcmClient.awaitInvocations(5, TimeUnit.SECONDS)).isTrue();
+		awaitRemainingTokens(memberId, Set.of("temporarily-failed-token"));
+	}
+
+	@Test
+	@DisplayName("FCM 예외는 애플리케이션에서 재시도하지 않는다")
+	void doesNotRetryAfterFcmException() throws Exception {
+		UUID memberId = insertActiveMemberWithToken("failing-token");
+		fakeFcmClient.expectInvocations(1);
+		fakeFcmClient.respondWith((tokens, message) -> {
+			throw new RuntimeException("FCM 발송 실패");
+		});
+
+		publisher.publish(memberId, NotificationType.BADGE, "제목", "본문", null, null, null);
+
+		assertThat(fakeFcmClient.awaitInvocations(5, TimeUnit.SECONDS)).isTrue();
+		Thread.sleep(300);
+		assertThat(fakeFcmClient.callCount()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("executor의 worker 2개와 queue 100이 모두 사용 중이면 새 발송 요청을 drop하고 호출 thread에서 실행하지 않는다")
+	void dropsWhenExecutorSaturated() throws Exception {
+		CountDownLatch started = new CountDownLatch(2);
+		CountDownLatch release = new CountDownLatch(1);
+		CountDownLatch finished = new CountDownLatch(102);
+		for (int i = 0; i < 102; i++) {
+			pushNotificationExecutor.execute(() -> {
+				started.countDown();
+				try {
+					release.await();
+				} catch (InterruptedException exception) {
+					Thread.currentThread().interrupt();
+				} finally {
+					finished.countDown();
+				}
+			});
+		}
+		try {
+			assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+			double dropsBefore = meterRegistry.get("push_notification.queue_dropped").counter().count();
+			UUID memberId = insertActiveMemberWithToken("saturated-token");
+
+			publisher.publish(memberId, NotificationType.BADGE, "제목", "본문", null, null, null);
+
+			assertThat(meterRegistry.get("push_notification.queue_dropped").counter().count())
+					.isEqualTo(dropsBefore + 1);
+			assertThat(fakeFcmClient.callCount()).isZero();
+		} finally {
+			release.countDown();
+			assertThat(finished.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+	}
+
+	@Test
+	@DisplayName("accepted, 실패, 무효 토큰 삭제 결과를 메트릭으로 구분할 수 있다")
+	void recordsDistinctMetricsPerOutcome() throws Exception {
+		UUID memberId = insertActiveMember();
+		insertSessionWithToken(memberId, "accepted-token", null, 30);
+		insertSessionWithToken(memberId, "unregistered-metric-token", null, 30);
+		double acceptedBefore = meterRegistry.get("push_notification.accepted").counter().count();
+		double failedBefore = meterRegistry.get("push_notification.failed").counter().count();
+		double deletedBefore = meterRegistry.get("push_notification.invalid_token_deleted").counter().count();
+		fakeFcmClient.expectInvocations(1);
+		fakeFcmClient.respondWith((tokens, message) -> new FcmSendResult(1, 1, List.of("unregistered-metric-token")));
+
+		publisher.publish(memberId, NotificationType.BADGE, "제목", "본문", null, null, null);
+
+		assertThat(fakeFcmClient.awaitInvocations(5, TimeUnit.SECONDS)).isTrue();
+		awaitRemainingTokens(memberId, Set.of("accepted-token"));
+		assertThat(meterRegistry.get("push_notification.accepted").counter().count()).isEqualTo(acceptedBefore + 1);
+		assertThat(meterRegistry.get("push_notification.failed").counter().count()).isEqualTo(failedBefore + 1);
+		assertThat(meterRegistry.get("push_notification.invalid_token_deleted").counter().count())
+				.isEqualTo(deletedBefore + 1);
+	}
+
+	@Test
+	@DisplayName("모든 성공·오류 경로의 로그에 등록 토큰, 회원 ID와 알림 제목·본문이 노출되지 않는다")
+	void logsExcludeSensitiveFields() throws Exception {
+		Logger logger = (Logger) LoggerFactory.getLogger(PushNotificationPublisher.class);
+		ListAppender<ILoggingEvent> appender = new ListAppender<>();
+		appender.start();
+		logger.addAppender(appender);
+		try {
+			UUID memberId = insertActiveMemberWithToken("sensitive-registration-token");
+			fakeFcmClient.expectInvocations(1);
+			fakeFcmClient
+					.respondWith((tokens, message) -> new FcmSendResult(0, 1, List.of("sensitive-registration-token")));
+
+			publisher.publish(memberId, NotificationType.BADGE, "민감한 제목", "민감한 본문", null, null, null);
+
+			assertThat(fakeFcmClient.awaitInvocations(5, TimeUnit.SECONDS)).isTrue();
+			awaitRemainingTokens(memberId, Set.of());
+			List<String> messages = appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+			assertThat(messages).isNotEmpty();
+			String combined = String.join("\n", messages);
+			assertThat(combined).doesNotContain("sensitive-registration-token").doesNotContain(memberId.toString())
+					.doesNotContain("민감한 제목").doesNotContain("민감한 본문");
+		} finally {
+			logger.detachAppender(appender);
+		}
+	}
+
+	private void awaitRemainingTokens(UUID memberId, Set<String> expectedTokens) throws InterruptedException {
+		long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+		while (System.nanoTime() < deadline) {
+			List<String> remaining = jdbcTemplate.query("""
+					SELECT push_token.registration_token
+					FROM push_tokens push_token
+					JOIN auth_sessions session ON session.id = push_token.auth_session_id
+					WHERE session.member_id = ?
+					""", (resultSet, rowNumber) -> resultSet.getString("registration_token"), memberId);
+			if (Set.copyOf(remaining).equals(expectedTokens)) {
+				return;
+			}
+			Thread.sleep(50);
+		}
+		throw new AssertionError("무효 토큰 삭제가 기대한 상태로 수렴하지 않았습니다.");
+	}
+
 	private UUID insertActiveMemberWithToken(String registrationToken) {
 		UUID memberId = insertActiveMember();
 		insertSessionWithToken(memberId, registrationToken, null, 30);
@@ -233,25 +392,39 @@ class PushNotificationPublisherIntegrationTests {
 		}
 	}
 
-	/** 실제 FCM 대신 발송 요청을 기록하는 테스트 대역이다. */
+	/** 실제 FCM 대신 발송 요청을 기록하는 테스트 대역이다. 호출 결과는 {@link #respondWith}로 구성한다. */
 	static class FakeFcmClient implements FcmClient {
 
 		private final List<Invocation> invocations = new CopyOnWriteArrayList<>();
+		private final AtomicInteger callCount = new AtomicInteger();
 		private volatile CountDownLatch latch = new CountDownLatch(0);
+		private volatile FcmResponder responder = (tokens, message) -> new FcmSendResult(tokens.size(), 0, List.of());
 
 		@Override
-		public void sendMulticast(List<String> registrationTokens, PushMessage message) {
-			invocations.add(new Invocation(List.copyOf(registrationTokens), message));
-			latch.countDown();
+		public FcmSendResult sendMulticast(List<String> registrationTokens, PushMessage message) {
+			callCount.incrementAndGet();
+			try {
+				FcmSendResult result = responder.respond(registrationTokens, message);
+				invocations.add(new Invocation(List.copyOf(registrationTokens), message, result));
+				return result;
+			} finally {
+				latch.countDown();
+			}
 		}
 
 		void reset() {
 			invocations.clear();
+			callCount.set(0);
 			latch = new CountDownLatch(0);
+			responder = (tokens, message) -> new FcmSendResult(tokens.size(), 0, List.of());
 		}
 
 		void expectInvocations(int count) {
 			latch = new CountDownLatch(count);
+		}
+
+		void respondWith(FcmResponder responder) {
+			this.responder = responder;
 		}
 
 		boolean awaitInvocations(long timeout, TimeUnit unit) throws InterruptedException {
@@ -262,7 +435,16 @@ class PushNotificationPublisherIntegrationTests {
 			return List.copyOf(invocations);
 		}
 
-		record Invocation(List<String> tokens, PushMessage message) {
+		int callCount() {
+			return callCount.get();
+		}
+
+		interface FcmResponder {
+
+			FcmSendResult respond(List<String> tokens, PushMessage message);
+		}
+
+		record Invocation(List<String> tokens, PushMessage message, FcmSendResult result) {
 		}
 	}
 }

--- a/src/test/java/com/buyeoon/notification/push/FcmClientConfigurationTests.java
+++ b/src/test/java/com/buyeoon/notification/push/FcmClientConfigurationTests.java
@@ -2,6 +2,8 @@ package com.buyeoon.notification.push;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Assumptions;
@@ -12,7 +14,8 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 class FcmClientConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withUserConfiguration(FcmClientConfiguration.class);
+			.withBean(MeterRegistry.class, SimpleMeterRegistry::new)
+			.withUserConfiguration(FcmClientConfiguration.class, PushNotificationMetrics.class);
 
 	@Test
 	@DisplayName("FCM_ENABLED=false이면 Firebase 자격증명 없이 no-op 구현으로 정상 기동한다")

--- a/src/test/java/com/buyeoon/notification/push/FirebaseFcmClientTests.java
+++ b/src/test/java/com/buyeoon/notification/push/FirebaseFcmClientTests.java
@@ -1,20 +1,65 @@
 package com.buyeoon.notification.push;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.buyeoon.notification.entity.NotificationType;
+import com.google.firebase.ErrorCode;
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.SendResponse;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-/** 실제 네트워크 호출 없이 FCM 메시지 구성 규칙만 검증한다. */
+/** 실제 네트워크 호출 없이 FCM 메시지 구성 규칙과 응답 해석 규칙을 검증한다. */
 class FirebaseFcmClientTests {
 
 	private final FirebaseFcmClient client = new FirebaseFcmClient(null);
+
+	@Test
+	@DisplayName("UNREGISTERED가 반환된 토큰만 삭제 대상으로 반환하고 다른 오류 토큰은 유지한다")
+	void mapsOnlyUnregisteredTokensForDeletion() throws Exception {
+		FirebaseMessaging firebaseMessaging = mock(FirebaseMessaging.class);
+		SendResponse success = mock(SendResponse.class);
+		when(success.isSuccessful()).thenReturn(true);
+		SendResponse unregistered = mock(SendResponse.class);
+		when(unregistered.isSuccessful()).thenReturn(false);
+		when(unregistered.getException()).thenReturn(exceptionWith(MessagingErrorCode.UNREGISTERED));
+		SendResponse internalError = mock(SendResponse.class);
+		when(internalError.isSuccessful()).thenReturn(false);
+		when(internalError.getException()).thenReturn(exceptionWith(MessagingErrorCode.INTERNAL));
+		BatchResponse batchResponse = mock(BatchResponse.class);
+		when(batchResponse.getResponses()).thenReturn(List.of(success, unregistered, internalError));
+		when(batchResponse.getSuccessCount()).thenReturn(1);
+		when(batchResponse.getFailureCount()).thenReturn(2);
+		when(firebaseMessaging.sendEachForMulticast(any())).thenReturn(batchResponse);
+		FirebaseFcmClient clientWithMock = new FirebaseFcmClient(firebaseMessaging);
+
+		FcmSendResult result = clientWithMock.sendMulticast(List.of("active", "unregistered", "temporarily-failed"),
+				new PushMessage(NotificationType.BADGE, "제목", "본문", null, null, null));
+
+		assertThat(result.acceptedCount()).isEqualTo(1);
+		assertThat(result.failedCount()).isEqualTo(2);
+		assertThat(result.unregisteredTokens()).containsExactly("unregistered");
+	}
+
+	private FirebaseMessagingException exceptionWith(MessagingErrorCode errorCode) throws Exception {
+		Method factory = FirebaseMessagingException.class.getDeclaredMethod("withMessagingErrorCode",
+				com.google.firebase.FirebaseException.class, MessagingErrorCode.class);
+		factory.setAccessible(true);
+		com.google.firebase.FirebaseException base = new com.google.firebase.FirebaseException(ErrorCode.UNKNOWN, "실패",
+				null);
+		return (FirebaseMessagingException) factory.invoke(null, base, errorCode);
+	}
 
 	@Test
 	@DisplayName("제목·본문은 notification payload에, 유형과 선택 식별자는 data payload에 담고 TTL·collapse 정책은 지정하지 않는다")

--- a/src/test/java/com/buyeoon/notification/push/NoOpFcmClientTests.java
+++ b/src/test/java/com/buyeoon/notification/push/NoOpFcmClientTests.java
@@ -1,0 +1,27 @@
+package com.buyeoon.notification.push;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.buyeoon.notification.entity.NotificationType;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NoOpFcmClientTests {
+
+	@Test
+	@DisplayName("비활성화되어 건너뛴 발송 대상 토큰 수를 metric으로 관측할 수 있다")
+	void recordsSkippedTokenCount() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		NoOpFcmClient client = new NoOpFcmClient(new PushNotificationMetrics(registry));
+		PushMessage message = new PushMessage(NotificationType.BADGE, "제목", "본문", null, null, null);
+
+		FcmSendResult result = client.sendMulticast(List.of("token-1", "token-2"), message);
+
+		assertThat(result.acceptedCount()).isZero();
+		assertThat(result.failedCount()).isZero();
+		assertThat(result.unregisteredTokens()).isEmpty();
+		assertThat(registry.get("push_notification.skipped").counter().count()).isEqualTo(2);
+	}
+}


### PR DESCRIPTION
## Summary
- FCM batch 응답을 토큰별로 해석해 `UNREGISTERED` 등록 토큰만 회원 도메인의 공개 seam(`PushTargetQueryService.deleteRegistrationTokens`)으로 삭제하고, 다른 오류 토큰은 유지·재시도하지 않는다.
- push 발송 executor(worker 2, queue 100)가 포화되면 호출 thread에서 FCM을 실행하지 않고 새 요청을 drop한다.
- 비활성 skip, accepted, 실패, 무효 토큰 삭제, queue drop 건수를 `PushNotificationMetrics`(Micrometer Counter)와 구조화 로그로 구분해 관측하되, 등록 토큰·회원 ID·알림 제목·본문은 어떤 경로에서도 노출하지 않는다.
- FCM 접수 성공(`FcmSendResult.acceptedCount`)은 기기 전달 완료가 아닌 accepted 결과로만 표현한다.

Closes #157

## Test plan
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh` (spotbugs의 `PushNotificationPublisher` 생성자 `EI_EXPOSE_REP2` 경고는 `main`에도 이미 존재하는 기존 항목으로, 이번 변경으로 인한 회귀 아님)
- [x] `./gradlew test` (전체 통과, `PushNotificationPublisherIntegrationTests`에 UNREGISTERED만 삭제/다른 오류 토큰 유지/재시도 없음/executor 포화 drop/메트릭 구분/로그 PII 미노출 검증 6건 추가)
- [ ] `./scripts/test/docker-build.sh` — 로컬 `.env`가 이미 `V16__seed_draft_terms.sql`을 실행한 공유 Supabase 인스턴스를 가리키고 있어 재현 불가 (이번 변경과 무관한 환경 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szi5XzYR8PoX9upETfacF6