### PR TITLE
fix: 정산 대상 포인트가 0원이어도 기부/이월 선택을 허용한다

### DIFF
--- a/src/main/java/com/buyeoon/point/application/PointSettlementService.java
+++ b/src/main/java/com/buyeoon/point/application/PointSettlementService.java
@@ -118,10 +118,7 @@ public class PointSettlementService {
 		if (settleablePoints > 0 && choice == null) {
 			throw new InvalidPointRequestException();
 		}
-		if (settleablePoints == 0 && choice != null) {
-			throw new InvalidPointRequestException();
-		}
-		SettlementChoice finalChoice = settleablePoints == 0 ? SettlementChoice.NO_POINTS : choice;
+		SettlementChoice finalChoice = choice != null ? choice : SettlementChoice.NO_POINTS;
 
 		long balance = pointTransactions.sumAmountByMemberId(memberId);
 		if (balance < settleablePoints) {
@@ -132,13 +129,14 @@ public class PointSettlementService {
 				settledAt);
 		pointSettlements.save(settlement);
 
-		if (finalChoice == SettlementChoice.LEAVE_TO_BUYEO) {
+		if (finalChoice == SettlementChoice.LEAVE_TO_BUYEO && settleablePoints > 0) {
 			leaveToBuyeo(memberId, tripId, settleablePoints, settledAt);
 		}
 
 		tripSettlementService.settle(tripId, settledAt);
 
-		List<AwardedBadgeResult> newlyAwardedBadges = awardDonationBadges(memberId, tripId, finalChoice);
+		List<AwardedBadgeResult> newlyAwardedBadges = awardDonationBadges(memberId, tripId, finalChoice,
+				settleablePoints);
 
 		long remainingBalance = pointTransactions.sumAmountByMemberId(memberId);
 		TripSettlementResult result = new TripSettlementResult(tripId, finalChoice, settleablePoints, remainingBalance,
@@ -164,8 +162,9 @@ public class PointSettlementService {
 	 * 양수 포인트를 부여에 남기는 정산만 {@code POINT_DONATION_COUNT}를 판정한다(UC-14, ADR-003). badge
 	 * Provider query가 방금 확정한 정산 row를 포함하도록 flush한 뒤 같은 transaction에서 판정한다.
 	 */
-	private List<AwardedBadgeResult> awardDonationBadges(UUID memberId, UUID tripId, SettlementChoice choice) {
-		if (choice != SettlementChoice.LEAVE_TO_BUYEO) {
+	private List<AwardedBadgeResult> awardDonationBadges(UUID memberId, UUID tripId, SettlementChoice choice,
+			long settleablePoints) {
+		if (choice != SettlementChoice.LEAVE_TO_BUYEO || settleablePoints <= 0) {
 			return List.of();
 		}
 		pointSettlements.flush();

--- a/src/main/resources/db/migration/V24__allow_zero_point_settlement_choice.sql
+++ b/src/main/resources/db/migration/V24__allow_zero_point_settlement_choice.sql
@@ -1,0 +1,10 @@
+-- 0포인트 정산도 LEAVE_TO_BUYEO/CARRY_OVER 선택을 저장할 수 있도록 완화한다.
+-- 정산 대상 포인트가 0원이어도 UX상 정산 확인 흐름(기부/이월 선택)을 그대로 보여주기로 했다.
+ALTER TABLE point_settlements DROP CONSTRAINT point_settlements_check;
+
+ALTER TABLE point_settlements ADD CONSTRAINT point_settlements_check CHECK (
+	choice = 'LEAVE_TO_BUYEO'::settlement_choice AND settled_points >= 0 AND expires_at IS NULL AND expired_at IS NULL
+	OR choice = 'CARRY_OVER'::settlement_choice AND settled_points >= 0
+		AND expires_at = (settled_at + '240:00:00'::interval) AND (expired_at IS NULL OR expired_at >= expires_at)
+	OR choice = 'NO_POINTS'::settlement_choice AND settled_points = 0 AND expires_at IS NULL AND expired_at IS NULL
+);


### PR DESCRIPTION
## 배경

프론트가 여행 종료 시 정산 확인 흐름(작별 인사 → 정산 미리보기 → 기부/이월 선택 → 발자취)을 정산 대상 포인트 유무와 무관하게 항상 보여주는 것으로 변경됨(Figma 순서 정합). 이전엔 `settleablePoints == 0`이면 이 흐름 전체를 건너뛰도록 구현돼 있었음.

## 문제

0원 정산인데도 `donate_confirm` 화면에서 "네, 남기고 갈게요"를 누르면 `choice: LEAVE_TO_BUYEO`가 서버로 전달되는데, 기존 코드는 이 조합(`settleablePoints==0 && choice!=null`)을 `InvalidPointRequestException`으로 거부하고 있었음. 이를 완화하자 이번엔 DB 체크 제약(`point_settlements_check`)이 `LEAVE_TO_BUYEO`/`CARRY_OVER`는 반드시 `settled_points > 0`이어야 한다고 강제해 `DataIntegrityViolationException`이 발생함.

## 변경 사항

- `PointSettlementService`: `settleablePoints==0 && choice!=null` 조합을 더 이상 거부하지 않음. 단 실제 포인트 이동(`leaveToBuyeo` insert)과 기부 뱃지 판정(`awardDonationBadges`)은 `settleablePoints > 0`일 때만 수행해 0원 정산이 부수효과(포인트 트랜잭션, 뱃지)를 남기지 않도록 가드 추가
- `V24__allow_zero_point_settlement_choice.sql`: `point_settlements_check` 제약을 완화해 `LEAVE_TO_BUYEO`/`CARRY_OVER`도 `settled_points = 0`을 허용

## Test plan

- [x] 로컬 DB에서 포인트 0원 계정으로 "네, 남기고 갈게요" → "다음에 이어서 쓰기" 두 경로 모두 재현 확인
- [ ] 포인트가 실제로 있는 계정으로 기존 정산 플로우(기부/이월) 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)