### PR TITLE
fix: 알림 아이콘 PNG → SVG 교체

### DIFF
--- a/src/main/java/com/buyeoon/notification/entity/NotificationType.java
+++ b/src/main/java/com/buyeoon/notification/entity/NotificationType.java
@@ -9,6 +9,6 @@ public enum NotificationType {
 	BUYEO_NEWS;
 
 	public String iconKey() {
-		return "public/notifications/" + name().toLowerCase() + ".png";
+		return "public/notifications/" + name().toLowerCase() + ".svg";
 	}
 }


### PR DESCRIPTION
## Summary
- 알림 아이콘(`public/notifications/*.png`)을 PNG로 export할 때 생기던 의도치 않은 회색 배경 문제 해결
- [Figma](https://www.figma.com/design/rl9vmWEv5PukINHuiLtSt9/%ED%95%9C%EA%B5%AD%EA%B4%80%EA%B4%91%EA%B3%B5%EC%82%AC-%EA%B3%B5%EB%AA%A8%EC%A0%84--%EA%B0%9C%EB%B0%9C%EC%9A%A9-?node-id=2006-4993)에서 벡터 레이어만 SVG로 다시 export
- S3 `public/notifications/`에 새 SVG 6종(`badge`, `buyeo_news`, `citizen_card`, `discount`, `nearby_quiz`, `point`) 업로드 완료, 기존 PNG 6종은 삭제 완료 (더 이상 코드에서 참조하지 않음, `Content-Type: image/svg+xml`로 업로드)
- `NotificationType.iconKey()`가 `.svg` 확장자를 참조하도록 변경

## Test plan
- [x] `./gradlew compileJava` 통과 확인
- [x] S3 `public/notifications/`에 svg 6종 업로드 및 png 6종 삭제 확인 (`aws s3 ls`)
- [x] 앱에서 알림 목록 진입해 6개 유형 아이콘이 배경 없이 정상 렌더링되는지 육안 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)