### PR TITLE
feat: 장소 조회 응답에 관람시간·입장료를 노출한다

### DIFF
--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -2138,6 +2138,18 @@ components:
           minimum: 0
         saved:
           type: boolean
+        opensAt:
+          type: [string, 'null']
+          format: partial-time
+          description: TourAPI 이용시간 원문을 파싱한 개장 시각. 파싱 실패 시 null.
+        closesAt:
+          type: [string, 'null']
+          format: partial-time
+          description: TourAPI 이용시간 원문을 파싱한 폐장 시각. 파싱 실패 시 null.
+        admissionFee:
+          type: [integer, 'null']
+          minimum: 0
+          description: TourAPI 이용요금 원문을 파싱한 입장료(원). 무료 또는 파싱 실패 시 null.
     MissionType:
       type: string
       enum: [MULTIPLE_CHOICE, OX, PHOTO]

--- a/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceQueryService.java
@@ -9,6 +9,7 @@ import com.buyeoon.place.repository.SavedPlaceProjection;
 import com.buyeoon.place.repository.SavedPlaceRepository;
 import com.buyeoon.trip.TripQueryService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -158,7 +159,8 @@ public class PlaceQueryService {
 
 		return new PlaceItemView(place.getId(), place.getCategory(), place.getName(), place.getSummary(),
 				place.getDescription(), place.getAddress(), imageUrl, place.getLocation().getY(),
-				place.getLocation().getX(), distanceMeters, walkingMinutes, saved);
+				place.getLocation().getX(), distanceMeters, walkingMinutes, saved, place.getOpensAt(),
+				place.getClosesAt(), place.getAdmissionFee());
 	}
 
 	public record PlaceListView(List<PlaceItemView> items, PageInfoView page) {
@@ -169,7 +171,7 @@ public class PlaceQueryService {
 
 	public record PlaceItemView(UUID placeId, PlaceCategory category, String name, String summary, String description,
 			String address, String imageUrl, double latitude, double longitude, Integer distanceMeters,
-			Integer walkingMinutes, boolean saved) {
+			Integer walkingMinutes, boolean saved, LocalTime opensAt, LocalTime closesAt, Integer admissionFee) {
 	}
 
 	public record PageInfoView(String nextCursor, boolean hasNext) {


### PR DESCRIPTION
## Summary
- TourAPI 연동(`TourApiRestClient.fetchPlaceDetail`)이 이미 `usetime`/`usefee`를 파싱해 `PlaceEntity`(`opens_at`, `closes_at`, `admission_fee`)에 저장하고 있었으나, `PlaceQueryService.toView()`가 이 필드들을 `PlaceItemView`에 매핑하지 않아 API 응답에는 전혀 노출되지 않고 있었다.
- `PlaceItemView`에 `opensAt`/`closesAt`/`admissionFee` 세 필드를 추가하고, 모든 `toView` 경로가 공통으로 거치는 최종 매핑 지점 한 곳만 수정했다.
- `docs/raw/openapi.yaml`의 `Place` 스키마에 동일 필드를 반영했다.

## Changes
- `PlaceQueryService.toView(PlaceEntity, Integer, Integer, boolean)`에서 `place.getOpensAt()`/`getClosesAt()`/`getAdmissionFee()`를 `PlaceItemView`에 포함
- `PlaceItemView` record에 필드 3개 추가
- OpenAPI `Place` 스키마에 `opensAt`(`partial-time`), `closesAt`(`partial-time`), `admissionFee`(정수, 원) 추가

## Test plan
- [x] `./gradlew compileJava` 통과
- [x] `./gradlew test --tests "com.buyeoon.place.*"` 전체 통과 (기존 회귀 없음)
- [ ] 배포 후 프론트에서 저장한 장소 상세의 "핵심 정보" 영역이 채워지는지 확인 (프론트 PR과 함께 검증 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)