### PR TITLE
test: 정산 통합 테스트에 S3 presign용 AWS credential 설정 추가

### DIFF
--- a/src/test/java/com/buyeoon/point/PointSettlementIntegrationTests.java
+++ b/src/test/java/com/buyeoon/point/PointSettlementIntegrationTests.java
@@ -19,7 +19,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -66,6 +68,18 @@ class PointSettlementIntegrationTests {
 	private PointSettlementService pointSettlementService;
 
 	private AuthenticatedMember member;
+
+	@BeforeAll
+	static void configureAwsCredentials() {
+		System.setProperty("aws.accessKeyId", "test-access-key");
+		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	@AfterAll
+	static void clearAwsCredentials() {
+		System.clearProperty("aws.accessKeyId");
+		System.clearProperty("aws.secretAccessKey");
+	}
 
 	@BeforeEach
 	void setUpMember() {


### PR DESCRIPTION
## 원인

CI `deploy` 잡의 `./gradlew test`에서 `PointSettlementIntegrationTests` 5개 테스트가 실패:

```
SdkClientException: Unable to load credentials from any of the providers in the chain ...
    at DefaultS3Presigner.presignGetObject(...)
```

V17 배지 카탈로그 1차 시딩(#191)으로 **"사비의 마음"** 배지에 `image_key`가 생기면서, 정산 응답(`PointSettlementService.toView`)이 `PublicImageUrlService.create()` → `S3Presigner.presignGetObject()`를 타게 됐다. `presignGetObject`는 네트워크 요청 없이 로컬 서명만 계산하지만 credential이 필요하다.

같은 흐름을 다루는 `PointSettlementBadgeAwardIntegrationTests`는 `@BeforeAll`에서 가짜 AWS credential을 주입하고 있어 통과했지만, `PointSettlementIntegrationTests`는 이 블록이 빠져 있어 credential provider chain이 비어 실패했다.

## 수정

`PointSettlementIntegrationTests`에 다른 통합 테스트와 동일하게 `@BeforeAll`/`@AfterAll`로 가짜 AWS credential(`aws.accessKeyId`/`aws.secretAccessKey`)을 주입/해제하는 블록을 추가했다. CI/시크릿 변경 없음.

## 검증

- `./gradlew test --tests "com.buyeoon.point.PointSettlementIntegrationTests"` → BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)