### PR TITLE
fix: 누락된 군민증 위치 확인 API를 main에 반영한다

### DIFF
--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -223,6 +223,27 @@ paths:
           $ref: '#/components/responses/CitizenCardOptionsSuccess'
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /citizen-cards/location-verification:
+    post:
+      tags: [CitizenCards]
+      summary: 군민증 발급 전 위치 확인
+      description: 군민증 발급 전에 현재 위치가 부여 행정구역 안인지 확인한다. 군민증 생성 시에도 위치를 다시 검증한다.
+      operationId: verifyCitizenCardLocation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Location'
+      responses:
+        '200':
+          $ref: '#/components/responses/CitizenCardLocationVerificationSuccess'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/CitizenCardCreationForbidden'
   /citizen-cards:
     post:
       tags: [CitizenCards]
@@ -969,6 +990,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CitizenCardOptionsEnvelope'
+    CitizenCardLocationVerificationSuccess:
+      description: 부여 내부 위치 확인 결과
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CitizenCardLocationVerificationEnvelope'
     CitizenCardSuccess:
       description: 디지털 군민증
       content:
@@ -2706,6 +2733,20 @@ components:
           properties:
             data:
               $ref: '#/components/schemas/CitizenCardOptionsData'
+    CitizenCardLocationVerificationData:
+      type: object
+      required: [withinBuyeo]
+      properties:
+        withinBuyeo:
+          type: boolean
+          example: true
+    CitizenCardLocationVerificationEnvelope:
+      allOf:
+        - $ref: '#/components/schemas/SuccessEnvelope'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/CitizenCardLocationVerificationData'
     CitizenCardEnvelope:
       allOf:
         - $ref: '#/components/schemas/SuccessEnvelope'

--- a/src/main/java/com/buyeoon/member/api/CitizenCardController.java
+++ b/src/main/java/com/buyeoon/member/api/CitizenCardController.java
@@ -5,6 +5,7 @@ import com.buyeoon.member.application.CitizenCardCreationService.CitizenCardComm
 import com.buyeoon.member.application.CitizenCardCreationService.CitizenCardView;
 import com.buyeoon.member.application.CitizenCardCreationService.LocationCommand;
 import com.buyeoon.member.application.CitizenCardCreator;
+import com.buyeoon.member.application.CitizenCardLocationVerifier;
 import com.buyeoon.member.application.CitizenCardQueryService;
 import com.buyeoon.member.application.CitizenCardQueryService.BarcodeView;
 import com.buyeoon.member.application.CitizenCardQueryService.CitizenCardOptionsView;
@@ -29,15 +30,24 @@ public class CitizenCardController {
 
 	private final CitizenCardQueryService citizenCards;
 	private final CitizenCardCreator citizenCardCreation;
+	private final CitizenCardLocationVerifier locationVerifier;
 
-	public CitizenCardController(CitizenCardQueryService citizenCards, CitizenCardCreator citizenCardCreation) {
+	public CitizenCardController(CitizenCardQueryService citizenCards, CitizenCardCreator citizenCardCreation,
+			CitizenCardLocationVerifier locationVerifier) {
 		this.citizenCards = citizenCards;
 		this.citizenCardCreation = citizenCardCreation;
+		this.locationVerifier = locationVerifier;
 	}
 
 	@GetMapping("/citizen-cards/options")
 	public SuccessResponse<CitizenCardOptionsView> getOptions() {
 		return SuccessResponse.of(citizenCards.getOptions());
+	}
+
+	@PostMapping("/citizen-cards/location-verification")
+	public SuccessResponse<LocationVerificationView> verifyLocation(@RequestBody JsonNode request) {
+		locationVerifier.verify(location(request));
+		return SuccessResponse.of(new LocationVerificationView(true));
 	}
 
 	@GetMapping("/citizen-cards/me")
@@ -71,6 +81,9 @@ public class CitizenCardController {
 		UUID themeId = uuid(request.get("themeId"));
 		LocationCommand location = location(request.get("location"));
 		return new CitizenCardCommand(displayName, characterId, themeId, location);
+	}
+
+	public record LocationVerificationView(boolean withinBuyeo) {
 	}
 
 	private String normalizedDisplayName(JsonNode node) {

--- a/src/main/java/com/buyeoon/member/application/CitizenCardCreationService.java
+++ b/src/main/java/com/buyeoon/member/application/CitizenCardCreationService.java
@@ -1,7 +1,6 @@
 package com.buyeoon.member.application;
 
 import com.buyeoon.common.api.SuccessResponse;
-import com.buyeoon.common.location.BuyeoBoundary;
 import com.buyeoon.common.storage.PublicImageUrlService;
 import com.buyeoon.member.api.InvalidCitizenCardRequestException;
 import com.buyeoon.member.application.CitizenCardQueryService.CardOptionView;
@@ -39,16 +38,16 @@ public final class CitizenCardCreationService implements CitizenCardCreator {
 
 	private final JdbcOperations jdbcOperations;
 	private final TransactionTemplate transactions;
-	private final BuyeoBoundary boundary;
+	private final CitizenCardLocationVerifier locationVerifier;
 	private final PublicImageUrlService imageUrls;
 	private final ObjectReader objectReader;
 	private final ObjectWriter objectWriter;
 
 	public CitizenCardCreationService(JdbcOperations jdbcOperations, PlatformTransactionManager transactionManager,
-			BuyeoBoundary boundary, PublicImageUrlService imageUrls, ObjectMapper objectMapper) {
+			CitizenCardLocationVerifier locationVerifier, PublicImageUrlService imageUrls, ObjectMapper objectMapper) {
 		this.jdbcOperations = jdbcOperations;
 		this.transactions = new TransactionTemplate(transactionManager);
-		this.boundary = boundary;
+		this.locationVerifier = locationVerifier;
 		this.imageUrls = imageUrls;
 		this.objectReader = objectMapper.reader();
 		this.objectWriter = objectMapper.writer();
@@ -57,9 +56,7 @@ public final class CitizenCardCreationService implements CitizenCardCreator {
 	@Override
 	public CitizenCardView create(UUID memberId, String idempotencyKey, CitizenCardCommand command) {
 		validateIdempotencyKey(idempotencyKey);
-		if (!boundary.covers(command.location().latitude(), command.location().longitude())) {
-			throw new OutsideBuyeoException();
-		}
+		locationVerifier.verify(command.location());
 		String requestHash = hash(command);
 		return Objects.requireNonNull(
 				transactions.execute(status -> createInTransaction(memberId, idempotencyKey, requestHash, command)),

--- a/src/main/java/com/buyeoon/member/application/CitizenCardLocationVerifier.java
+++ b/src/main/java/com/buyeoon/member/application/CitizenCardLocationVerifier.java
@@ -1,0 +1,21 @@
+package com.buyeoon.member.application;
+
+import com.buyeoon.common.location.BuyeoBoundary;
+import com.buyeoon.member.application.CitizenCardCreationService.LocationCommand;
+import org.springframework.stereotype.Service;
+
+@Service
+public final class CitizenCardLocationVerifier {
+
+	private final BuyeoBoundary boundary;
+
+	public CitizenCardLocationVerifier(BuyeoBoundary boundary) {
+		this.boundary = boundary;
+	}
+
+	public void verify(LocationCommand location) {
+		if (!boundary.covers(location.latitude(), location.longitude())) {
+			throw new OutsideBuyeoException();
+		}
+	}
+}

--- a/src/test/java/com/buyeoon/member/CitizenCardCreationIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/CitizenCardCreationIntegrationTests.java
@@ -136,6 +136,18 @@ class CitizenCardCreationIntegrationTests {
 				request("경계인", catalog.characterId(), catalog.themeId(), 36.2, 126.8)).andExpect(status().isCreated());
 	}
 
+	@Test
+	@DisplayName("군민증 발급 전 위치 확인은 부여 내부 여부를 반환한다")
+	void locationVerificationReturnsBoundaryResult() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+
+		performLocationVerification(member, locationRequest(36.27, 126.91)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true)).andExpect(jsonPath("$.data.withinBuyeo").value(true));
+
+		performLocationVerification(member, locationRequest(36.5, 127.2)).andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.data.code").value("OUTSIDE_BUYEO"));
+	}
+
 	/** 현재 필수 약관을 모두 동의하지 않은 회원은 군민증을 발급받을 수 없다. */
 	@Test
 	@DisplayName("현재 필수 약관 미동의는 군민증 생성을 거부한다")
@@ -307,6 +319,14 @@ class CitizenCardCreationIntegrationTests {
 				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
 	}
 
+	@Test
+	@DisplayName("발급 전 위치 확인에는 유효한 인증 세션이 필요하다")
+	void locationVerificationAuthenticationIsRequired() throws Exception {
+		mockMvc.perform(post("/citizen-cards/location-verification").contentType(MediaType.APPLICATION_JSON)
+				.content(locationRequest(36.27, 126.91))).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
 	private MvcResult concurrentCreate(AuthenticatedMember member, String body, CountDownLatch ready,
 			CountDownLatch start) throws Exception {
 		ready.countDown();
@@ -324,6 +344,13 @@ class CitizenCardCreationIntegrationTests {
 			request.header("Idempotency-Key", key);
 		}
 		return mockMvc.perform(request);
+	}
+
+	private org.springframework.test.web.servlet.ResultActions performLocationVerification(AuthenticatedMember member,
+			String body) throws Exception {
+		return mockMvc.perform(
+				post("/citizen-cards/location-verification").header("Authorization", "Bearer " + member.accessToken())
+						.contentType(MediaType.APPLICATION_JSON).content(body));
 	}
 
 	private AuthenticatedMember insertAuthenticatedMember() {
@@ -389,6 +416,11 @@ class CitizenCardCreationIntegrationTests {
 		return "{\"displayName\":\"" + displayName + "\",\"characterId\":\"" + characterId + "\",\"themeId\":\""
 				+ themeId + "\",\"location\":{\"latitude\":" + latitude + ",\"longitude\":" + longitude
 				+ ",\"accuracyMeters\":5.5,\"capturedAt\":\"2026-08-12T15:30:00+09:00\"}}";
+	}
+
+	private String locationRequest(double latitude, double longitude) {
+		return "{\"latitude\":" + latitude + ",\"longitude\":" + longitude
+				+ ",\"accuracyMeters\":5.5,\"capturedAt\":\"2026-08-12T15:30:00+09:00\"}";
 	}
 
 	private void assertCreationStateIsEmpty(UUID memberId) {


### PR DESCRIPTION
## 변경 사항
- 기존 PR #109의 군민증 발급 전 위치 확인 API를 최신 main에 재반영
- POST /citizen-cards/location-verification 추가
- 군민증 생성과 사전 위치 확인이 같은 부여 경계 판정기를 사용하도록 통합
- OpenAPI 원본 문서 및 통합 테스트 반영
- 최신 main에서 제거된 swagger 산출물은 복원하지 않음

## 누락 원인
PR #109가 main이 아닌 이미 병합된 feat/location-terms-onboarding 브랜치를 대상으로 병합되어 main에 전파되지 않았습니다.

## 검증
- ./gradlew test --tests com.buyeoon.member.CitizenCardCreationIntegrationTests
- ./gradlew test
- 전체 테스트 BUILD SUCCESSFUL