### PR TITLE
test: 알림 통합 테스트 설정과 executor 격리를 보완한다

### DIFF
--- a/src/test/java/com/buyeoon/notification/NotificationListIntegrationTests.java
+++ b/src/test/java/com/buyeoon/notification/NotificationListIntegrationTests.java
@@ -14,7 +14,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,6 +54,18 @@ class NotificationListIntegrationTests {
 
 	@Autowired
 	private AccessTokenService accessTokenService;
+
+	@BeforeAll
+	static void configureAwsCredentials() {
+		System.setProperty("aws.accessKeyId", "test-access-key");
+		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	@AfterAll
+	static void clearAwsCredentials() {
+		System.clearProperty("aws.accessKeyId");
+		System.clearProperty("aws.secretAccessKey");
+	}
 
 	@AfterEach
 	void cleanUp() {
@@ -252,6 +266,8 @@ class NotificationListIntegrationTests {
 		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
 		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
 		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("storage.images.bucket", () -> "buyeoon-test-images");
+		registry.add("storage.images.region", () -> "ap-northeast-2");
 		registry.add("spring.flyway.enabled", () -> true);
 		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
 		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");

--- a/src/test/java/com/buyeoon/notification/NotificationReadIntegrationTests.java
+++ b/src/test/java/com/buyeoon/notification/NotificationReadIntegrationTests.java
@@ -13,7 +13,9 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,6 +54,18 @@ class NotificationReadIntegrationTests {
 
 	@Autowired
 	private AccessTokenService accessTokenService;
+
+	@BeforeAll
+	static void configureAwsCredentials() {
+		System.setProperty("aws.accessKeyId", "test-access-key");
+		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	@AfterAll
+	static void clearAwsCredentials() {
+		System.clearProperty("aws.accessKeyId");
+		System.clearProperty("aws.secretAccessKey");
+	}
 
 	@AfterEach
 	void cleanUp() {
@@ -190,6 +204,8 @@ class NotificationReadIntegrationTests {
 		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
 		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
 		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("storage.images.bucket", () -> "buyeoon-test-images");
+		registry.add("storage.images.region", () -> "ap-northeast-2");
 		registry.add("spring.flyway.enabled", () -> true);
 		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
 		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");

--- a/src/test/java/com/buyeoon/notification/application/PushNotificationPublisherIntegrationTests.java
+++ b/src/test/java/com/buyeoon/notification/application/PushNotificationPublisherIntegrationTests.java
@@ -33,6 +33,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -242,23 +243,18 @@ class PushNotificationPublisherIntegrationTests {
 	@Test
 	@DisplayName("executor의 worker 2개와 queue 100이 모두 사용 중이면 새 발송 요청을 drop하고 호출 thread에서 실행하지 않는다")
 	void dropsWhenExecutorSaturated() throws Exception {
+		awaitExecutorIdle();
 		CountDownLatch started = new CountDownLatch(2);
 		CountDownLatch release = new CountDownLatch(1);
 		CountDownLatch finished = new CountDownLatch(102);
-		for (int i = 0; i < 102; i++) {
-			pushNotificationExecutor.execute(() -> {
-				started.countDown();
-				try {
-					release.await();
-				} catch (InterruptedException exception) {
-					Thread.currentThread().interrupt();
-				} finally {
-					finished.countDown();
-				}
-			});
-		}
 		try {
+			for (int i = 0; i < 2; i++) {
+				submitBlockingTask(started, release, finished);
+			}
 			assertThat(started.await(5, TimeUnit.SECONDS)).isTrue();
+			for (int i = 0; i < 100; i++) {
+				submitBlockingTask(started, release, finished);
+			}
 			double dropsBefore = meterRegistry.get("push_notification.queue_dropped").counter().count();
 			UUID memberId = insertActiveMemberWithToken("saturated-token");
 
@@ -271,6 +267,31 @@ class PushNotificationPublisherIntegrationTests {
 			release.countDown();
 			assertThat(finished.await(10, TimeUnit.SECONDS)).isTrue();
 		}
+	}
+
+	private void submitBlockingTask(CountDownLatch started, CountDownLatch release, CountDownLatch finished) {
+		pushNotificationExecutor.execute(() -> {
+			started.countDown();
+			try {
+				release.await();
+			} catch (InterruptedException exception) {
+				Thread.currentThread().interrupt();
+			} finally {
+				finished.countDown();
+			}
+		});
+	}
+
+	private void awaitExecutorIdle() throws InterruptedException {
+		ThreadPoolTaskExecutor executor = (ThreadPoolTaskExecutor) pushNotificationExecutor;
+		long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+		while (System.nanoTime() < deadline) {
+			if (executor.getActiveCount() == 0 && executor.getThreadPoolExecutor().getQueue().isEmpty()) {
+				return;
+			}
+			Thread.sleep(10);
+		}
+		throw new AssertionError("이전 비동기 발송 작업이 종료되지 않았습니다.");
 	}
 
 	@Test


### PR DESCRIPTION
## 변경 내용
- FCM executor 포화 테스트 시작 전 공유 executor가 비었는지 확인합니다.
- worker 2개가 실제로 점유된 뒤 queue 100개를 채워 포화 상태를 결정적으로 만듭니다.
- 작업 제출 중 예외가 발생해도 blocking 작업을 반드시 해제하도록 정리 범위를 보완합니다.
- 알림 목록/읽음 통합 테스트에 이미지 버킷·리전과 테스트용 AWS 자격증명을 추가합니다.

## 원인
- PR #180의 포화 테스트가 이전 비동기 작업과 경쟁하면 직접 제출 단계에서 예외가 발생하고 executor를 점유한 작업이 남아 뒤 테스트까지 연쇄 실패했습니다.
- PR #182는 PublicImageUrlService를 새로 사용하지만 두 알림 통합 테스트에 S3 presigner 설정이 없었습니다.

## 검증
- 관련 알림·FCM 통합 테스트 25개 통과
- ./gradlew test --no-daemon 전체 460개 통과

PR #181의 군민증 위치 확인 API 운영 배포를 막던 테스트 게이트를 복구합니다.