### PR TITLE
feat: 관리자용 장소/미션(퀴즈)/배지 CRUD API 추가

### DIFF
--- a/src/main/java/com/buyeoon/badge/api/BadgeAdminController.java
+++ b/src/main/java/com/buyeoon/badge/api/BadgeAdminController.java
@@ -1,0 +1,78 @@
+package com.buyeoon.badge.api;
+
+import com.buyeoon.badge.BadgeMetric;
+import com.buyeoon.badge.application.BadgeAdminCommandService;
+import com.buyeoon.badge.application.BadgeAdminQueryService;
+import com.buyeoon.common.api.SuccessResponse;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class BadgeAdminController {
+
+	private static final int MIN_SIZE = 1;
+	private static final int MAX_SIZE = 100;
+
+	private final BadgeAdminCommandService badgeAdminCommandService;
+	private final BadgeAdminQueryService badgeAdminQueryService;
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public BadgeAdminController(BadgeAdminCommandService badgeAdminCommandService,
+			BadgeAdminQueryService badgeAdminQueryService) {
+		this.badgeAdminCommandService = badgeAdminCommandService;
+		this.badgeAdminQueryService = badgeAdminQueryService;
+	}
+
+	@PostMapping("/admin/badges")
+	public SuccessResponse<Map<String, UUID>> create(@RequestBody BadgeAdminCreateRequest request) {
+		UUID badgeId = badgeAdminCommandService.create(request);
+		return SuccessResponse.of(Map.of("badgeId", badgeId));
+	}
+
+	@PutMapping("/admin/badges/{badgeId}")
+	public SuccessResponse<Map<String, Object>> update(@PathVariable UUID badgeId,
+			@RequestBody BadgeAdminUpdateRequest request) {
+		badgeAdminCommandService.update(badgeId, request);
+		return SuccessResponse.of(Map.of());
+	}
+
+	@PostMapping("/admin/badges/{badgeId}/retire")
+	public SuccessResponse<Map<String, Object>> retire(@PathVariable UUID badgeId) {
+		badgeAdminCommandService.retire(badgeId);
+		return SuccessResponse.of(Map.of());
+	}
+
+	@PostMapping("/admin/badges/{badgeId}/activate")
+	public SuccessResponse<Map<String, Object>> activate(@PathVariable UUID badgeId) {
+		badgeAdminCommandService.activate(badgeId);
+		return SuccessResponse.of(Map.of());
+	}
+
+	@GetMapping("/admin/badges")
+	public SuccessResponse<BadgeAdminListView> list(@RequestParam(defaultValue = "0") int page,
+			@RequestParam(defaultValue = "20") int size) {
+		if (size < MIN_SIZE || size > MAX_SIZE || page < 0) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+		return SuccessResponse.of(badgeAdminQueryService.list(page, size));
+	}
+
+	@GetMapping("/admin/badges/{badgeId}")
+	public SuccessResponse<BadgeAdminView> get(@PathVariable UUID badgeId) {
+		return SuccessResponse.of(badgeAdminQueryService.get(badgeId));
+	}
+
+	@GetMapping("/admin/badge-metrics")
+	public SuccessResponse<List<BadgeMetric>> getBadgeMetrics() {
+		return SuccessResponse.of(List.of(BadgeMetric.values()));
+	}
+}

--- a/src/main/java/com/buyeoon/badge/api/BadgeAdminCreateRequest.java
+++ b/src/main/java/com/buyeoon/badge/api/BadgeAdminCreateRequest.java
@@ -1,0 +1,7 @@
+package com.buyeoon.badge.api;
+
+import java.util.List;
+
+public record BadgeAdminCreateRequest(String category, String name, String description, String imageKey,
+		String conditionText, boolean active, List<BadgeConditionRequest> conditions) {
+}

--- a/src/main/java/com/buyeoon/badge/api/BadgeAdminListView.java
+++ b/src/main/java/com/buyeoon/badge/api/BadgeAdminListView.java
@@ -1,0 +1,10 @@
+package com.buyeoon.badge.api;
+
+import java.util.List;
+
+public record BadgeAdminListView(List<BadgeAdminView> items, int page, int size, long totalElements,
+		int totalPages) {
+	public BadgeAdminListView {
+		items = List.copyOf(items);
+	}
+}

--- a/src/main/java/com/buyeoon/badge/api/BadgeAdminUpdateRequest.java
+++ b/src/main/java/com/buyeoon/badge/api/BadgeAdminUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.buyeoon.badge.api;
+
+import java.util.List;
+
+public record BadgeAdminUpdateRequest(String category, String name, String description, String imageKey,
+		String conditionText, List<BadgeConditionRequest> conditions) {
+}

--- a/src/main/java/com/buyeoon/badge/api/BadgeAdminView.java
+++ b/src/main/java/com/buyeoon/badge/api/BadgeAdminView.java
@@ -1,0 +1,15 @@
+package com.buyeoon.badge.api;
+
+import com.buyeoon.badge.entity.BadgeCategory;
+import java.util.List;
+import java.util.UUID;
+
+public record BadgeAdminView(UUID badgeId, BadgeCategory category, String name, String description, String imageKey,
+		String conditionText, boolean retired, List<BadgeAdminConditionView> conditions) {
+	public BadgeAdminView {
+		conditions = List.copyOf(conditions);
+	}
+
+	public record BadgeAdminConditionView(String metricKey, long threshold) {
+	}
+}

--- a/src/main/java/com/buyeoon/badge/api/BadgeConditionRequest.java
+++ b/src/main/java/com/buyeoon/badge/api/BadgeConditionRequest.java
@@ -1,0 +1,4 @@
+package com.buyeoon.badge.api;
+
+public record BadgeConditionRequest(String metricKey, long threshold) {
+}

--- a/src/main/java/com/buyeoon/badge/api/BadgeExceptionHandler.java
+++ b/src/main/java/com/buyeoon/badge/api/BadgeExceptionHandler.java
@@ -7,10 +7,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice(assignableTypes = BadgeController.class)
+@RestControllerAdvice(assignableTypes = {BadgeController.class, BadgeAdminController.class})
 public class BadgeExceptionHandler {
 
-	@ExceptionHandler(InvalidBadgeRequestException.class)
+	@ExceptionHandler({InvalidBadgeRequestException.class, InvalidBadgeAdminRequestException.class})
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	public ErrorResponse handleInvalidRequest() {
 		return ErrorResponse.invalidRequest();

--- a/src/main/java/com/buyeoon/badge/api/InvalidBadgeAdminRequestException.java
+++ b/src/main/java/com/buyeoon/badge/api/InvalidBadgeAdminRequestException.java
@@ -1,0 +1,4 @@
+package com.buyeoon.badge.api;
+
+public class InvalidBadgeAdminRequestException extends RuntimeException {
+}

--- a/src/main/java/com/buyeoon/badge/application/BadgeAdminCommandService.java
+++ b/src/main/java/com/buyeoon/badge/application/BadgeAdminCommandService.java
@@ -1,0 +1,149 @@
+package com.buyeoon.badge.application;
+
+import com.buyeoon.badge.BadgeMetric;
+import com.buyeoon.badge.api.BadgeAdminCreateRequest;
+import com.buyeoon.badge.api.BadgeAdminUpdateRequest;
+import com.buyeoon.badge.api.BadgeConditionRequest;
+import com.buyeoon.badge.api.InvalidBadgeAdminRequestException;
+import com.buyeoon.badge.entity.BadgeCategory;
+import com.buyeoon.badge.entity.BadgeConditionEntity;
+import com.buyeoon.badge.entity.BadgeEntity;
+import com.buyeoon.badge.repository.BadgeConditionRepository;
+import com.buyeoon.badge.repository.BadgeRepository;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class BadgeAdminCommandService {
+
+	private static final String IMAGE_KEY_PREFIX = "public/";
+
+	private final BadgeRepository badgeRepository;
+	private final BadgeConditionRepository badgeConditionRepository;
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public BadgeAdminCommandService(BadgeRepository badgeRepository, BadgeConditionRepository badgeConditionRepository) {
+		this.badgeRepository = badgeRepository;
+		this.badgeConditionRepository = badgeConditionRepository;
+	}
+
+	@Transactional
+	public UUID create(BadgeAdminCreateRequest request) {
+		BadgeCategory category = category(request.category());
+		String name = requiredText(request.name());
+		String description = requiredText(request.description());
+		String conditionText = requiredText(request.conditionText());
+		String imageKey = imageKey(request.imageKey());
+		List<BadgeConditionRequest> conditions = validatedConditions(request.conditions());
+
+		if (request.active() && conditions.isEmpty()) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+
+		BadgeEntity badge = BadgeEntity.create(category, name, description, imageKey, conditionText);
+		if (!request.active()) {
+			badge.retire();
+		}
+		badgeRepository.save(badge);
+		saveConditions(badge.getId(), conditions);
+		return badge.getId();
+	}
+
+	@Transactional
+	public void update(UUID badgeId, BadgeAdminUpdateRequest request) {
+		BadgeEntity badge = badgeRepository.findById(badgeId).orElseThrow(BadgeNotFoundException::new);
+		BadgeCategory category = category(request.category());
+		String name = requiredText(request.name());
+		String description = requiredText(request.description());
+		String conditionText = requiredText(request.conditionText());
+		String imageKey = imageKey(request.imageKey());
+		List<BadgeConditionRequest> conditions = validatedConditions(request.conditions());
+
+		if (badge.getRetiredAt() == null && conditions.isEmpty()) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+
+		badge.updateMetadata(category, name, description, imageKey, conditionText);
+		badgeConditionRepository.deleteByIdBadgeId(badgeId);
+		badgeConditionRepository.flush();
+		saveConditions(badgeId, conditions);
+	}
+
+	@Transactional
+	public void retire(UUID badgeId) {
+		BadgeEntity badge = badgeRepository.findById(badgeId).orElseThrow(BadgeNotFoundException::new);
+		badge.retire();
+	}
+
+	@Transactional
+	public void activate(UUID badgeId) {
+		BadgeEntity badge = badgeRepository.findById(badgeId).orElseThrow(BadgeNotFoundException::new);
+		List<BadgeConditionEntity> conditions = badgeConditionRepository.findByIdBadgeIdIn(List.of(badgeId));
+		if (conditions.isEmpty()) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+		badge.activate();
+	}
+
+	private void saveConditions(UUID badgeId, List<BadgeConditionRequest> conditions) {
+		for (BadgeConditionRequest condition : conditions) {
+			badgeConditionRepository.save(BadgeConditionEntity.create(badgeId, condition.metricKey(),
+					condition.threshold()));
+		}
+	}
+
+	private List<BadgeConditionRequest> validatedConditions(List<BadgeConditionRequest> conditions) {
+		if (conditions == null) {
+			return List.of();
+		}
+		for (BadgeConditionRequest condition : conditions) {
+			metric(condition.metricKey());
+			if (condition.threshold() <= 0) {
+				throw new InvalidBadgeAdminRequestException();
+			}
+		}
+		return conditions;
+	}
+
+	private BadgeMetric metric(String value) {
+		if (value == null) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+		try {
+			return BadgeMetric.valueOf(value);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+	}
+
+	private BadgeCategory category(String value) {
+		if (value == null) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+		try {
+			return BadgeCategory.valueOf(value);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+	}
+
+	private String requiredText(String value) {
+		if (value == null || value.isBlank()) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+		return value;
+	}
+
+	private String imageKey(String value) {
+		if (value == null) {
+			return null;
+		}
+		if (!value.startsWith(IMAGE_KEY_PREFIX)) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+		return value;
+	}
+}

--- a/src/main/java/com/buyeoon/badge/application/BadgeAdminQueryService.java
+++ b/src/main/java/com/buyeoon/badge/application/BadgeAdminQueryService.java
@@ -1,0 +1,51 @@
+package com.buyeoon.badge.application;
+
+import com.buyeoon.badge.api.BadgeAdminListView;
+import com.buyeoon.badge.api.BadgeAdminView;
+import com.buyeoon.badge.api.BadgeAdminView.BadgeAdminConditionView;
+import com.buyeoon.badge.entity.BadgeConditionEntity;
+import com.buyeoon.badge.entity.BadgeEntity;
+import com.buyeoon.badge.repository.BadgeConditionRepository;
+import com.buyeoon.badge.repository.BadgeRepository;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class BadgeAdminQueryService {
+
+	private final BadgeRepository badgeRepository;
+	private final BadgeConditionRepository badgeConditionRepository;
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public BadgeAdminQueryService(BadgeRepository badgeRepository, BadgeConditionRepository badgeConditionRepository) {
+		this.badgeRepository = badgeRepository;
+		this.badgeConditionRepository = badgeConditionRepository;
+	}
+
+	public BadgeAdminListView list(int page, int size) {
+		PageRequest pageRequest = PageRequest.of(page, size);
+		Page<BadgeEntity> result = badgeRepository.findAll(pageRequest);
+		List<BadgeAdminView> items = result.getContent().stream().map(badge -> toView(badge, List.of())).toList();
+		return new BadgeAdminListView(items, page, size, result.getTotalElements(), result.getTotalPages());
+	}
+
+	public BadgeAdminView get(UUID badgeId) {
+		BadgeEntity badge = badgeRepository.findById(badgeId).orElseThrow(BadgeNotFoundException::new);
+		List<BadgeConditionEntity> conditions = badgeConditionRepository.findByIdBadgeIdIn(List.of(badgeId));
+		return toView(badge, conditions);
+	}
+
+	private BadgeAdminView toView(BadgeEntity badge, List<BadgeConditionEntity> conditions) {
+		List<BadgeAdminConditionView> conditionViews = conditions.stream()
+				.map(condition -> new BadgeAdminConditionView(condition.getId().metricKey(), condition.getThreshold()))
+				.toList();
+		return new BadgeAdminView(badge.getId(), badge.getCategory(), badge.getName(), badge.getDescription(),
+				badge.getImageKey(), badge.getConditionText(), badge.getRetiredAt() != null, conditionViews);
+	}
+}

--- a/src/main/java/com/buyeoon/badge/entity/BadgeEntity.java
+++ b/src/main/java/com/buyeoon/badge/entity/BadgeEntity.java
@@ -53,4 +53,21 @@ public class BadgeEntity {
 		badge.conditionText = conditionText;
 		return badge;
 	}
+
+	public void updateMetadata(BadgeCategory category, String name, String description, String imageKey,
+			String conditionText) {
+		this.category = category;
+		this.name = name;
+		this.description = description;
+		this.imageKey = imageKey;
+		this.conditionText = conditionText;
+	}
+
+	public void retire() {
+		this.retiredAt = Instant.now();
+	}
+
+	public void activate() {
+		this.retiredAt = null;
+	}
 }

--- a/src/main/java/com/buyeoon/badge/repository/BadgeConditionRepository.java
+++ b/src/main/java/com/buyeoon/badge/repository/BadgeConditionRepository.java
@@ -10,4 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface BadgeConditionRepository extends JpaRepository<BadgeConditionEntity, BadgeConditionId> {
 
 	List<BadgeConditionEntity> findByIdBadgeIdIn(Collection<UUID> badgeIds);
+
+	void deleteByIdBadgeId(UUID badgeId);
 }

--- a/src/main/java/com/buyeoon/mission/api/MissionAdminController.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionAdminController.java
@@ -1,0 +1,66 @@
+package com.buyeoon.mission.api;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.mission.application.MissionAdminCommandService;
+import com.buyeoon.mission.application.MissionAdminQueryService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MissionAdminController {
+
+	private static final int MIN_SIZE = 1;
+	private static final int MAX_SIZE = 100;
+
+	private final MissionAdminCommandService missionAdminCommandService;
+	private final MissionAdminQueryService missionAdminQueryService;
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public MissionAdminController(MissionAdminCommandService missionAdminCommandService,
+			MissionAdminQueryService missionAdminQueryService) {
+		this.missionAdminCommandService = missionAdminCommandService;
+		this.missionAdminQueryService = missionAdminQueryService;
+	}
+
+	@PostMapping("/admin/missions")
+	public SuccessResponse<Map<String, UUID>> create(@RequestBody MissionAdminCreateRequest request) {
+		UUID missionId = missionAdminCommandService.create(request);
+		return SuccessResponse.of(Map.of("missionId", missionId));
+	}
+
+	@PutMapping("/admin/missions/{missionId}")
+	public SuccessResponse<Map<String, Object>> update(@PathVariable UUID missionId,
+			@RequestBody MissionAdminUpdateRequest request) {
+		missionAdminCommandService.update(missionId, request);
+		return SuccessResponse.of(Map.of());
+	}
+
+	@DeleteMapping("/admin/missions/{missionId}")
+	public SuccessResponse<Map<String, Object>> delete(@PathVariable UUID missionId) {
+		missionAdminCommandService.delete(missionId);
+		return SuccessResponse.of(Map.of());
+	}
+
+	@GetMapping("/admin/missions")
+	public SuccessResponse<MissionAdminListView> list(@RequestParam(required = false) UUID placeId,
+			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "20") int size) {
+		if (size < MIN_SIZE || size > MAX_SIZE || page < 0) {
+			throw new InvalidMissionRequestException();
+		}
+		return SuccessResponse.of(missionAdminQueryService.list(placeId, page, size));
+	}
+
+	@GetMapping("/admin/missions/{missionId}")
+	public SuccessResponse<MissionAdminView> get(@PathVariable UUID missionId) {
+		return SuccessResponse.of(missionAdminQueryService.get(missionId));
+	}
+}

--- a/src/main/java/com/buyeoon/mission/api/MissionAdminCreateRequest.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionAdminCreateRequest.java
@@ -1,0 +1,8 @@
+package com.buyeoon.mission.api;
+
+import java.util.List;
+import java.util.UUID;
+
+public record MissionAdminCreateRequest(UUID placeId, String type, String title, String description,
+		int rewardPoints, Integer maxAttempts, Boolean oxCorrectAnswer, List<MissionChoiceRequest> choices) {
+}

--- a/src/main/java/com/buyeoon/mission/api/MissionAdminListView.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionAdminListView.java
@@ -1,0 +1,10 @@
+package com.buyeoon.mission.api;
+
+import java.util.List;
+
+public record MissionAdminListView(List<MissionAdminView> items, int page, int size, long totalElements,
+		int totalPages) {
+	public MissionAdminListView {
+		items = List.copyOf(items);
+	}
+}

--- a/src/main/java/com/buyeoon/mission/api/MissionAdminUpdateRequest.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionAdminUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.buyeoon.mission.api;
+
+import java.util.List;
+
+public record MissionAdminUpdateRequest(String title, String description, int rewardPoints, Integer maxAttempts,
+		Boolean oxCorrectAnswer, List<MissionChoiceRequest> choices) {
+}

--- a/src/main/java/com/buyeoon/mission/api/MissionAdminView.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionAdminView.java
@@ -1,0 +1,16 @@
+package com.buyeoon.mission.api;
+
+import com.buyeoon.mission.entity.MissionType;
+import java.util.List;
+import java.util.UUID;
+
+public record MissionAdminView(UUID missionId, UUID placeId, MissionType type, String title, String description,
+		int rewardPoints, Integer maxAttempts, Boolean oxCorrectAnswer, List<MissionAdminChoiceView> choices,
+		boolean deleted) {
+	public MissionAdminView {
+		choices = List.copyOf(choices);
+	}
+
+	public record MissionAdminChoiceView(UUID choiceId, String label, boolean correct, int sortOrder) {
+	}
+}

--- a/src/main/java/com/buyeoon/mission/api/MissionChoiceRequest.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionChoiceRequest.java
@@ -1,0 +1,4 @@
+package com.buyeoon.mission.api;
+
+public record MissionChoiceRequest(String label, boolean correct, int sortOrder) {
+}

--- a/src/main/java/com/buyeoon/mission/api/MissionExceptionHandler.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionExceptionHandler.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
-@RestControllerAdvice(assignableTypes = MissionController.class)
+@RestControllerAdvice(assignableTypes = {MissionController.class, MissionAdminController.class})
 public class MissionExceptionHandler {
 
 	@ExceptionHandler({InvalidMissionRequestException.class, InvalidMissionSubmissionException.class,

--- a/src/main/java/com/buyeoon/mission/application/MissionAdminCommandService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionAdminCommandService.java
@@ -1,0 +1,172 @@
+package com.buyeoon.mission.application;
+
+import com.buyeoon.mission.api.InvalidMissionRequestException;
+import com.buyeoon.mission.api.MissionAdminCreateRequest;
+import com.buyeoon.mission.api.MissionAdminUpdateRequest;
+import com.buyeoon.mission.api.MissionChoiceRequest;
+import com.buyeoon.mission.entity.MissionChoiceEntity;
+import com.buyeoon.mission.entity.MissionEntity;
+import com.buyeoon.mission.entity.MissionType;
+import com.buyeoon.mission.repository.MissionChoiceRepository;
+import com.buyeoon.mission.repository.MissionQueryRepository;
+import com.buyeoon.place.entity.PlaceEntity;
+import com.buyeoon.place.repository.PlaceQueryRepository;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MissionAdminCommandService {
+
+	private final MissionQueryRepository missionQueryRepository;
+	private final MissionChoiceRepository missionChoiceRepository;
+	private final PlaceQueryRepository placeQueryRepository;
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public MissionAdminCommandService(MissionQueryRepository missionQueryRepository,
+			MissionChoiceRepository missionChoiceRepository, PlaceQueryRepository placeQueryRepository) {
+		this.missionQueryRepository = missionQueryRepository;
+		this.missionChoiceRepository = missionChoiceRepository;
+		this.placeQueryRepository = placeQueryRepository;
+	}
+
+	@Transactional
+	public UUID create(MissionAdminCreateRequest request) {
+		if (request.placeId() == null) {
+			throw new InvalidMissionRequestException();
+		}
+		PlaceEntity place = placeQueryRepository.findById(request.placeId())
+				.filter(candidate -> !candidate.isDeleted()).orElseThrow(InvalidMissionRequestException::new);
+		MissionType type = missionType(request.type());
+		String title = requiredText(request.title());
+		String description = requiredText(request.description());
+
+		MissionEntity mission;
+		try {
+			mission = switch (type) {
+				case MULTIPLE_CHOICE -> {
+					requireNoOxAnswer(request.oxCorrectAnswer());
+					yield MissionEntity.multipleChoice(place.getId(), place.getLocation(), title, description,
+							request.rewardPoints(), request.maxAttempts());
+				}
+				case OX -> {
+					if (request.oxCorrectAnswer() == null) {
+						throw new InvalidMissionRequestException();
+					}
+					requireNoChoices(request.choices());
+					yield MissionEntity.ox(place.getId(), place.getLocation(), title, description,
+							request.rewardPoints(), request.maxAttempts(), request.oxCorrectAnswer());
+				}
+				case PHOTO -> {
+					requireNoOxAnswer(request.oxCorrectAnswer());
+					requireNoChoices(request.choices());
+					if (request.maxAttempts() != null) {
+						throw new InvalidMissionRequestException();
+					}
+					yield MissionEntity.photo(place.getId(), place.getLocation(), title, description,
+							request.rewardPoints());
+				}
+			};
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidMissionRequestException();
+		}
+		missionQueryRepository.save(mission);
+
+		if (type == MissionType.MULTIPLE_CHOICE) {
+			saveChoices(mission.getId(), request.choices());
+		}
+		return mission.getId();
+	}
+
+	@Transactional
+	public void update(UUID missionId, MissionAdminUpdateRequest request) {
+		MissionEntity mission = missionQueryRepository.findById(missionId).filter(candidate -> !candidate.isDeleted())
+				.orElseThrow(MissionNotFoundException::new);
+		String title = requiredText(request.title());
+		String description = requiredText(request.description());
+
+		try {
+			switch (mission.getType()) {
+				case MULTIPLE_CHOICE -> {
+					requireNoOxAnswer(request.oxCorrectAnswer());
+					mission.updateMultipleChoice(title, description, request.rewardPoints(), request.maxAttempts());
+					missionChoiceRepository.deleteByMissionId(missionId);
+					missionChoiceRepository.flush();
+					saveChoices(missionId, request.choices());
+				}
+				case OX -> {
+					if (request.oxCorrectAnswer() == null) {
+						throw new InvalidMissionRequestException();
+					}
+					requireNoChoices(request.choices());
+					mission.updateOx(title, description, request.rewardPoints(), request.maxAttempts(),
+							request.oxCorrectAnswer());
+				}
+				case PHOTO -> {
+					requireNoOxAnswer(request.oxCorrectAnswer());
+					requireNoChoices(request.choices());
+					if (request.maxAttempts() != null) {
+						throw new InvalidMissionRequestException();
+					}
+					mission.updatePhoto(title, description, request.rewardPoints());
+				}
+			}
+		} catch (IllegalArgumentException | IllegalStateException exception) {
+			throw new InvalidMissionRequestException();
+		}
+	}
+
+	@Transactional
+	public void delete(UUID missionId) {
+		MissionEntity mission = missionQueryRepository.findById(missionId).filter(candidate -> !candidate.isDeleted())
+				.orElseThrow(MissionNotFoundException::new);
+		mission.softDelete();
+	}
+
+	private void saveChoices(UUID missionId, List<MissionChoiceRequest> choices) {
+		if (choices == null || choices.isEmpty()) {
+			throw new InvalidMissionRequestException();
+		}
+		boolean hasCorrect = choices.stream().anyMatch(MissionChoiceRequest::correct);
+		if (!hasCorrect) {
+			throw new InvalidMissionRequestException();
+		}
+		for (MissionChoiceRequest choice : choices) {
+			String label = requiredText(choice.label());
+			missionChoiceRepository.save(MissionChoiceEntity.create(missionId, label, choice.correct(),
+					choice.sortOrder()));
+		}
+	}
+
+	private void requireNoChoices(List<MissionChoiceRequest> choices) {
+		if (choices != null && !choices.isEmpty()) {
+			throw new InvalidMissionRequestException();
+		}
+	}
+
+	private void requireNoOxAnswer(Boolean oxCorrectAnswer) {
+		if (oxCorrectAnswer != null) {
+			throw new InvalidMissionRequestException();
+		}
+	}
+
+	private MissionType missionType(String value) {
+		if (value == null) {
+			throw new InvalidMissionRequestException();
+		}
+		try {
+			return MissionType.valueOf(value);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidMissionRequestException();
+		}
+	}
+
+	private String requiredText(String value) {
+		if (value == null || value.isBlank()) {
+			throw new InvalidMissionRequestException();
+		}
+		return value;
+	}
+}

--- a/src/main/java/com/buyeoon/mission/application/MissionAdminQueryService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionAdminQueryService.java
@@ -1,0 +1,59 @@
+package com.buyeoon.mission.application;
+
+import com.buyeoon.mission.api.MissionAdminListView;
+import com.buyeoon.mission.api.MissionAdminView;
+import com.buyeoon.mission.api.MissionAdminView.MissionAdminChoiceView;
+import com.buyeoon.mission.entity.MissionChoiceEntity;
+import com.buyeoon.mission.entity.MissionEntity;
+import com.buyeoon.mission.entity.MissionType;
+import com.buyeoon.mission.repository.MissionChoiceRepository;
+import com.buyeoon.mission.repository.MissionQueryRepository;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MissionAdminQueryService {
+
+	private final MissionQueryRepository missionQueryRepository;
+	private final MissionChoiceRepository missionChoiceRepository;
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public MissionAdminQueryService(MissionQueryRepository missionQueryRepository,
+			MissionChoiceRepository missionChoiceRepository) {
+		this.missionQueryRepository = missionQueryRepository;
+		this.missionChoiceRepository = missionChoiceRepository;
+	}
+
+	public MissionAdminListView list(UUID placeId, int page, int size) {
+		PageRequest pageRequest = PageRequest.of(page, size);
+		Page<MissionEntity> result = placeId == null
+				? missionQueryRepository.findAll(pageRequest)
+				: missionQueryRepository.findByPlaceId(placeId, pageRequest);
+		List<MissionAdminView> items = result.getContent().stream().map(mission -> toView(mission, List.of())).toList();
+		return new MissionAdminListView(items, page, size, result.getTotalElements(), result.getTotalPages());
+	}
+
+	public MissionAdminView get(UUID missionId) {
+		MissionEntity mission = missionQueryRepository.findById(missionId).orElseThrow(MissionNotFoundException::new);
+		List<MissionChoiceEntity> choices = mission.getType() == MissionType.MULTIPLE_CHOICE
+				? missionChoiceRepository.findByMissionIdOrderBySortOrderAsc(missionId)
+				: List.of();
+		return toView(mission, choices);
+	}
+
+	private MissionAdminView toView(MissionEntity mission, List<MissionChoiceEntity> choices) {
+		List<MissionAdminChoiceView> choiceViews = choices.stream()
+				.map(choice -> new MissionAdminChoiceView(choice.getId(), choice.getLabel(), choice.isCorrect(),
+						choice.getSortOrder()))
+				.toList();
+		return new MissionAdminView(mission.getId(), mission.getPlaceId(), mission.getType(), mission.getTitle(),
+				mission.getDescription(), mission.getRewardPoints(), mission.getMaxAttempts(),
+				mission.getOxCorrectAnswer(), choiceViews, mission.isDeleted());
+	}
+}

--- a/src/main/java/com/buyeoon/mission/entity/MissionEntity.java
+++ b/src/main/java/com/buyeoon/mission/entity/MissionEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -50,6 +51,9 @@ public class MissionEntity {
 	@Column(name = "ox_correct_answer")
 	private Boolean oxCorrectAnswer;
 
+	@Column(name = "deleted_at")
+	private Instant deletedAt;
+
 	public static MissionEntity multipleChoice(UUID placeId, Point location, String title, String description,
 			int rewardPoints, Integer maxAttempts) {
 		return create(placeId, location, MissionType.MULTIPLE_CHOICE, title, description, rewardPoints, maxAttempts,
@@ -69,9 +73,7 @@ public class MissionEntity {
 
 	private static MissionEntity create(UUID placeId, Point location, MissionType type, String title,
 			String description, int rewardPoints, Integer maxAttempts, Boolean oxCorrectAnswer) {
-		if (maxAttempts != null && maxAttempts <= 0) {
-			throw new IllegalArgumentException("Maximum attempts must be positive");
-		}
+		validateMaxAttempts(maxAttempts);
 		location.setSRID(4326);
 		MissionEntity mission = new MissionEntity();
 		mission.placeId = placeId;
@@ -83,5 +85,52 @@ public class MissionEntity {
 		mission.maxAttempts = maxAttempts;
 		mission.oxCorrectAnswer = oxCorrectAnswer;
 		return mission;
+	}
+
+	public void updateMultipleChoice(String title, String description, int rewardPoints, Integer maxAttempts) {
+		if (type != MissionType.MULTIPLE_CHOICE) {
+			throw new IllegalStateException("객관식 미션이 아닙니다.");
+		}
+		validateMaxAttempts(maxAttempts);
+		this.title = title;
+		this.description = description;
+		this.rewardPoints = rewardPoints;
+		this.maxAttempts = maxAttempts;
+	}
+
+	public void updateOx(String title, String description, int rewardPoints, Integer maxAttempts,
+			boolean correctAnswer) {
+		if (type != MissionType.OX) {
+			throw new IllegalStateException("OX 미션이 아닙니다.");
+		}
+		validateMaxAttempts(maxAttempts);
+		this.title = title;
+		this.description = description;
+		this.rewardPoints = rewardPoints;
+		this.maxAttempts = maxAttempts;
+		this.oxCorrectAnswer = correctAnswer;
+	}
+
+	public void updatePhoto(String title, String description, int rewardPoints) {
+		if (type != MissionType.PHOTO) {
+			throw new IllegalStateException("사진 인증 미션이 아닙니다.");
+		}
+		this.title = title;
+		this.description = description;
+		this.rewardPoints = rewardPoints;
+	}
+
+	public void softDelete() {
+		this.deletedAt = Instant.now();
+	}
+
+	public boolean isDeleted() {
+		return deletedAt != null;
+	}
+
+	private static void validateMaxAttempts(Integer maxAttempts) {
+		if (maxAttempts != null && maxAttempts <= 0) {
+			throw new IllegalArgumentException("Maximum attempts must be positive");
+		}
 	}
 }

--- a/src/main/java/com/buyeoon/mission/repository/MissionChoiceRepository.java
+++ b/src/main/java/com/buyeoon/mission/repository/MissionChoiceRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MissionChoiceRepository extends JpaRepository<MissionChoiceEntity, UUID> {
 
 	List<MissionChoiceEntity> findByMissionIdOrderBySortOrderAsc(UUID missionId);
+
+	void deleteByMissionId(UUID missionId);
 }

--- a/src/main/java/com/buyeoon/mission/repository/MissionQueryRepository.java
+++ b/src/main/java/com/buyeoon/mission/repository/MissionQueryRepository.java
@@ -4,6 +4,8 @@ import com.buyeoon.mission.entity.MissionEntity;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,7 +25,8 @@ public interface MissionQueryRepository extends JpaRepository<MissionEntity, UUI
 			JOIN PlaceEntity p ON p.id = m.placeId
 			LEFT JOIN MissionParticipationEntity participation
 			    ON participation.missionId = m.id AND participation.tripId = :tripId
-			WHERE ST_Distance(m.location,
+			WHERE m.deletedAt IS NULL
+			  AND ST_Distance(m.location,
 			          ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)) <= 500
 			ORDER BY 3 ASC, m.id ASC
 			""")
@@ -40,6 +43,7 @@ public interface MissionQueryRepository extends JpaRepository<MissionEntity, UUI
 			LEFT JOIN MissionParticipationEntity participation
 			    ON participation.missionId = m.id AND participation.tripId = :tripId
 			WHERE m.id = :missionId
+			  AND m.deletedAt IS NULL
 			""")
 	Optional<NearbyMissionProjection> findDetail(@Param("missionId") UUID missionId, @Param("tripId") UUID tripId,
 			@Param("latitude") double latitude, @Param("longitude") double longitude);
@@ -51,7 +55,10 @@ public interface MissionQueryRepository extends JpaRepository<MissionEntity, UUI
 			FROM MissionEntity m
 			JOIN PlaceEntity p ON p.id = m.placeId
 			WHERE m.id = :missionId
+			  AND m.deletedAt IS NULL
 			""")
 	Optional<MissionPlaceDistanceProjection> findWithDistance(@Param("missionId") UUID missionId,
 			@Param("latitude") double latitude, @Param("longitude") double longitude);
+
+	Page<MissionEntity> findByPlaceId(UUID placeId, Pageable pageable);
 }

--- a/src/main/java/com/buyeoon/place/api/PlaceAdminController.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceAdminController.java
@@ -1,0 +1,78 @@
+package com.buyeoon.place.api;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.place.application.PlaceAdminCommandService;
+import com.buyeoon.place.application.PlaceAdminQueryService;
+import com.buyeoon.place.entity.PlaceCategory;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Map;
+import java.util.UUID;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PlaceAdminController {
+
+	private static final int MIN_SIZE = 1;
+	private static final int MAX_SIZE = 100;
+
+	private final PlaceAdminCommandService placeAdminCommandService;
+	private final PlaceAdminQueryService placeAdminQueryService;
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public PlaceAdminController(PlaceAdminCommandService placeAdminCommandService,
+			PlaceAdminQueryService placeAdminQueryService) {
+		this.placeAdminCommandService = placeAdminCommandService;
+		this.placeAdminQueryService = placeAdminQueryService;
+	}
+
+	@PostMapping("/admin/places")
+	public SuccessResponse<Map<String, UUID>> create(@RequestBody PlaceAdminCreateRequest request) {
+		UUID placeId = placeAdminCommandService.create(request);
+		return SuccessResponse.of(Map.of("placeId", placeId));
+	}
+
+	@PutMapping("/admin/places/{placeId}")
+	public SuccessResponse<Map<String, Object>> update(@PathVariable UUID placeId,
+			@RequestBody PlaceAdminUpdateRequest request) {
+		placeAdminCommandService.update(placeId, request);
+		return SuccessResponse.of(Map.of());
+	}
+
+	@DeleteMapping("/admin/places/{placeId}")
+	public SuccessResponse<Map<String, Object>> delete(@PathVariable UUID placeId) {
+		placeAdminCommandService.delete(placeId);
+		return SuccessResponse.of(Map.of());
+	}
+
+	@GetMapping("/admin/places")
+	public SuccessResponse<PlaceAdminListView> list(@RequestParam(required = false) String category,
+			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "20") int size) {
+		if (size < MIN_SIZE || size > MAX_SIZE || page < 0) {
+			throw new InvalidPlaceRequestException();
+		}
+		return SuccessResponse.of(placeAdminQueryService.list(parseCategory(category), page, size));
+	}
+
+	@GetMapping("/admin/places/{placeId}")
+	public SuccessResponse<PlaceAdminView> get(@PathVariable UUID placeId) {
+		return SuccessResponse.of(placeAdminQueryService.get(placeId));
+	}
+
+	private PlaceCategory parseCategory(String category) {
+		if (category == null) {
+			return null;
+		}
+		try {
+			return PlaceCategory.valueOf(category);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidPlaceRequestException();
+		}
+	}
+}

--- a/src/main/java/com/buyeoon/place/api/PlaceAdminCreateRequest.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceAdminCreateRequest.java
@@ -1,0 +1,6 @@
+package com.buyeoon.place.api;
+
+public record PlaceAdminCreateRequest(String category, String name, String summary, String description,
+		String address, String imageKey, Double latitude, Double longitude, String operatingHoursRaw,
+		Boolean alwaysOpen, String opensAt, String closesAt, Integer admissionFee) {
+}

--- a/src/main/java/com/buyeoon/place/api/PlaceAdminListView.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceAdminListView.java
@@ -1,0 +1,10 @@
+package com.buyeoon.place.api;
+
+import java.util.List;
+
+public record PlaceAdminListView(List<PlaceAdminView> items, int page, int size, long totalElements,
+		int totalPages) {
+	public PlaceAdminListView {
+		items = List.copyOf(items);
+	}
+}

--- a/src/main/java/com/buyeoon/place/api/PlaceAdminUpdateRequest.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceAdminUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.buyeoon.place.api;
+
+public record PlaceAdminUpdateRequest(String category, String name, String summary, String description,
+		String address, String imageKey, Double latitude, Double longitude, String operatingHoursRaw,
+		Boolean alwaysOpen, String opensAt, String closesAt, Integer admissionFee) {
+}

--- a/src/main/java/com/buyeoon/place/api/PlaceAdminView.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceAdminView.java
@@ -1,0 +1,10 @@
+package com.buyeoon.place.api;
+
+import com.buyeoon.place.entity.PlaceCategory;
+import java.time.LocalTime;
+import java.util.UUID;
+
+public record PlaceAdminView(UUID placeId, PlaceCategory category, String name, String summary, String description,
+		String address, String imageKey, double latitude, double longitude, String operatingHoursRaw,
+		boolean alwaysOpen, LocalTime opensAt, LocalTime closesAt, Integer admissionFee, boolean deleted) {
+}

--- a/src/main/java/com/buyeoon/place/api/PlaceExceptionHandler.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceExceptionHandler.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
-@RestControllerAdvice(assignableTypes = PlaceController.class)
+@RestControllerAdvice(assignableTypes = {PlaceController.class, PlaceAdminController.class})
 public class PlaceExceptionHandler {
 
 	@ExceptionHandler({InvalidPlaceRequestException.class, MissingServletRequestParameterException.class,

--- a/src/main/java/com/buyeoon/place/application/PlaceAdminCommandService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceAdminCommandService.java
@@ -1,0 +1,107 @@
+package com.buyeoon.place.application;
+
+import com.buyeoon.place.api.InvalidPlaceRequestException;
+import com.buyeoon.place.api.PlaceAdminCreateRequest;
+import com.buyeoon.place.api.PlaceAdminUpdateRequest;
+import com.buyeoon.place.entity.PlaceCategory;
+import com.buyeoon.place.entity.PlaceEntity;
+import com.buyeoon.place.repository.PlaceQueryRepository;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
+import java.util.UUID;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PlaceAdminCommandService {
+
+	private final PlaceQueryRepository placeQueryRepository;
+	private final GeometryFactory geometryFactory = new GeometryFactory();
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public PlaceAdminCommandService(PlaceQueryRepository placeQueryRepository) {
+		this.placeQueryRepository = placeQueryRepository;
+	}
+
+	@Transactional
+	public UUID create(PlaceAdminCreateRequest request) {
+		PlaceCategory category = category(request.category());
+		String name = requiredText(request.name());
+		Point location = point(request.latitude(), request.longitude());
+
+		PlaceEntity place = PlaceEntity.create(category, name, request.summary(), request.description(),
+				request.address(), request.imageKey(), location, null, null, null);
+		place.applyOperatingInfo(request.operatingHoursRaw(), alwaysOpen(request.alwaysOpen()),
+				time(request.opensAt()), time(request.closesAt()), request.admissionFee());
+		return placeQueryRepository.save(place).getId();
+	}
+
+	@Transactional
+	public void update(UUID placeId, PlaceAdminUpdateRequest request) {
+		PlaceEntity place = placeQueryRepository.findById(placeId).filter(candidate -> !candidate.isDeleted())
+				.orElseThrow(PlaceNotFoundException::new);
+
+		PlaceCategory category = category(request.category());
+		String name = requiredText(request.name());
+		Point location = point(request.latitude(), request.longitude());
+
+		place.applyAdminUpdate(category, name, request.summary(), request.description(), request.address(),
+				request.imageKey(), location);
+		place.applyOperatingInfo(request.operatingHoursRaw(), alwaysOpen(request.alwaysOpen()),
+				time(request.opensAt()), time(request.closesAt()), request.admissionFee());
+	}
+
+	@Transactional
+	public void delete(UUID placeId) {
+		PlaceEntity place = placeQueryRepository.findById(placeId).filter(candidate -> !candidate.isDeleted())
+				.orElseThrow(PlaceNotFoundException::new);
+		place.softDelete();
+	}
+
+	private PlaceCategory category(String value) {
+		if (value == null) {
+			throw new InvalidPlaceRequestException();
+		}
+		try {
+			return PlaceCategory.valueOf(value);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidPlaceRequestException();
+		}
+	}
+
+	private String requiredText(String value) {
+		if (value == null || value.isBlank()) {
+			throw new InvalidPlaceRequestException();
+		}
+		return value;
+	}
+
+	private Point point(Double latitude, Double longitude) {
+		if (latitude == null || longitude == null) {
+			throw new InvalidPlaceRequestException();
+		}
+		if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+			throw new InvalidPlaceRequestException();
+		}
+		return geometryFactory.createPoint(new Coordinate(longitude, latitude));
+	}
+
+	private boolean alwaysOpen(Boolean value) {
+		return value != null && value;
+	}
+
+	private LocalTime time(String value) {
+		if (value == null) {
+			return null;
+		}
+		try {
+			return LocalTime.parse(value);
+		} catch (DateTimeParseException exception) {
+			throw new InvalidPlaceRequestException();
+		}
+	}
+}

--- a/src/main/java/com/buyeoon/place/application/PlaceAdminQueryService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceAdminQueryService.java
@@ -1,0 +1,47 @@
+package com.buyeoon.place.application;
+
+import com.buyeoon.place.api.PlaceAdminListView;
+import com.buyeoon.place.api.PlaceAdminView;
+import com.buyeoon.place.entity.PlaceCategory;
+import com.buyeoon.place.entity.PlaceEntity;
+import com.buyeoon.place.repository.PlaceQueryRepository;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class PlaceAdminQueryService {
+
+	private final PlaceQueryRepository placeQueryRepository;
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
+	public PlaceAdminQueryService(PlaceQueryRepository placeQueryRepository) {
+		this.placeQueryRepository = placeQueryRepository;
+	}
+
+	public PlaceAdminListView list(PlaceCategory category, int page, int size) {
+		PageRequest pageRequest = PageRequest.of(page, size);
+		Page<PlaceEntity> result = category == null
+				? placeQueryRepository.findByDeletedAtIsNull(pageRequest)
+				: placeQueryRepository.findByDeletedAtIsNullAndCategory(category, pageRequest);
+		return new PlaceAdminListView(result.getContent().stream().map(this::toView).toList(), page, size,
+				result.getTotalElements(), result.getTotalPages());
+	}
+
+	public PlaceAdminView get(UUID placeId) {
+		PlaceEntity place = placeQueryRepository.findById(placeId).filter(candidate -> !candidate.isDeleted())
+				.orElseThrow(PlaceNotFoundException::new);
+		return toView(place);
+	}
+
+	private PlaceAdminView toView(PlaceEntity place) {
+		return new PlaceAdminView(place.getId(), place.getCategory(), place.getName(), place.getSummary(),
+				place.getDescription(), place.getAddress(), place.getImageKey(), place.getLocation().getY(),
+				place.getLocation().getX(), place.getOperatingHoursRaw(), place.isAlwaysOpen(), place.getOpensAt(),
+				place.getClosesAt(), place.getAdmissionFee(), place.isDeleted());
+	}
+}

--- a/src/main/java/com/buyeoon/place/entity/PlaceEntity.java
+++ b/src/main/java/com/buyeoon/place/entity/PlaceEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.Instant;
 import java.time.LocalTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -82,6 +83,9 @@ public class PlaceEntity {
 	@Column(name = "detail_info", nullable = false, columnDefinition = "jsonb")
 	private Map<String, String> detailInfo = new LinkedHashMap<>();
 
+	@Column(name = "deleted_at")
+	private Instant deletedAt;
+
 	public static PlaceEntity create(PlaceCategory category, String name, String summary, String description,
 			String address, String imageKey, Point location, String sourceName, String externalId, String sourceUrl) {
 		location.setSRID(4326);
@@ -143,5 +147,26 @@ public class PlaceEntity {
 		place.sourceUrl = sourceUrl;
 		place.sourceImageHref = sourceImageHref;
 		return place;
+	}
+
+	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "JTS Point는 PostGIS geography 매핑을 위해 그대로 보관한다.")
+	public void applyAdminUpdate(PlaceCategory category, String name, String summary, String description,
+			String address, String imageKey, Point location) {
+		location.setSRID(4326);
+		this.category = category;
+		this.name = name;
+		this.summary = summary;
+		this.description = description;
+		this.address = address;
+		this.imageKey = imageKey;
+		this.location = location;
+	}
+
+	public void softDelete() {
+		this.deletedAt = Instant.now();
+	}
+
+	public boolean isDeleted() {
+		return deletedAt != null;
 	}
 }

--- a/src/main/java/com/buyeoon/place/repository/PlaceQueryRepository.java
+++ b/src/main/java/com/buyeoon/place/repository/PlaceQueryRepository.java
@@ -5,6 +5,7 @@ import com.buyeoon.place.entity.PlaceEntity;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,6 +22,7 @@ public interface PlaceQueryRepository extends JpaRepository<PlaceEntity, UUID> {
 			       ST_Distance(p.location,
 			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
 			FROM PlaceEntity p
+			WHERE p.deletedAt IS NULL
 			ORDER BY 2 ASC, p.id ASC
 			""")
 	List<PlaceProjection> findFromStart(@Param("latitude") double latitude, @Param("longitude") double longitude,
@@ -32,6 +34,7 @@ public interface PlaceQueryRepository extends JpaRepository<PlaceEntity, UUID> {
 			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
 			FROM PlaceEntity p
 			WHERE p.category = :category
+			  AND p.deletedAt IS NULL
 			ORDER BY 2 ASC, p.id ASC
 			""")
 	List<PlaceProjection> findFromStartByCategory(@Param("category") PlaceCategory category,
@@ -42,13 +45,14 @@ public interface PlaceQueryRepository extends JpaRepository<PlaceEntity, UUID> {
 			       ST_Distance(p.location,
 			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
 			FROM PlaceEntity p
-			WHERE ST_Distance(p.location,
+			WHERE p.deletedAt IS NULL
+			  AND (ST_Distance(p.location,
 			          ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326))
 			      > :distanceMeters
 			   OR (ST_Distance(p.location,
 			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326))
 			       >= :distanceMeters
-			       AND p.id > :placeId)
+			       AND p.id > :placeId))
 			ORDER BY 2 ASC, p.id ASC
 			""")
 	List<PlaceProjection> findAfter(@Param("latitude") double latitude, @Param("longitude") double longitude,
@@ -60,6 +64,7 @@ public interface PlaceQueryRepository extends JpaRepository<PlaceEntity, UUID> {
 			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)))
 			FROM PlaceEntity p
 			WHERE p.category = :category
+			  AND p.deletedAt IS NULL
 			  AND (ST_Distance(p.location,
 			           ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326))
 			       > :distanceMeters
@@ -84,4 +89,8 @@ public interface PlaceQueryRepository extends JpaRepository<PlaceEntity, UUID> {
 			@Param("longitude") double longitude);
 
 	Optional<PlaceEntity> findBySourceNameAndExternalId(String sourceName, String externalId);
+
+	Page<PlaceEntity> findByDeletedAtIsNull(Pageable pageable);
+
+	Page<PlaceEntity> findByDeletedAtIsNullAndCategory(PlaceCategory category, Pageable pageable);
 }

--- a/src/main/java/com/buyeoon/place/sync/PlaceUpsertService.java
+++ b/src/main/java/com/buyeoon/place/sync/PlaceUpsertService.java
@@ -4,6 +4,7 @@ import com.buyeoon.place.entity.PlaceCategory;
 import com.buyeoon.place.entity.PlaceEntity;
 import com.buyeoon.place.repository.PlaceQueryRepository;
 import com.buyeoon.place.sync.OperatingHoursParser.ParsedOperatingHours;
+import java.util.Optional;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
@@ -29,14 +30,21 @@ class PlaceUpsertService {
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	void upsert(PlaceCategory category, TourApiPlaceDetail detail) {
+		Optional<PlaceEntity> existing = placeQueryRepository.findBySourceNameAndExternalId(SOURCE_NAME,
+				detail.contentId());
+		if (existing.isPresent() && existing.get().isDeleted()) {
+			// 관리자가 soft delete한 장소는 sync가 되살리지 않는다.
+			return;
+		}
+
 		Point location = geometryFactory.createPoint(new Coordinate(detail.longitude(), detail.latitude()));
 		ParsedOperatingHours parsedHours = OperatingHoursParser.parse(detail.useTime());
 		Integer admissionFee = OperatingHoursParser.parseFee(detail.useFee());
 		String summary = PlaceSummaryGenerator.fromOverview(detail.overview());
 
-		PlaceEntity place = placeQueryRepository.findBySourceNameAndExternalId(SOURCE_NAME, detail.contentId())
-				.orElseGet(() -> PlaceEntity.createFromSync(category, detail.title(), summary, detail.overview(),
-						detail.address(), location, SOURCE_NAME, detail.contentId(), null, detail.firstImageUrl()));
+		PlaceEntity place = existing.orElseGet(() -> PlaceEntity.createFromSync(category, detail.title(), summary,
+				detail.overview(), detail.address(), location, SOURCE_NAME, detail.contentId(), null,
+				detail.firstImageUrl()));
 
 		place.overwriteFrom(category, detail.title(), summary, detail.overview(), detail.address(), location, null,
 				detail.firstImageUrl());

--- a/src/main/resources/db/migration/V32__add_place_deleted_at.sql
+++ b/src/main/resources/db/migration/V32__add_place_deleted_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE places ADD COLUMN deleted_at timestamptz;

--- a/src/main/resources/db/migration/V33__add_mission_deleted_at.sql
+++ b/src/main/resources/db/migration/V33__add_mission_deleted_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE missions ADD COLUMN deleted_at timestamptz;

--- a/src/test/java/com/buyeoon/badge/BadgeAdminControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/badge/BadgeAdminControllerIntegrationTests.java
@@ -1,0 +1,198 @@
+package com.buyeoon.badge;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import tools.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class BadgeAdminControllerIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+	private static final String VALID_API_KEY = "test-admin-api-key";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeAll
+	static void configureAwsCredentials() {
+		System.setProperty("aws.accessKeyId", "test-access-key");
+		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	@AfterAll
+	static void clearAwsCredentials() {
+		System.clearProperty("aws.accessKeyId");
+		System.clearProperty("aws.secretAccessKey");
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM member_badges");
+		jdbcTemplate.update("DELETE FROM badge_conditions WHERE badge_id IN (SELECT id FROM badges WHERE name LIKE '테스트%')");
+		jdbcTemplate.update("DELETE FROM badges WHERE name LIKE '테스트%'");
+	}
+
+	@Test
+	@DisplayName("조건을 포함해 생성하고 수정한 뒤 retire/activate 토글이 동작한다")
+	void createUpdateAndToggleBadge() throws Exception {
+		MvcResult createResult = mockMvc
+				.perform(createRequest("""
+						{"category":"EXPLORATION","name":"테스트 배지","description":"설명","imageKey":"public/badge.png",
+						"conditionText":"조건 설명","active":true,
+						"conditions":[{"metricKey":"MISSION_COMPLETED_COUNT","threshold":5}]}
+						"""))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.badgeId").exists()).andReturn();
+		String badgeId = objectMapper.readTree(createResult.getResponse().getContentAsString()).path("data")
+				.path("badgeId").asString();
+
+		mockMvc.perform(getDetailRequest(badgeId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.retired").value(false))
+				.andExpect(jsonPath("$.data.conditions.length()").value(1));
+
+		mockMvc.perform(updateRequest(badgeId, """
+				{"category":"QUIZ","name":"테스트 배지 수정","description":"수정 설명","imageKey":"public/badge2.png",
+				"conditionText":"수정 조건",
+				"conditions":[{"metricKey":"QUIZ_CORRECT_COUNT","threshold":10}]}
+				""")).andExpect(status().isOk());
+
+		mockMvc.perform(getDetailRequest(badgeId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.name").value("테스트 배지 수정"));
+
+		mockMvc.perform(retireRequest(badgeId)).andExpect(status().isOk());
+		mockMvc.perform(getDetailRequest(badgeId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.retired").value(true));
+
+		mockMvc.perform(activateRequest(badgeId)).andExpect(status().isOk());
+		mockMvc.perform(getDetailRequest(badgeId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.retired").value(false));
+	}
+
+	@Test
+	@DisplayName("잘못된 metricKey로 생성하면 400을 받는다")
+	void returns400ForInvalidMetricKey() throws Exception {
+		mockMvc.perform(createRequest("""
+				{"category":"EXPLORATION","name":"테스트 배지","description":"설명","conditionText":"조건",
+				"active":true,"conditions":[{"metricKey":"NOT_A_METRIC","threshold":1}]}
+				""")).andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	@Test
+	@DisplayName("조건 없이 활성화를 시도하면 400을 받는다")
+	void returns400WhenActivatingWithoutConditions() throws Exception {
+		MvcResult createResult = mockMvc
+				.perform(createRequest("""
+						{"category":"EXPLORATION","name":"테스트 배지","description":"설명","conditionText":"조건",
+						"active":false,"conditions":[]}
+						"""))
+				.andExpect(status().isOk()).andReturn();
+		String badgeId = objectMapper.readTree(createResult.getResponse().getContentAsString()).path("data")
+				.path("badgeId").asString();
+
+		mockMvc.perform(activateRequest(badgeId)).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	@Test
+	@DisplayName("조건 없이 즉시 활성화로 생성하면 400을 받는다")
+	void returns400WhenCreatingActiveWithoutConditions() throws Exception {
+		mockMvc.perform(createRequest("""
+				{"category":"EXPLORATION","name":"테스트 배지","description":"설명","conditionText":"조건",
+				"active":true,"conditions":[]}
+				""")).andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	@Test
+	@DisplayName("허용된 metric 목록을 조회할 수 있다")
+	void returnsAllowedMetrics() throws Exception {
+		mockMvc.perform(get("/admin/badge-metrics").header("X-Admin-Api-Key", VALID_API_KEY)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.length()").value(8));
+	}
+
+	@Test
+	@DisplayName("API Key가 없으면 401을 받는다")
+	void returns401WhenApiKeyMissing() throws Exception {
+		mockMvc.perform(get("/admin/badges")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 배지를 조회하면 404를 받는다")
+	void returns404WhenBadgeDoesNotExist() throws Exception {
+		mockMvc.perform(getDetailRequest(java.util.UUID.randomUUID().toString())).andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	private MockHttpServletRequestBuilder createRequest(String body) {
+		return post("/admin/badges").header("X-Admin-Api-Key", VALID_API_KEY).contentType(MediaType.APPLICATION_JSON)
+				.content(body);
+	}
+
+	private MockHttpServletRequestBuilder updateRequest(String badgeId, String body) {
+		return put("/admin/badges/{badgeId}", badgeId).header("X-Admin-Api-Key", VALID_API_KEY)
+				.contentType(MediaType.APPLICATION_JSON).content(body);
+	}
+
+	private MockHttpServletRequestBuilder retireRequest(String badgeId) {
+		return post("/admin/badges/{badgeId}/retire", badgeId).header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	private MockHttpServletRequestBuilder activateRequest(String badgeId) {
+		return post("/admin/badges/{badgeId}/activate", badgeId).header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	private MockHttpServletRequestBuilder getDetailRequest(String badgeId) {
+		return get("/admin/badges/{badgeId}", badgeId).header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("storage.images.bucket", () -> "buyeoon-test-images");
+		registry.add("storage.images.region", () -> "ap-northeast-2");
+		registry.add("admin.api-key", () -> VALID_API_KEY);
+	}
+}

--- a/src/test/java/com/buyeoon/mission/MissionAdminControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionAdminControllerIntegrationTests.java
@@ -1,0 +1,208 @@
+package com.buyeoon.mission;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import tools.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class MissionAdminControllerIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+	private static final String VALID_API_KEY = "test-admin-api-key";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeAll
+	static void configureAwsCredentials() {
+		System.setProperty("aws.accessKeyId", "test-access-key");
+		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	@AfterAll
+	static void clearAwsCredentials() {
+		System.clearProperty("aws.accessKeyId");
+		System.clearProperty("aws.secretAccessKey");
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update(
+				"DELETE FROM mission_choices WHERE mission_id IN "
+						+ "(SELECT id FROM missions WHERE place_id IN (SELECT id FROM places WHERE ST_Y(location::geometry) < -70))");
+		jdbcTemplate.update(
+				"DELETE FROM missions WHERE place_id IN (SELECT id FROM places WHERE ST_Y(location::geometry) < -70)");
+		jdbcTemplate.update("DELETE FROM places WHERE ST_Y(location::geometry) < -70");
+	}
+
+	@Test
+	@DisplayName("객관식 미션을 생성하면 choices가 저장되고, 수정하면 교체되며, 삭제하면 목록에서 제외된다")
+	void createUpdateAndDeleteMultipleChoiceMission() throws Exception {
+		UUID placeId = insertPlace();
+
+		MvcResult createResult = mockMvc
+				.perform(createRequest("""
+						{"placeId":"%s","type":"MULTIPLE_CHOICE","title":"문제1","description":"설명",
+						"rewardPoints":100,"maxAttempts":3,
+						"choices":[{"label":"보기1","correct":true,"sortOrder":0},
+						           {"label":"보기2","correct":false,"sortOrder":1}]}
+						""".formatted(placeId)))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.missionId").exists()).andReturn();
+		String missionId = objectMapper.readTree(createResult.getResponse().getContentAsString()).path("data")
+				.path("missionId").asString();
+
+		mockMvc.perform(getDetailRequest(missionId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.type").value("MULTIPLE_CHOICE"))
+				.andExpect(jsonPath("$.data.choices.length()").value(2));
+
+		mockMvc.perform(updateRequest(missionId, """
+				{"title":"수정된 문제","description":"수정된 설명","rewardPoints":200,"maxAttempts":5,
+				"choices":[{"label":"새 보기","correct":true,"sortOrder":0}]}
+				""")).andExpect(status().isOk());
+
+		mockMvc.perform(getDetailRequest(missionId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.title").value("수정된 문제"))
+				.andExpect(jsonPath("$.data.choices.length()").value(1));
+
+		mockMvc.perform(listRequest(placeId.toString())).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items[?(@.missionId=='" + missionId + "')]").exists());
+
+		mockMvc.perform(deleteRequest(missionId)).andExpect(status().isOk());
+
+		mockMvc.perform(getDetailRequest(missionId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.deleted").value(true));
+
+		Boolean deleted = jdbcTemplate.queryForObject("SELECT deleted_at IS NOT NULL FROM missions WHERE id = ?::uuid",
+				Boolean.class, missionId);
+		assertThat(deleted).isTrue();
+	}
+
+	@Test
+	@DisplayName("PHOTO 타입 미션에 maxAttempts를 넣으면 400을 받는다")
+	void returns400WhenPhotoMissionHasMaxAttempts() throws Exception {
+		UUID placeId = insertPlace();
+
+		mockMvc.perform(createRequest("""
+				{"placeId":"%s","type":"PHOTO","title":"사진미션","description":"설명","rewardPoints":100,"maxAttempts":3}
+				""".formatted(placeId))).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	@Test
+	@DisplayName("OX 타입 미션을 생성하고 조회할 수 있다")
+	void createsOxMission() throws Exception {
+		UUID placeId = insertPlace();
+
+		mockMvc.perform(createRequest("""
+				{"placeId":"%s","type":"OX","title":"OX 미션","description":"설명","rewardPoints":100,
+				"oxCorrectAnswer":true}
+				""".formatted(placeId))).andExpect(status().isOk());
+	}
+
+	@Test
+	@DisplayName("API Key가 없으면 401을 받는다")
+	void returns401WhenApiKeyMissing() throws Exception {
+		mockMvc.perform(get("/admin/missions")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	@Test
+	@DisplayName("API Key가 틀리면 401을 받는다")
+	void returns401WhenApiKeyIncorrect() throws Exception {
+		mockMvc.perform(get("/admin/missions").header("X-Admin-Api-Key", "wrong-key"))
+				.andExpect(status().isUnauthorized()).andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 미션을 조회하면 404를 받는다")
+	void returns404WhenMissionDoesNotExist() throws Exception {
+		mockMvc.perform(getDetailRequest(UUID.randomUUID().toString())).andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	private UUID insertPlace() {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO places (id, category, name, location) VALUES (?, 'HERITAGE'::place_category, '장소', "
+						+ "ST_SetSRID(ST_MakePoint(0, -75), 4326)::geography)",
+				id);
+		return id;
+	}
+
+	private MockHttpServletRequestBuilder createRequest(String body) {
+		return post("/admin/missions").header("X-Admin-Api-Key", VALID_API_KEY).contentType(MediaType.APPLICATION_JSON)
+				.content(body);
+	}
+
+	private MockHttpServletRequestBuilder updateRequest(String missionId, String body) {
+		return put("/admin/missions/{missionId}", missionId).header("X-Admin-Api-Key", VALID_API_KEY)
+				.contentType(MediaType.APPLICATION_JSON).content(body);
+	}
+
+	private MockHttpServletRequestBuilder deleteRequest(String missionId) {
+		return delete("/admin/missions/{missionId}", missionId).header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	private MockHttpServletRequestBuilder getDetailRequest(String missionId) {
+		return get("/admin/missions/{missionId}", missionId).header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	private MockHttpServletRequestBuilder listRequest(String placeId) {
+		return get("/admin/missions").param("placeId", placeId).header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("storage.images.bucket", () -> "buyeoon-test-images");
+		registry.add("storage.images.region", () -> "ap-northeast-2");
+		registry.add("admin.api-key", () -> VALID_API_KEY);
+	}
+}

--- a/src/test/java/com/buyeoon/mission/MissionControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionControllerIntegrationTests.java
@@ -96,6 +96,21 @@ class MissionControllerIntegrationTests {
 						.value(org.hamcrest.Matchers.containsInAnyOrder("OX", "MULTIPLE_CHOICE", "PHOTO")));
 	}
 
+	/** soft delete된 미션은 근처 미션 목록에서 제외된다. */
+	@Test
+	@DisplayName("soft delete된 미션은 근처 목록에서 제외된다")
+	void excludesSoftDeletedMissionFromNearbyList() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertPlace("장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE);
+		UUID visible = insertOxMission(place, "노출 미션", 100, null, true);
+		UUID deleted = insertOxMission(place, "삭제된 미션", 100, null, true);
+		jdbcTemplate.update("UPDATE missions SET deleted_at = now() WHERE id = ?", deleted);
+
+		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items.length()").value(1))
+				.andExpect(jsonPath("$.data.items[0].missionId").value(visible.toString()));
+	}
+
 	/** 500m 직전 미션은 포함되고 직후 미션은 제외된다. */
 	@Test
 	@DisplayName("500m 경계 안쪽 미션은 포함되고 바깥쪽 미션은 제외된다")

--- a/src/test/java/com/buyeoon/place/PlaceAdminControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/place/PlaceAdminControllerIntegrationTests.java
@@ -1,0 +1,177 @@
+package com.buyeoon.place;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import tools.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class PlaceAdminControllerIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+	private static final String VALID_API_KEY = "test-admin-api-key";
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@BeforeAll
+	static void configureAwsCredentials() {
+		System.setProperty("aws.accessKeyId", "test-access-key");
+		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	@AfterAll
+	static void clearAwsCredentials() {
+		System.clearProperty("aws.accessKeyId");
+		System.clearProperty("aws.secretAccessKey");
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM saved_places");
+		jdbcTemplate.update("DELETE FROM places WHERE ST_Y(location::geometry) < -70");
+	}
+
+	@Test
+	@DisplayName("생성 후 수정, 목록/상세 조회, 삭제, 목록 제외까지 전체 흐름이 동작한다")
+	void createUpdateListAndDeleteFlow() throws Exception {
+		MvcResult createResult = mockMvc
+				.perform(createRequest("""
+						{"category":"HERITAGE","name":"관리자 생성 장소","summary":"요약","description":"설명",
+						"address":"주소","imageKey":"public/place.jpg","latitude":-75.0,"longitude":0.0,
+						"operatingHoursRaw":"09:00~18:00","alwaysOpen":false,"opensAt":"09:00","closesAt":"18:00",
+						"admissionFee":1000}"""))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.placeId").exists()).andReturn();
+		String placeId = objectMapper.readTree(createResult.getResponse().getContentAsString()).path("data")
+				.path("placeId").asString();
+
+		mockMvc.perform(getDetailRequest(placeId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.name").value("관리자 생성 장소"))
+				.andExpect(jsonPath("$.data.deleted").value(false));
+
+		mockMvc.perform(updateRequest(placeId, """
+				{"category":"CAFE","name":"수정된 장소","summary":"새 요약","description":"새 설명",
+				"address":"새 주소","imageKey":"public/new.jpg","latitude":-75.0,"longitude":0.0,
+				"operatingHoursRaw":"상시 개방","alwaysOpen":true,"admissionFee":0}"""))
+				.andExpect(status().isOk());
+
+		mockMvc.perform(getDetailRequest(placeId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.name").value("수정된 장소"))
+				.andExpect(jsonPath("$.data.category").value("CAFE"));
+
+		mockMvc.perform(listRequest()).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items[?(@.placeId=='" + placeId + "')]").exists());
+
+		mockMvc.perform(deleteRequest(placeId)).andExpect(status().isOk());
+
+		mockMvc.perform(getDetailRequest(placeId)).andExpect(status().isNotFound());
+
+		Boolean deleted = jdbcTemplate.queryForObject("SELECT deleted_at IS NOT NULL FROM places WHERE id = ?::uuid",
+				Boolean.class, placeId);
+		assertThat(deleted).isTrue();
+	}
+
+	@Test
+	@DisplayName("API Key가 없으면 401을 받는다")
+	void returns401WhenApiKeyMissing() throws Exception {
+		mockMvc.perform(get("/admin/places")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	@Test
+	@DisplayName("API Key가 틀리면 401을 받는다")
+	void returns401WhenApiKeyIncorrect() throws Exception {
+		mockMvc.perform(get("/admin/places").header("X-Admin-Api-Key", "wrong-key")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	@Test
+	@DisplayName("필수 값이 없으면 400을 받는다")
+	void returns400WhenRequiredFieldsMissing() throws Exception {
+		mockMvc.perform(createRequest("{}")).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 장소를 조회하면 404를 받는다")
+	void returns404WhenPlaceDoesNotExist() throws Exception {
+		mockMvc.perform(getDetailRequest(UUID.randomUUID().toString())).andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	private MockHttpServletRequestBuilder createRequest(String body) {
+		return post("/admin/places").header("X-Admin-Api-Key", VALID_API_KEY).contentType(MediaType.APPLICATION_JSON)
+				.content(body);
+	}
+
+	private MockHttpServletRequestBuilder updateRequest(String placeId, String body) {
+		return put("/admin/places/{placeId}", placeId).header("X-Admin-Api-Key", VALID_API_KEY)
+				.contentType(MediaType.APPLICATION_JSON).content(body);
+	}
+
+	private MockHttpServletRequestBuilder deleteRequest(String placeId) {
+		return delete("/admin/places/{placeId}", placeId).header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	private MockHttpServletRequestBuilder getDetailRequest(String placeId) {
+		return get("/admin/places/{placeId}", placeId).header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	private MockHttpServletRequestBuilder listRequest() {
+		return get("/admin/places").header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("storage.images.bucket", () -> "buyeoon-test-images");
+		registry.add("storage.images.region", () -> "ap-northeast-2");
+		registry.add("admin.api-key", () -> VALID_API_KEY);
+	}
+}

--- a/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/place/PlaceControllerIntegrationTests.java
@@ -225,6 +225,28 @@ class PlaceControllerIntegrationTests {
 				.andExpect(jsonPath("$.data.items[0].category").value("CAFE"));
 	}
 
+	/**
+	 * soft delete된 장소는 사용자용 목록에서 제외된다. 시드 마이그레이션이 넣어 둔 부여 장소도 같은 카테고리로 함께
+	 * 잡히므로, 전체 개수가 아니라 삭제된 장소의 노출 여부만 확인한다.
+	 */
+	@Test
+	@DisplayName("soft delete된 장소는 목록에서 제외된다")
+	void excludesSoftDeletedPlaceFromList() throws Exception {
+		startTrip(member.memberId());
+		UUID visible = savePlace(PlaceCategory.HERITAGE, "노출 장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE + 0.001);
+		UUID deleted = savePlace(PlaceCategory.HERITAGE, "삭제된 장소", ORIGIN_LATITUDE + 0.002, ORIGIN_LONGITUDE + 0.002);
+		softDeletePlace(deleted);
+
+		mockMvc.perform(placeRequest().param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude",
+				String.valueOf(ORIGIN_LONGITUDE))).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items[?(@.placeId=='" + visible + "')]").exists())
+				.andExpect(jsonPath("$.data.items[?(@.placeId=='" + deleted + "')]").doesNotExist());
+	}
+
+	private void softDeletePlace(UUID placeId) {
+		jdbcTemplate.update("UPDATE places SET deleted_at = now() WHERE id = ?", placeId);
+	}
+
 	/** size만큼 끊어 반환하고, 커서로 이어받으면 남은 장소가 중복 없이 나온다. */
 	@Test
 	@DisplayName("size만큼 페이지네이션된 결과와 다음 커서를 받는다")


### PR DESCRIPTION
## Summary
- TourAPI 동기화(`/admin/places/sync`)와 Flyway seed로만 채워지던 장소/미션(퀴즈)/배지 운영 데이터를, 배포 없이 관리자가 직접 생성/수정/삭제할 수 있도록 `/admin/**` API를 추가했습니다.
- 인증은 기존 `AdminApiKeyFilter`(`X-Admin-Api-Key` 헤더, `/admin/**` 자동 적용)를 그대로 재사용합니다.
- 장소·미션은 `deleted_at` soft delete를 도입했고(FK로 연결된 미션/찜/제출 이력을 깨뜨리지 않기 위해), TourAPI 동기화가 관리자가 지운 장소를 되살리지 않도록 skip 분기를 추가했습니다.
- 배지는 기존 `retired_at`을 그대로 재활용해 활성/비활성 전환 API(`retire`/`activate`)를 추가했고, 배지 조건의 `metric_key`는 `BadgeMetric` enum(구현된 메트릭)으로만 제한 검증합니다. 메트릭 계산 로직 자체는 이번 스코프에서 건드리지 않았습니다.

## 신규 엔드포인트
- `POST/PUT/DELETE/GET /admin/places`, `/admin/places/{placeId}`
- `POST/PUT/DELETE/GET /admin/missions`, `/admin/missions/{missionId}` (place_id 필터 지원)
- `POST/PUT/GET /admin/badges`, `/admin/badges/{badgeId}`, `POST /admin/badges/{badgeId}/retire|activate`, `GET /admin/badge-metrics`

## 수정 중 발견한 버그
- `MissionAdminCommandService`/`BadgeAdminCommandService`에서 선택지/조건 전체 교체 시 `deleteByMissionId`/`deleteByIdBadgeId` 뒤에 `flush()`가 없어 Hibernate 플러시 순서(INSERT 먼저, DELETE 나중) 때문에 unique 제약(`sort_order`/`metric_key`) 위반이 발생 → `flush()` 추가로 해결.
- 기존 `PlaceControllerIntegrationTests`에 새로 추가한 soft-delete 테스트가 V4 시드 마이그레이션이 넣어둔 장소(정림사지)를 고려하지 않고 `items.length()==1`을 기대하던 문제 → 존재/부재 확인 방식으로 수정.

## Test plan
- [x] `./gradlew compileJava compileTestJava` 통과
- [x] 신규 `PlaceAdminControllerIntegrationTests`, `MissionAdminControllerIntegrationTests`, `BadgeAdminControllerIntegrationTests` 통과
- [x] 전체 `./gradlew test` 스위트(500개 이상) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DG8nZiKUW9NuBWdJqdjiQB