### PR TITLE
ci: main 병합 시 운영 배포 자동 실행

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,7 +24,6 @@ permissions:
 
 jobs:
   deploy:
-    if: github.event_name == 'workflow_dispatch' || vars.PRODUCTION_DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 30


### PR DESCRIPTION
## 변경 사항
- Production 배포 job의 환경 변수 기반 실행 조건을 제거했습니다.
- `main` 브랜치에 push가 발생하면 Deploy Production 워크플로가 실행됩니다.
- 수동 `workflow_dispatch` 실행 방식은 그대로 유지됩니다.

## 기대 동작
- PR이 `main`에 병합되면 테스트와 이미지 빌드를 거쳐 운영 환경에 자동 배포됩니다.
- 배포 완료 후 운영 health check가 수행됩니다.