### PR TITLE
feat: 진행 중인 여행 조회 API에서 미정산 여행도 함께 반환

### DIFF
--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -322,7 +322,8 @@ paths:
   /trips/current:
     get:
       tags: [Trips]
-      summary: 진행 중 여행 조회
+      summary: 진행 중이거나 미정산인 여행 조회
+      description: 진행 중이거나(IN_PROGRESS) 종료 후 아직 정산하지 않은(ENDED) 여행을 조회한다. 정산까지 끝났거나(SETTLED) 여행 이력이 없으면 404를 반환한다.
       operationId: getCurrentTrip
       responses:
         '200':
@@ -1139,7 +1140,7 @@ components:
               endedAt: null
               settledAt: null
     CurrentTripSuccess:
-      description: 진행 중 여행 정보
+      description: 진행 중이거나 미정산인 여행 정보
       content:
         application/json:
           schema:

--- a/src/main/java/com/buyeoon/trip/TripQueryService.java
+++ b/src/main/java/com/buyeoon/trip/TripQueryService.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -44,12 +45,17 @@ public class TripQueryService {
 		return tripRepository.findByIdAndMemberId(tripId, memberId).map(TripEntity::getStatus);
 	}
 
-	/** 요청 회원의 진행 중인 여행을 조회한다. 진행 중인 여행이 없으면 404 예외를 던진다. */
+	/**
+	 * 요청 회원의 진행 중이거나 종료 후 미정산인 여행을 조회한다. 그런 여행이 없으면 404 예외를 던진다. 프론트엔드가
+	 * 미정산 여행의 정산 페이지로 라우팅할 수 있도록 종료된 여행도 함께 조회한다.
+	 */
 	public TripStartService.TripView getCurrentTrip(UUID memberId) {
-		TripEntity trip = tripRepository.findByMemberIdAndStatus(memberId, TripStatus.IN_PROGRESS)
+		TripEntity trip = tripRepository
+				.findByMemberIdAndStatusIn(memberId, List.of(TripStatus.IN_PROGRESS, TripStatus.ENDED))
 				.orElseThrow(ResourceNotFoundException::new);
+		ZonedDateTime endedAt = trip.getEndedAt() == null ? null : trip.getEndedAt().atZone(ASIA_SEOUL);
 		return new TripStartService.TripView(trip.getId(), trip.getStatus(), trip.getStartedAt().atZone(ASIA_SEOUL),
-				null, null);
+				endedAt, null);
 	}
 
 	/** 요청 회원이 소유한 여행의 통계를 계산한다. 소유하지 않았거나 존재하지 않으면 404 예외를 던진다. */

--- a/src/main/java/com/buyeoon/trip/TripRepository.java
+++ b/src/main/java/com/buyeoon/trip/TripRepository.java
@@ -15,6 +15,9 @@ public interface TripRepository extends JpaRepository<TripEntity, UUID> {
 
 	Optional<TripEntity> findByMemberIdAndStatus(UUID memberId, TripStatus status);
 
+	/** 회원이 진행 중이거나 종료 후 미정산인 여행을 조회한다. 이 두 상태는 동시에 최대 하나만 존재한다. */
+	Optional<TripEntity> findByMemberIdAndStatusIn(UUID memberId, Collection<TripStatus> statuses);
+
 	/** 회원이 여행 시작을 막는 상태의 여행을 소유하는지 확인한다. */
 	boolean existsByMemberIdAndStatusIn(UUID memberId, Collection<TripStatus> statuses);
 

--- a/src/test/java/com/buyeoon/trip/TripCurrentIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/TripCurrentIntegrationTests.java
@@ -25,7 +25,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
-/** UC-05 진행 중인 여행 조회(GET /trips/current)를 검증한다. */
+/** UC-05 진행 중이거나 미정산인 여행 조회(GET /trips/current)를 검증한다. */
 @SpringBootTest
 @AutoConfigureMockMvc
 @Testcontainers
@@ -78,12 +78,25 @@ class TripCurrentIntegrationTests {
 		performCurrent(member).andExpect(status().isNotFound());
 	}
 
-	/** 종료된 여행만 있으면(진행 중 여행이 아니므로) 404를 반환한다. */
+	/** 종료됐지만 미정산인 여행이 있으면 그 여행 정보를 반환한다. */
 	@Test
-	@DisplayName("종료된 여행만 있으면 404를 반환한다")
-	void endedTripOnlyReturnsNotFound() throws Exception {
+	@DisplayName("미정산인 종료된 여행이 있으면 200과 여행 정보를 반환한다")
+	void endedUnsettledTripIsReturned() throws Exception {
 		AuthenticatedMember member = insertAuthenticatedMember();
-		insertTrip(member.memberId(), "ENDED");
+		UUID tripId = insertTrip(member.memberId(), "ENDED");
+
+		performCurrent(member).andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.tripId").value(tripId.toString()))
+				.andExpect(jsonPath("$.data.status").value("ENDED")).andExpect(jsonPath("$.data.startedAt").isString())
+				.andExpect(jsonPath("$.data.endedAt").isString());
+	}
+
+	/** 정산까지 끝난 여행만 있으면 404를 반환한다. */
+	@Test
+	@DisplayName("정산까지 끝난 여행만 있으면 404를 반환한다")
+	void settledTripOnlyReturnsNotFound() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		insertTrip(member.memberId(), "SETTLED");
 
 		performCurrent(member).andExpect(status().isNotFound());
 	}
@@ -116,12 +129,13 @@ class TripCurrentIntegrationTests {
 	private UUID insertTrip(UUID memberId, String status) {
 		UUID tripId = UUID.randomUUID();
 		Instant startedAt = Instant.parse("2026-08-12T09:00:00Z");
-		Instant endedAt = "ENDED".equals(status) ? startedAt.plus(2, ChronoUnit.HOURS) : null;
+		Instant endedAt = "IN_PROGRESS".equals(status) ? null : startedAt.plus(2, ChronoUnit.HOURS);
+		Instant settledAt = "SETTLED".equals(status) ? startedAt.plus(3, ChronoUnit.HOURS) : null;
 		jdbcTemplate.update("""
-				INSERT INTO trips (id, member_id, status, started_at, ended_at)
-				VALUES (?, ?, ?::trip_status, ?, ?)
+				INSERT INTO trips (id, member_id, status, started_at, ended_at, settled_at)
+				VALUES (?, ?, ?::trip_status, ?, ?, ?)
 				""", tripId, memberId, status, Timestamp.from(startedAt),
-				endedAt == null ? null : Timestamp.from(endedAt));
+				endedAt == null ? null : Timestamp.from(endedAt), settledAt == null ? null : Timestamp.from(settledAt));
 		return tripId;
 	}
 


### PR DESCRIPTION
## Summary
- 여행이 끝났지만 아직 정산되지 않은 경우, 프론트엔드가 해당 여행의 tripId를 알 방법이 없어 정산 페이지로 라우팅할 수 없던 문제를 해결한다.
- `GET /trips/current`가 기존 `IN_PROGRESS` 여행뿐 아니라 `ENDED`(종료·미정산) 여행도 조회하도록 확장했다. `SETTLED`까지 끝난 경우에는 기존과 동일하게 404를 반환한다.
- 응답 스키마는 변경 없음 — 기존 `Trip`/`TripEnvelope` 스키마가 이미 `status`, `endedAt`을 포함하고 있어 프론트엔드는 `data.status === "ENDED"`로 분기만 추가하면 된다.
- 트립 도메인 불변식(진행 중/미정산 여행은 회원당 최대 1개)에 따라 `TripRepository.findByMemberIdAndStatusIn`으로 단건 조회.
- `docs/raw/openapi.yaml`의 summary/description을 실제 동작에 맞게 갱신.

## Test plan
- [x] `./gradlew test --tests "com.buyeoon.trip.TripCurrentIntegrationTests"` — 5개 테스트 통과 (진행 중 여행 반환, 미정산 종료 여행 반환 신규 추가, 정산 완료 여행만 있을 때 404 케이스로 변경, 여행 없을 때 404, 인증 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMb6Wgs8NTCzZ4MAKqa586