### PR TITLE
feat: 알림 발송 대상 조회에 알림 동의 필드 게이팅 적용

### DIFF
--- a/src/main/java/com/buyeoon/member/application/PushTargetQueryService.java
+++ b/src/main/java/com/buyeoon/member/application/PushTargetQueryService.java
@@ -15,17 +15,19 @@ public class PushTargetQueryService {
 		this.jdbcOperations = jdbcOperations;
 	}
 
-	/** 활성 회원의 미폐기·미만료 인증 세션에 연결된 모든 등록 토큰을 반환한다. 알림 설정과 동의는 확인하지 않는다. */
+	/** 활성 회원의 미폐기·미만료 인증 세션에 연결되고 알림 동의가 켜진 등록 토큰만 반환한다. */
 	public List<String> findRegistrationTokens(UUID memberId) {
 		return jdbcOperations.query("""
 				SELECT push_token.registration_token
 				FROM push_tokens push_token
 				JOIN auth_sessions session ON session.id = push_token.auth_session_id
 				JOIN members member ON member.id = session.member_id
+				JOIN member_settings settings ON settings.member_id = member.id
 				WHERE member.id = ?
 				  AND member.status = 'ACTIVE'
 				  AND session.revoked_at IS NULL
 				  AND session.expires_at > CURRENT_TIMESTAMP
+				  AND settings.nearby_quiz_notification_enabled = true
 				""", (resultSet, rowNumber) -> resultSet.getString("registration_token"), memberId);
 	}
 

--- a/src/test/java/com/buyeoon/member/application/PushTargetQueryServiceIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/application/PushTargetQueryServiceIntegrationTests.java
@@ -80,15 +80,27 @@ class PushTargetQueryServiceIntegrationTests {
 	}
 
 	@Test
-	@DisplayName("근처 퀴즈 알림 설정이나 마케팅 동의 값과 무관하게 동일한 발송 대상 토큰을 반환한다")
-	void returnsSameTargetsRegardlessOfNotificationSettings() {
-		UUID optedOutMemberId = insertActiveMember(false, false);
+	@DisplayName("마케팅 동의 값과 무관하게 동일한 발송 대상 토큰을 반환한다")
+	void returnsSameTargetsRegardlessOfMarketingConsent() {
+		UUID memberId = insertActiveMember(true, false);
+		UUID session = insertSession(memberId, null, 30);
+		insertPushToken(session, "device-token");
+
+		List<String> tokens = pushTargetQueryService.findRegistrationTokens(memberId);
+
+		assertThat(tokens).containsExactly("device-token");
+	}
+
+	@Test
+	@DisplayName("알림 동의가 꺼진 회원의 등록 토큰은 반환하지 않는다")
+	void excludesMembersWithNotificationsDisabled() {
+		UUID optedOutMemberId = insertActiveMember(false, true);
 		UUID session = insertSession(optedOutMemberId, null, 30);
 		insertPushToken(session, "device-token");
 
 		List<String> tokens = pushTargetQueryService.findRegistrationTokens(optedOutMemberId);
 
-		assertThat(tokens).containsExactly("device-token");
+		assertThat(tokens).isEmpty();
 	}
 
 	private UUID insertActiveMember(boolean nearbyQuizNotificationEnabled, boolean marketingConsentAgreed) {

--- a/src/test/java/com/buyeoon/notification/application/PushNotificationPublisherIntegrationTests.java
+++ b/src/test/java/com/buyeoon/notification/application/PushNotificationPublisherIntegrationTests.java
@@ -372,7 +372,7 @@ class PushNotificationPublisherIntegrationTests {
 		jdbcTemplate.update("""
 				INSERT INTO member_settings
 				    (member_id, nearby_quiz_notification_enabled, dark_mode_enabled, version)
-				VALUES (?, false, false, 0)
+				VALUES (?, true, false, 0)
 				""", memberId);
 		return memberId;
 	}


### PR DESCRIPTION
## Summary
- `PushTargetQueryService.findRegistrationTokens`가 `member_settings`와 조인해 `nearby_quiz_notification_enabled = true`인 회원의 등록 토큰만 반환하도록 변경
- `PushNotificationPublisher.publish(...)`를 호출하는 모든 도메인이 타입별 개별 체크 없이 이 게이팅의 혜택을 받음
- javadoc을 실제 동작에 맞게 갱신
- 컬럼/필드명 rename, 알림 유형별 개별 동의 필드 신설은 범위 제외 (이 티켓은 가장 작은 변경만 적용)

Closes #221

## Test plan
- [x] `./gradlew test` (전체 스위트) — BUILD SUCCESSFUL
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/static-check.sh` (기존 무관 checkstyle 위반 3건은 이 변경과 무관)
- [ ] `./scripts/test/docker-build.sh` — 로컬 환경의 공유 원격 DB에 이미 데이터가 있어 V16 마이그레이션이 실패하는 기존 환경 문제로 확인 미완료 (이 PR과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMb6Wgs8NTCzZ4MAKqa586