### PR TITLE
ci: Flyway 마이그레이션 버전 중복 검사 워크플로우 추가

### DIFF
--- a/.github/workflows/check-migration-versions.yml
+++ b/.github/workflows/check-migration-versions.yml
@@ -1,0 +1,43 @@
+name: Check Flyway Migration Versions
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/main/resources/db/migration/**'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+
+      - name: Check for duplicate Flyway version numbers
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          migrations_dir="src/main/resources/db/migration"
+
+          # 'V<version>__<description>.sql' 형식에서 'V' 뒤 버전 부분만 추출해 중복을 찾는다.
+          # 예: V1__initial_schema.sql -> 1, V9.1__add_location_term_type.sql -> 9.1
+          duplicates="$(
+            find "${migrations_dir}" -maxdepth 1 -type f -name 'V*__*.sql' -printf '%f\n' \
+              | sed -n 's/^V\([0-9][0-9.]*\)__.*$/\1/p' \
+              | sort \
+              | uniq -d
+          )"
+
+          if [[ -n "${duplicates}" ]]; then
+            echo "::error::Flyway 마이그레이션 버전이 중복되었습니다."
+            for version in ${duplicates}; do
+              echo "중복 버전 V${version}:"
+              find "${migrations_dir}" -maxdepth 1 -type f -name "V${version}__*.sql" -printf '  %f\n'
+            done
+            exit 1
+          fi
+
+          echo "Flyway 마이그레이션 버전 충돌 없음"


### PR DESCRIPTION
## 요약

PR에서 Flyway 마이그레이션 파일(`V<version>__*.sql`)의 버전이 중복되면 실패시키는 GitHub Actions 워크플로우를 추가한다.

## 배경

서로 다른 브랜치에서 같은 `V{숫자}` 마이그레이션을 추가하면 Flyway가 startup에서
"Found more than one migration with version N"으로 실패한다. 느린 전체 테스트/배포까지 가지 않고
PR 시점에 잡아내기 위한 가드레일이다.

## 동작

- 트리거: `pull_request` → `main`, 단 `src/main/resources/db/migration/**` 변경 시에만 실행
- `V*__*.sql` 파일에서 `V` 뒤 버전(`V1`, `V9.1`, `V23` …)을 추출해 `sort | uniq -d`로 중복 검사
- 중복 발견 시 `::error::` 어노테이션 + 중복 파일 목록 출력 후 실패

🤖 Generated with [Claude Code](https://claude.com/claude-code)