### PR TITLE
test: 비사진 제출 배지 검증을 '추억 수집가'로 한정

### DIFF
--- a/src/test/java/com/buyeoon/mission/MissionPhotoBadgeAwardIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionPhotoBadgeAwardIntegrationTests.java
@@ -145,8 +145,11 @@ class MissionPhotoBadgeAwardIntegrationTests {
 
 		for (int i = 1; i <= 15; i++) {
 			UUID missionId = insertOxMission(place, "OX 미션 " + i, 10);
+			// OX 정답 제출은 '백제 박사'·'무결점'·'집중력' 등 퀴즈 배지를 정당하게 지급할 수 있으므로,
+			// 새로 지급된 배지가 '추억 수집가'(인증 사진 배지)가 아닌지로 좁혀 검증한다.
 			mockMvc.perform(submit(missionId, "ox-submit-" + i, oxRequest(tripId))).andExpect(status().isOk())
-					.andExpect(jsonPath("$.data.newlyAwardedBadges", hasSize(0)));
+					.andExpect(jsonPath("$.data.newlyAwardedBadges[?(@.badgeId == '" + MEMORY_COLLECTOR_BADGE_ID + "')]",
+							hasSize(0)));
 		}
 
 		assertThat(


### PR DESCRIPTION
## 문제

`MissionPhotoBadgeAwardIntegrationTests.nonPhotoSubmissionsDoNotCountTowardPhotoMetric`이 CI에서 실패합니다.

```
JSON path "$.data.newlyAwardedBadges"
Expected: a collection with size <0>
     but: collection size was <1>
```

## 원인

이 테스트는 시드 배지 카탈로그를 그대로 둔 채 OX 정답을 15회 제출하는데, OX 정답 제출은 퀴즈 계열 메트릭(`QUIZ_CORRECT_COUNT`, `QUIZ_CORRECT_STREAK`, `QUIZ_CORRECT_WITHIN_60_MINUTES_COUNT`)을 함께 판정하므로 아래 퀴즈 배지를 정당하게 지급합니다.

- 5회: 무결점 (`QUIZ_CORRECT_STREAK >= 5`)
- 10회: 집중력 (`QUIZ_CORRECT_WITHIN_60_MINUTES_COUNT >= 10`)
- 15회: 백제 박사 (`QUIZ_CORRECT_COUNT >= 15`)

기존 단언은 "사진 배지가 아님"이 아니라 "아무 배지도 지급 안 됨"(`hasSize(0)`)을 검증해 실패했습니다. 다른 퀴즈 배지 통합 테스트들은 `@BeforeEach`에서 카탈로그를 비워 이 간섭을 회피하지만, 이 테스트는 실제 시드 배지를 사용해 잠재돼 있던 문제가 드러났습니다.

## 수정

"아무 배지도 없음" 대신 "새로 지급된 배지 중 `추억 수집가`가 없음"으로 좁혀 검증합니다.

```java
.andExpect(jsonPath("$.data.newlyAwardedBadges[?(@.badgeId == '" + MEMORY_COLLECTOR_BADGE_ID + "')]", hasSize(0)));
```

최종 `member_badges` 검증은 기존대로 유지되어 의도가 이중으로 보장됩니다.

## 검증

`MissionPhotoBadgeAwardIntegrationTests` 전체 통과 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
