### PR TITLE
feat: 여행 사진 조회 응답에 촬영 장소명 추가

### DIFF
--- a/docs/domains/trip/use-cases/uc-26-view-trip-photos.md
+++ b/docs/domains/trip/use-cases/uc-26-view-trip-photos.md
@@ -2,7 +2,7 @@
 id: UC-26
 title: 여행 사진 조회
 owner: trip
-participants: [mission]
+participants: [mission, place]
 policies: [authorization, date-time]
 api: ["GET /trips/{tripId}/photos"]
 adrs: [ADR-008]
@@ -22,7 +22,7 @@ adrs: [ADR-008]
 ## 기본 흐름
 
 1. 사용자가 `활동내역` 탭을 누른다.
-2. 앱이 오늘의 추억 사진으로 해당 여행에서 업로드 시각 순으로 촬영한 사진을 표시한다.
+2. 앱이 오늘의 추억 사진으로 해당 여행에서 업로드 시각 순으로 촬영한 사진을, 사진을 찍은 미션이 연결된 장소명과 함께 표시한다.
 3. 사용자가 사진을 눌러 크게 본다.
 
 ## 예외 흐름

--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -1265,6 +1265,7 @@ components:
                 - photoId: 550e8400-e29b-41d4-a716-446655440013
                   url: https://buyeoon-images.s3.ap-northeast-2.amazonaws.com/private/mission-photos/550e8400-e29b-41d4-a716-446655440013.jpg?X-Amz-Signature=...
                   uploadedAt: '2026-08-06T11:20:00+09:00'
+                  placeName: 정림사지
     PlaceListSuccess:
       description: 장소 목록
       content:
@@ -2829,6 +2830,23 @@ components:
           properties:
             data:
               $ref: '#/components/schemas/FootprintData'
+    TripPhotoData:
+      type: object
+      required: [photoId, url, uploadedAt, placeName]
+      properties:
+        photoId:
+          type: string
+          format: uuid
+        url:
+          type: string
+          format: uri
+          description: 소유권 확인 후 발급한 10분 유효 S3 Presigned GET URL. bearer URL이므로 저장·공유하거나 로그에 기록하지 않는다.
+        uploadedAt:
+          type: string
+          format: date-time
+        placeName:
+          type: string
+          description: 사진을 찍은 미션이 연결된 문화재 장소명
     TripPhotoListData:
       type: object
       required: [items]
@@ -2836,7 +2854,7 @@ components:
         items:
           type: array
           items:
-            $ref: '#/components/schemas/MissionPhotoData'
+            $ref: '#/components/schemas/TripPhotoData'
     TripPhotoListEnvelope:
       allOf:
         - $ref: '#/components/schemas/SuccessEnvelope'

--- a/src/main/java/com/buyeoon/trip/FootprintPhotoRepository.java
+++ b/src/main/java/com/buyeoon/trip/FootprintPhotoRepository.java
@@ -4,10 +4,27 @@ import com.buyeoon.mission.entity.MissionPhotoEntity;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-/** 발자취 조회와 여행 사진 조회가 요청자 소유 여행의 미션 사진을 읽기 위한 trip 도메인 소유의 읽기 전용 리포지토리다. */
+/**
+ * 발자취 조회와 여행 사진 조회가 요청자 소유 여행의 미션 사진을 읽기 위한 trip 도메인 소유의 읽기 전용 리포지토리다. 사진과
+ * 장소는 별도 도메인 테이블이지만 매핑된 연관관계가 없으므로 JPQL ad-hoc join으로 연결한다.
+ */
 public interface FootprintPhotoRepository extends JpaRepository<MissionPhotoEntity, UUID> {
 
 	/** 업로드 시각 오름차순으로 요청자 소유 여행의 사진만 조회한다. */
 	List<MissionPhotoEntity> findByMemberIdAndTripIdOrderByUploadedAtAsc(UUID memberId, UUID tripId);
+
+	/** 업로드 시각 오름차순으로 요청자 소유 여행의 사진을 촬영 미션이 연결된 장소명과 함께 조회한다. */
+	@Query("""
+			SELECT new com.buyeoon.trip.TripPhotoProjection(photo, place.name)
+			FROM MissionPhotoEntity photo
+			JOIN MissionEntity mission ON mission.id = photo.missionId
+			JOIN PlaceEntity place ON place.id = mission.placeId
+			WHERE photo.memberId = :memberId AND photo.tripId = :tripId
+			ORDER BY photo.uploadedAt ASC
+			""")
+	List<TripPhotoProjection> findWithPlaceNameByMemberIdAndTripId(@Param("memberId") UUID memberId,
+			@Param("tripId") UUID tripId);
 }

--- a/src/main/java/com/buyeoon/trip/TripController.java
+++ b/src/main/java/com/buyeoon/trip/TripController.java
@@ -161,9 +161,15 @@ public class TripController {
 		}
 	}
 
-	private record TripPhotoListResponse(List<FootprintPhotoResponse> items) {
+	private record TripPhotoListResponse(List<TripPhotoResponse> items) {
 		static TripPhotoListResponse from(TripQueryService.PhotoListView view) {
-			return new TripPhotoListResponse(view.items().stream().map(FootprintPhotoResponse::from).toList());
+			return new TripPhotoListResponse(view.items().stream().map(TripPhotoResponse::from).toList());
+		}
+	}
+
+	private record TripPhotoResponse(UUID photoId, String url, Instant uploadedAt, String placeName) {
+		static TripPhotoResponse from(TripQueryService.PhotoView photo) {
+			return new TripPhotoResponse(photo.photoId(), photo.url(), photo.uploadedAt(), photo.placeName());
 		}
 	}
 

--- a/src/main/java/com/buyeoon/trip/TripPhotoProjection.java
+++ b/src/main/java/com/buyeoon/trip/TripPhotoProjection.java
@@ -1,0 +1,7 @@
+package com.buyeoon.trip;
+
+import com.buyeoon.mission.entity.MissionPhotoEntity;
+
+/** 사진과 그 사진이 찍힌 미션이 연결된 장소명을 함께 담는 조회 전용 프로젝션이다. */
+public record TripPhotoProjection(MissionPhotoEntity photo, String placeName) {
+}

--- a/src/main/java/com/buyeoon/trip/TripQueryService.java
+++ b/src/main/java/com/buyeoon/trip/TripQueryService.java
@@ -71,17 +71,20 @@ public class TripQueryService {
 	 */
 	public PhotoListView getPhotos(UUID memberId, UUID tripId) {
 		tripRepository.findByIdAndMemberId(tripId, memberId).orElseThrow(ResourceNotFoundException::new);
-		List<FootprintQueryService.PhotoView> items = photoRepository
-				.findByMemberIdAndTripIdOrderByUploadedAtAsc(memberId, tripId).stream()
-				.map(photo -> new FootprintQueryService.PhotoView(photo.getId(),
-						privateImageUrls.create(photo.getObjectKey()), photo.getUploadedAt()))
+		List<PhotoView> items = photoRepository.findWithPlaceNameByMemberIdAndTripId(memberId, tripId).stream()
+				.map(projection -> new PhotoView(projection.photo().getId(),
+						privateImageUrls.create(projection.photo().getObjectKey()), projection.photo().getUploadedAt(),
+						projection.placeName()))
 				.toList();
 		return new PhotoListView(items);
 	}
 
-	public record PhotoListView(List<FootprintQueryService.PhotoView> items) {
+	public record PhotoListView(List<PhotoView> items) {
 		public PhotoListView {
 			items = List.copyOf(items);
 		}
+	}
+
+	public record PhotoView(UUID photoId, String url, Instant uploadedAt, String placeName) {
 	}
 }

--- a/src/test/java/com/buyeoon/trip/TripPhotosIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/TripPhotosIntegrationTests.java
@@ -80,7 +80,30 @@ class TripPhotosIntegrationTests {
 		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.items.length()").value(1))
 				.andExpect(jsonPath("$.data.items[0].photoId").value(photoId.toString()))
 				.andExpect(jsonPath("$.data.items[0].url").value("https://signed-url.example.com/photo"))
-				.andExpect(jsonPath("$.data.items[0].uploadedAt").exists());
+				.andExpect(jsonPath("$.data.items[0].uploadedAt").exists())
+				.andExpect(jsonPath("$.data.items[0].placeName").value("정림사지"));
+	}
+
+	/** 사진이 찍힌 미션이 연결된 장소명을 사진마다 정확히 매칭해 반환한다. */
+	@Test
+	@DisplayName("사진마다 촬영 미션이 연결된 장소명을 반환한다")
+	void photosIncludeConnectedPlaceName() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId(), "IN_PROGRESS", Instant.now(), null);
+		UUID placeA = insertPlace("정림사지");
+		UUID placeB = insertPlace("궁남지");
+		UUID missionA = insertMission(placeA, "미션 A");
+		UUID missionB = insertMission(placeB, "미션 B");
+		UUID photoAtPlaceA = insertMissionPhoto(member.memberId(), tripId, missionA, Instant.now().minus(1, ChronoUnit.HOURS));
+		UUID photoAtPlaceB = insertMissionPhoto(member.memberId(), tripId, missionB, Instant.now());
+
+		when(privateImageGetUrlService.create(anyString())).thenReturn("https://signed-url.example.com/photo");
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.items.length()").value(2))
+				.andExpect(jsonPath("$.data.items[0].photoId").value(photoAtPlaceA.toString()))
+				.andExpect(jsonPath("$.data.items[0].placeName").value("정림사지"))
+				.andExpect(jsonPath("$.data.items[1].photoId").value(photoAtPlaceB.toString()))
+				.andExpect(jsonPath("$.data.items[1].placeName").value("궁남지"));
 	}
 
 	/** ENDED(정산 전) 상태 여행도 사진을 조회할 수 있다. */


### PR DESCRIPTION
## Summary
- PR #208(`GET /trips/{tripId}/photos`)의 후속 작업. 사진과, 그 사진을 찍은 미션이 연결된 장소명을 함께 내려주도록 확장했다.
- `mission_photos` → `missions` → `places`는 매핑된 연관관계가 없어서 `MissionQueryRepository`에 있던 JPQL ad-hoc join 패턴(`JOIN ... ON`)을 그대로 재사용해 `TripPhotoProjection(photo, placeName)`을 만들었다.
- footprint(`GET /trips/{tripId}/footprint`)의 사진 응답 스키마는 건드리지 않았다 — 새 엔드포인트에만 `placeName`을 추가했다.

## Test plan
- [x] `TripPhotosIntegrationTests`에 `placeName` 검증 추가 (단일 사진, 서로 다른 미션/장소의 사진 여러 개가 각자 올바른 장소명과 매칭되는지) — 10개 전부 통과
- [x] `./gradlew test --tests "com.buyeoon.trip.*"` 트립 도메인 전체 회귀 통과
- [x] `docs/raw/openapi.yaml` YAML 파싱 검증 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)