### PR TITLE
fix: 카카오 이미지 검색 테스트 설정을 추가한다

### DIFF
--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -32,4 +32,9 @@ tourapi.signgu-code=6
 tourapi.connect-timeout=3s
 tourapi.read-timeout=5s
 
+kakao.image-search.base-url=https://dapi.kakao.test
+kakao.image-search.rest-api-key=
+kakao.image-search.connect-timeout=3s
+kakao.image-search.read-timeout=5s
+
 admin.api-key=test-admin-api-key


### PR DESCRIPTION
## 변경 사항
- 카카오 이미지 검색 클라이언트의 테스트 전용 base URL·timeout 설정을 추가했습니다.
- REST API 키는 빈 값으로 두어 외부 카카오 API를 호출하지 않습니다.

## 배경
- 테스트 classpath의 `application.properties`에 새 설정이 없어 Spring 컨텍스트 기동이 실패하던 문제를 해결합니다.

## 확인
- `git diff --check` 통과
- 로컬 테스트는 실행하지 않았습니다.