### PR TITLE
feat: 진행 중인 여행 조회 API 추가 (GET /trips/current)

### DIFF
--- a/src/main/java/com/buyeoon/trip/TripController.java
+++ b/src/main/java/com/buyeoon/trip/TripController.java
@@ -56,6 +56,13 @@ public class TripController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.of(trip));
 	}
 
+	@GetMapping("/trips/current")
+	public ResponseEntity<SuccessResponse<TripView>> current(@AuthenticationPrincipal Jwt jwt) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		TripView trip = tripQuery.getCurrentTrip(memberId);
+		return ResponseEntity.ok(SuccessResponse.of(trip));
+	}
+
 	@PostMapping("/trips/{tripId}/end")
 	public ResponseEntity<SuccessResponse<TripView>> end(@AuthenticationPrincipal Jwt jwt, @PathVariable UUID tripId,
 			@RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey) {

--- a/src/main/java/com/buyeoon/trip/TripQueryService.java
+++ b/src/main/java/com/buyeoon/trip/TripQueryService.java
@@ -6,6 +6,7 @@ import com.buyeoon.trip.entity.TripStatus;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 public class TripQueryService {
+
+	private static final ZoneId ASIA_SEOUL = ZoneId.of("Asia/Seoul");
 
 	private final TripRepository tripRepository;
 	private final VisitRecordRepository visitRecordRepository;
@@ -32,6 +35,14 @@ public class TripQueryService {
 	/** 요청 회원이 소유한 여행의 현재 상태를 조회한다. 소유한 여행이 없으면 빈 값을 반환한다. */
 	public Optional<TripStatus> findOwnedTripStatus(UUID memberId, UUID tripId) {
 		return tripRepository.findByIdAndMemberId(tripId, memberId).map(TripEntity::getStatus);
+	}
+
+	/** 요청 회원의 진행 중인 여행을 조회한다. 진행 중인 여행이 없으면 404 예외를 던진다. */
+	public TripStartService.TripView getCurrentTrip(UUID memberId) {
+		TripEntity trip = tripRepository.findByMemberIdAndStatus(memberId, TripStatus.IN_PROGRESS)
+				.orElseThrow(ResourceNotFoundException::new);
+		return new TripStartService.TripView(trip.getId(), trip.getStatus(), trip.getStartedAt().atZone(ASIA_SEOUL),
+				null, null);
 	}
 
 	/** 요청 회원이 소유한 여행의 통계를 계산한다. 소유하지 않았거나 존재하지 않으면 404 예외를 던진다. */

--- a/src/test/java/com/buyeoon/trip/TripCurrentIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/TripCurrentIntegrationTests.java
@@ -1,0 +1,142 @@
+package com.buyeoon.trip;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/** UC-05 진행 중인 여행 조회(GET /trips/current)를 검증한다. */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class TripCurrentIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@BeforeEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 진행 중인 여행이 있으면 그 여행 정보를 반환한다. */
+	@Test
+	@DisplayName("진행 중인 여행이 있으면 200과 여행 정보를 반환한다")
+	void inProgressTripIsReturned() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId(), "IN_PROGRESS");
+
+		performCurrent(member).andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.tripId").value(tripId.toString()))
+				.andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
+				.andExpect(jsonPath("$.data.startedAt").isString()).andExpect(jsonPath("$.data.endedAt").isEmpty());
+	}
+
+	/** 진행 중인 여행이 없으면 404를 반환한다. */
+	@Test
+	@DisplayName("진행 중인 여행이 없으면 404를 반환한다")
+	void noTripReturnsNotFound() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+
+		performCurrent(member).andExpect(status().isNotFound());
+	}
+
+	/** 종료된 여행만 있으면(진행 중 여행이 아니므로) 404를 반환한다. */
+	@Test
+	@DisplayName("종료된 여행만 있으면 404를 반환한다")
+	void endedTripOnlyReturnsNotFound() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		insertTrip(member.memberId(), "ENDED");
+
+		performCurrent(member).andExpect(status().isNotFound());
+	}
+
+	/** 인증되지 않은 요청은 진행 중 여행 조회 계층에 도달하지 않는다. */
+	@Test
+	@DisplayName("여행 조회에는 유효한 인증 세션이 필요하다")
+	void authenticationIsRequired() throws Exception {
+		mockMvc.perform(get("/trips/current")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	private ResultActions performCurrent(AuthenticatedMember member) throws Exception {
+		return mockMvc.perform(get("/trips/current").header("Authorization", "Bearer " + member.accessToken()));
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	/** 지정한 상태의 여행 테스트 데이터를 저장한다. */
+	private UUID insertTrip(UUID memberId, String status) {
+		UUID tripId = UUID.randomUUID();
+		Instant startedAt = Instant.parse("2026-08-12T09:00:00Z");
+		Instant endedAt = "ENDED".equals(status) ? startedAt.plus(2, ChronoUnit.HOURS) : null;
+		jdbcTemplate.update("""
+				INSERT INTO trips (id, member_id, status, started_at, ended_at)
+				VALUES (?, ?, ?::trip_status, ?, ?)
+				""", tripId, memberId, status, Timestamp.from(startedAt),
+				endedAt == null ? null : Timestamp.from(endedAt));
+		return tripId;
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("location.buyeo-boundary", () -> "classpath:boundaries/buyeo-test.geojson");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## Summary
- `GET /trips/current` 엔드포인트를 추가해 회원의 진행 중인 여행을 조회한다.
- 프론트(`buyeo-on-fe`)는 이 엔드포인트를 이미 호출하도록 구현돼 있었으나 백엔드에 없어 항상 404를 받았고, 이를 "진행 중인 여행 없음"으로 오인해 마이페이지 여행종료 등에서 모순이 발생했다.
- 기존 `TripRepository.findByMemberIdAndStatus`와 `ResourceNotFoundException`(404 매핑)을 재사용해 최소 변경으로 구현했다. 응답 shape도 `POST /trips`와 동일한 `TripStartService.TripView`를 그대로 재사용한다.

## Changes
- `TripQueryService.getCurrentTrip(memberId)` 추가
- `TripController`에 `GET /trips/current` 매핑 추가
- `TripCurrentIntegrationTests` 신설: 진행중 있음(200) / 없음(404) / 종료된 여행만 있음(404) / 미인증(401)

## Test plan
- [x] `./gradlew test --tests "com.buyeoon.trip.*"` 전체 통과 확인
- [x] `PointSettlementIntegrationTests` 실패는 이번 변경과 무관한 기존 결함임을 stash로 확인(별도 이슈)
- [ ] 병합 후 CI 통과 확인
- [ ] 프론트에서 마이페이지 "여행 종료" 플로우 재검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)