### PR TITLE
fix: PointSettlementIntegrationTests가 포인트 기부 배지 지급을 반영하도록 수정

### DIFF
--- a/src/test/java/com/buyeoon/point/PointSettlementIntegrationTests.java
+++ b/src/test/java/com/buyeoon/point/PointSettlementIntegrationTests.java
@@ -74,6 +74,7 @@ class PointSettlementIntegrationTests {
 
 	@AfterEach
 	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM member_badges");
 		jdbcTemplate.update("DELETE FROM idempotency_requests");
 		jdbcTemplate.update("DELETE FROM point_settlements");
 		jdbcTemplate.update("DELETE FROM point_transactions");
@@ -101,7 +102,8 @@ class PointSettlementIntegrationTests {
 				.andExpect(jsonPath("$.data.remainingBalance").value(500))
 				.andExpect(jsonPath("$.data.expiresAt").isEmpty()).andExpect(jsonPath("$.data.settledAt").isString())
 				.andExpect(jsonPath("$.data.newlyAwardedBadges").isArray())
-				.andExpect(jsonPath("$.data.newlyAwardedBadges.length()").value(0));
+				.andExpect(jsonPath("$.data.newlyAwardedBadges.length()").value(1))
+				.andExpect(jsonPath("$.data.newlyAwardedBadges[0].name").value("사비의 마음"));
 
 		assertThat(jdbcTemplate.queryForObject(
 				"SELECT COALESCE(SUM(amount),0) FROM point_transactions WHERE member_id = ?", Long.class,
@@ -399,6 +401,8 @@ class PointSettlementIntegrationTests {
 		registry.add("spring.flyway.enabled", () -> true);
 		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
 		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("storage.images.bucket", () -> "buyeoon-test-images");
+		registry.add("storage.images.region", () -> "ap-northeast-2");
 	}
 
 	private record AuthenticatedMember(UUID memberId, String accessToken) {


### PR DESCRIPTION
## Summary
- V17 배지 catalog 시딩(#191)이 `POINT_DONATION_COUNT>=1` 조건의 "사비의 마음" 배지를 추가하면서 `LEAVE_TO_BUYEO` 정산마다 배지가 지급되게 됐지만, `PointSettlementIntegrationTests`는 갱신되지 않아 CI에서 13개 테스트가 실패하고 있었음
- `storage.images.bucket`/`region` 설정 누락으로 배지 아이콘 URL 생성 시 `IllegalStateException` 발생 → 설정 추가
- `newlyAwardedBadges` 개수 assertion이 0으로 고정되어 있던 것을 실제 동작(1개 지급)에 맞게 수정
- `@AfterEach` cleanup 순서상 `member_badges`를 먼저 지우지 않아 `trips` 삭제 시 FK 위반 발생 → 삭제 순서에 추가

## Test plan
- [x] `./gradlew test --tests "com.buyeoon.point.PointSettlementIntegrationTests"` 15/15 통과
- [x] `./gradlew test` 전체 스위트 460/460 통과
- [x] `./gradlew spotlessCheck checkstyleTest` 통과

https://claude.ai/code/session_01TSLwpBiVTdb5RfwJKNxdYA