### PR TITLE
feat: notification 응답에 type별 icon URL 추가

### DIFF
--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -2576,7 +2576,7 @@ components:
       enum: [POINT, BADGE, NEARBY_QUIZ, DISCOUNT, CITIZEN_CARD, BUYEO_NEWS]
     Notification:
       type: object
-      required: [notificationId, type, title, body, read, occurredAt]
+      required: [notificationId, type, title, body, read, occurredAt, iconUrl]
       properties:
         notificationId:
           type: string
@@ -2596,6 +2596,9 @@ components:
           type: [string, 'null']
         targetId:
           type: [string, 'null']
+        iconUrl:
+          type: string
+          format: uri
     PushTokenUpdateRequest:
       type: object
       additionalProperties: false

--- a/src/main/java/com/buyeoon/notification/application/NotificationQueryService.java
+++ b/src/main/java/com/buyeoon/notification/application/NotificationQueryService.java
@@ -1,5 +1,6 @@
 package com.buyeoon.notification.application;
 
+import com.buyeoon.common.storage.PublicImageUrlService;
 import com.buyeoon.notification.entity.NotificationType;
 import com.buyeoon.notification.repository.NotificationProjection;
 import com.buyeoon.notification.repository.NotificationQueryRepository;
@@ -16,9 +17,12 @@ public class NotificationQueryService {
 	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
 
 	private final NotificationQueryRepository notificationQueryRepository;
+	private final PublicImageUrlService publicImageUrlService;
 
-	public NotificationQueryService(NotificationQueryRepository notificationQueryRepository) {
+	public NotificationQueryService(NotificationQueryRepository notificationQueryRepository,
+			PublicImageUrlService publicImageUrlService) {
 		this.notificationQueryRepository = notificationQueryRepository;
+		this.publicImageUrlService = publicImageUrlService;
 	}
 
 	public NotificationListView list(UUID memberId, NotificationCursor cursor, int size) {
@@ -38,8 +42,9 @@ public class NotificationQueryService {
 
 	private NotificationItemView toView(NotificationProjection row) {
 		String targetId = row.targetId() == null ? null : row.targetId().toString();
+		String iconUrl = publicImageUrlService.create(row.type().iconKey());
 		return new NotificationItemView(row.id(), row.type(), row.title(), row.body(), row.read(),
-				row.occurredAt().atZone(ASIA_SEOUL), row.targetType(), targetId);
+				row.occurredAt().atZone(ASIA_SEOUL), row.targetType(), targetId, iconUrl);
 	}
 
 	public record NotificationListView(List<NotificationItemView> items, PageInfoView page) {
@@ -49,7 +54,7 @@ public class NotificationQueryService {
 	}
 
 	public record NotificationItemView(UUID notificationId, NotificationType type, String title, String body,
-			boolean read, ZonedDateTime occurredAt, String targetType, String targetId) {
+			boolean read, ZonedDateTime occurredAt, String targetType, String targetId, String iconUrl) {
 	}
 
 	public record PageInfoView(String nextCursor, boolean hasNext) {

--- a/src/main/java/com/buyeoon/notification/application/NotificationReadService.java
+++ b/src/main/java/com/buyeoon/notification/application/NotificationReadService.java
@@ -1,5 +1,6 @@
 package com.buyeoon.notification.application;
 
+import com.buyeoon.common.storage.PublicImageUrlService;
 import com.buyeoon.notification.entity.NotificationEntity;
 import com.buyeoon.notification.entity.NotificationType;
 import com.buyeoon.notification.repository.NotificationRepository;
@@ -15,9 +16,12 @@ public class NotificationReadService {
 	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
 
 	private final NotificationRepository notificationRepository;
+	private final PublicImageUrlService publicImageUrlService;
 
-	public NotificationReadService(NotificationRepository notificationRepository) {
+	public NotificationReadService(NotificationRepository notificationRepository,
+			PublicImageUrlService publicImageUrlService) {
 		this.notificationRepository = notificationRepository;
+		this.publicImageUrlService = publicImageUrlService;
 	}
 
 	@Transactional
@@ -32,10 +36,11 @@ public class NotificationReadService {
 		return new NotificationView(notification.getId(), notification.getType(), notification.getTitle(),
 				notification.getBody(), notification.getReadAt() != null,
 				notification.getOccurredAt().atZone(ASIA_SEOUL), notification.getTargetType(),
-				notification.getTargetId() == null ? null : notification.getTargetId().toString());
+				notification.getTargetId() == null ? null : notification.getTargetId().toString(),
+				publicImageUrlService.create(notification.getType().iconKey()));
 	}
 
 	public record NotificationView(UUID notificationId, NotificationType type, String title, String body, boolean read,
-			ZonedDateTime occurredAt, String targetType, String targetId) {
+			ZonedDateTime occurredAt, String targetType, String targetId, String iconUrl) {
 	}
 }

--- a/src/main/java/com/buyeoon/notification/entity/NotificationType.java
+++ b/src/main/java/com/buyeoon/notification/entity/NotificationType.java
@@ -6,5 +6,9 @@ public enum NotificationType {
 	NEARBY_QUIZ,
 	DISCOUNT,
 	CITIZEN_CARD,
-	BUYEO_NEWS
+	BUYEO_NEWS;
+
+	public String iconKey() {
+		return "public/notifications/" + name().toLowerCase() + ".png";
+	}
 }


### PR DESCRIPTION
## Summary
- NotificationType에 S3 `public/notifications/{type}.png` 아이콘 키를 매핑하는 `iconKey()` 추가
- 목록 조회(`NotificationQueryService`) 및 읽음 처리(`NotificationReadService`) 응답에 기존 `PublicImageUrlService`로 생성한 presigned `iconUrl` 필드 추가
- 실제 S3 아이콘 파일 업로드는 별도 진행 예정 (이번 PR은 코드 반영만)

## Test plan
- [x] `./gradlew compileJava`
- [ ] S3에 `public/notifications/{point,badge,nearby_quiz,discount,citizen_card,buyeo_news}.png` 업로드 후 응답 확인

Claude-Session: https://claude.ai/code/session_01HhNTZf9N6JpyKfoHQQv7aw