### PR TITLE
feat: 관리자 이미지 presigned 업로드 + 조회 URL 변환

### DIFF
--- a/src/main/java/com/buyeoon/badge/api/BadgeAdminController.java
+++ b/src/main/java/com/buyeoon/badge/api/BadgeAdminController.java
@@ -4,6 +4,7 @@ import com.buyeoon.badge.BadgeMetric;
 import com.buyeoon.badge.application.BadgeAdminCommandService;
 import com.buyeoon.badge.application.BadgeAdminQueryService;
 import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.common.storage.PublicImageUploadUrlView;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Map;
@@ -74,5 +75,12 @@ public class BadgeAdminController {
 	@GetMapping("/admin/badge-metrics")
 	public SuccessResponse<List<BadgeMetric>> getBadgeMetrics() {
 		return SuccessResponse.of(List.of(BadgeMetric.values()));
+	}
+
+	@PostMapping("/admin/badges/images/upload-url")
+	public SuccessResponse<PublicImageUploadUrlView> createImageUploadUrl(
+			@RequestBody BadgeAdminImageUploadUrlRequest request) {
+		return SuccessResponse
+				.of(badgeAdminCommandService.createImageUploadUrl(request.contentType(), request.fileSizeBytes()));
 	}
 }

--- a/src/main/java/com/buyeoon/badge/api/BadgeAdminImageUploadUrlRequest.java
+++ b/src/main/java/com/buyeoon/badge/api/BadgeAdminImageUploadUrlRequest.java
@@ -1,0 +1,4 @@
+package com.buyeoon.badge.api;
+
+public record BadgeAdminImageUploadUrlRequest(String contentType, long fileSizeBytes) {
+}

--- a/src/main/java/com/buyeoon/badge/api/BadgeAdminView.java
+++ b/src/main/java/com/buyeoon/badge/api/BadgeAdminView.java
@@ -4,7 +4,7 @@ import com.buyeoon.badge.entity.BadgeCategory;
 import java.util.List;
 import java.util.UUID;
 
-public record BadgeAdminView(UUID badgeId, BadgeCategory category, String name, String description, String imageKey,
+public record BadgeAdminView(UUID badgeId, BadgeCategory category, String name, String description, String imageUrl,
 		String conditionText, boolean retired, List<BadgeAdminConditionView> conditions) {
 	public BadgeAdminView {
 		conditions = List.copyOf(conditions);

--- a/src/main/java/com/buyeoon/badge/application/BadgeAdminCommandService.java
+++ b/src/main/java/com/buyeoon/badge/application/BadgeAdminCommandService.java
@@ -10,9 +10,17 @@ import com.buyeoon.badge.entity.BadgeConditionEntity;
 import com.buyeoon.badge.entity.BadgeEntity;
 import com.buyeoon.badge.repository.BadgeConditionRepository;
 import com.buyeoon.badge.repository.BadgeRepository;
+import com.buyeoon.common.storage.PublicImageObjectStore;
+import com.buyeoon.common.storage.PublicImageObjectStore.PublicImageObject;
+import com.buyeoon.common.storage.PublicImageUploadPresigner;
+import com.buyeoon.common.storage.PublicImageUploadPresigner.PublicImageUploadTarget;
+import com.buyeoon.common.storage.PublicImageUploadUrlView;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,14 +28,26 @@ import org.springframework.transaction.annotation.Transactional;
 public class BadgeAdminCommandService {
 
 	private static final String IMAGE_KEY_PREFIX = "public/";
+	private static final String UPLOAD_KEY_PREFIX = "public/badges/";
+	private static final Set<String> ALLOWED_IMAGE_CONTENT_TYPES = Set.of("image/jpeg", "image/png", "image/webp");
+	private static final Map<String, String> CONTENT_TYPE_EXTENSIONS = Map.of("image/jpeg", "jpg", "image/png", "png",
+			"image/webp", "webp");
 
 	private final BadgeRepository badgeRepository;
 	private final BadgeConditionRepository badgeConditionRepository;
+	private final PublicImageUploadPresigner publicImageUploadPresigner;
+	private final PublicImageObjectStore publicImageObjectStore;
+	private final long maxUploadBytes;
 
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
-	public BadgeAdminCommandService(BadgeRepository badgeRepository, BadgeConditionRepository badgeConditionRepository) {
+	public BadgeAdminCommandService(BadgeRepository badgeRepository, BadgeConditionRepository badgeConditionRepository,
+			PublicImageUploadPresigner publicImageUploadPresigner, PublicImageObjectStore publicImageObjectStore,
+			@Value("${storage.images.max-upload-bytes:10485760}") long maxUploadBytes) {
 		this.badgeRepository = badgeRepository;
 		this.badgeConditionRepository = badgeConditionRepository;
+		this.publicImageUploadPresigner = publicImageUploadPresigner;
+		this.publicImageObjectStore = publicImageObjectStore;
+		this.maxUploadBytes = maxUploadBytes;
 	}
 
 	@Transactional
@@ -88,6 +108,19 @@ public class BadgeAdminCommandService {
 		badge.activate();
 	}
 
+	public PublicImageUploadUrlView createImageUploadUrl(String contentType, long fileSizeBytes) {
+		if (contentType == null || !ALLOWED_IMAGE_CONTENT_TYPES.contains(contentType)) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+		if (fileSizeBytes <= 0 || fileSizeBytes > maxUploadBytes) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+		String key = UPLOAD_KEY_PREFIX + UUID.randomUUID() + "." + CONTENT_TYPE_EXTENSIONS.get(contentType);
+		PublicImageUploadTarget target = publicImageUploadPresigner.presign(key, contentType, fileSizeBytes);
+		return new PublicImageUploadUrlView(key, target.uploadUrl(), "PUT", target.headers(), 200,
+				target.expiresAt());
+	}
+
 	private void saveConditions(UUID badgeId, List<BadgeConditionRequest> conditions) {
 		for (BadgeConditionRequest condition : conditions) {
 			badgeConditionRepository.save(BadgeConditionEntity.create(badgeId, condition.metricKey(),
@@ -142,6 +175,13 @@ public class BadgeAdminCommandService {
 			return null;
 		}
 		if (!value.startsWith(IMAGE_KEY_PREFIX)) {
+			throw new InvalidBadgeAdminRequestException();
+		}
+		PublicImageObject object = publicImageObjectStore.head(value)
+				.orElseThrow(InvalidBadgeAdminRequestException::new);
+		if (object.fileSizeBytes() != object.declaredFileSizeBytes()
+				|| !object.contentType().equals(object.declaredContentType())
+				|| !ALLOWED_IMAGE_CONTENT_TYPES.contains(object.contentType())) {
 			throw new InvalidBadgeAdminRequestException();
 		}
 		return value;

--- a/src/main/java/com/buyeoon/badge/application/BadgeAdminQueryService.java
+++ b/src/main/java/com/buyeoon/badge/application/BadgeAdminQueryService.java
@@ -7,6 +7,7 @@ import com.buyeoon.badge.entity.BadgeConditionEntity;
 import com.buyeoon.badge.entity.BadgeEntity;
 import com.buyeoon.badge.repository.BadgeConditionRepository;
 import com.buyeoon.badge.repository.BadgeRepository;
+import com.buyeoon.common.storage.PublicImageUrlService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.UUID;
@@ -21,11 +22,14 @@ public class BadgeAdminQueryService {
 
 	private final BadgeRepository badgeRepository;
 	private final BadgeConditionRepository badgeConditionRepository;
+	private final PublicImageUrlService imageUrls;
 
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
-	public BadgeAdminQueryService(BadgeRepository badgeRepository, BadgeConditionRepository badgeConditionRepository) {
+	public BadgeAdminQueryService(BadgeRepository badgeRepository, BadgeConditionRepository badgeConditionRepository,
+			PublicImageUrlService imageUrls) {
 		this.badgeRepository = badgeRepository;
 		this.badgeConditionRepository = badgeConditionRepository;
+		this.imageUrls = imageUrls;
 	}
 
 	public BadgeAdminListView list(int page, int size) {
@@ -45,7 +49,8 @@ public class BadgeAdminQueryService {
 		List<BadgeAdminConditionView> conditionViews = conditions.stream()
 				.map(condition -> new BadgeAdminConditionView(condition.getId().metricKey(), condition.getThreshold()))
 				.toList();
+		String imageUrl = badge.getImageKey() != null ? imageUrls.create(badge.getImageKey()) : null;
 		return new BadgeAdminView(badge.getId(), badge.getCategory(), badge.getName(), badge.getDescription(),
-				badge.getImageKey(), badge.getConditionText(), badge.getRetiredAt() != null, conditionViews);
+				imageUrl, badge.getConditionText(), badge.getRetiredAt() != null, conditionViews);
 	}
 }

--- a/src/main/java/com/buyeoon/common/storage/PublicImageObjectStore.java
+++ b/src/main/java/com/buyeoon/common/storage/PublicImageObjectStore.java
@@ -1,0 +1,21 @@
+package com.buyeoon.common.storage;
+
+import java.util.Optional;
+
+/**
+ * 관리자용 공개 이미지에서 실제로 업로드된 S3 객체의 실체를 확인하는 seam이다. 테스트는 실제 AWS 호출 없이 이 인터페이스를
+ * 대체해 크기·Content-Type의 일치·불일치와 존재하지 않는 객체를 조합해 검증한다.
+ */
+public interface PublicImageObjectStore {
+
+	Optional<PublicImageObject> head(String objectKey);
+
+	/**
+	 * {@code contentType}·{@code fileSizeBytes}는 실제 업로드된 객체의 값이고,
+	 * {@code declaredContentType}·{@code declaredFileSizeBytes}는 Presigned URL 발급
+	 * 요청에서 서명된 메타데이터로 남긴 값이다.
+	 */
+	record PublicImageObject(String contentType, long fileSizeBytes, String declaredContentType,
+			long declaredFileSizeBytes) {
+	}
+}

--- a/src/main/java/com/buyeoon/common/storage/PublicImageUploadPresigner.java
+++ b/src/main/java/com/buyeoon/common/storage/PublicImageUploadPresigner.java
@@ -1,0 +1,20 @@
+package com.buyeoon.common.storage;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * 관리자용 공개 이미지(장소/배지 등)의 S3 Presigned PUT URL 발급 seam이다. 테스트는 실제 AWS 호출 없이 이 인터페이스를
+ * 대체한다.
+ */
+public interface PublicImageUploadPresigner {
+
+	PublicImageUploadTarget presign(String objectKey, String contentType, long fileSizeBytes);
+
+	record PublicImageUploadTarget(String uploadUrl, Map<String, String> headers, Instant expiresAt) {
+
+		public PublicImageUploadTarget {
+			headers = Map.copyOf(headers);
+		}
+	}
+}

--- a/src/main/java/com/buyeoon/common/storage/PublicImageUploadUrlView.java
+++ b/src/main/java/com/buyeoon/common/storage/PublicImageUploadUrlView.java
@@ -1,0 +1,12 @@
+package com.buyeoon.common.storage;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record PublicImageUploadUrlView(String imageKey, String uploadUrl, String method, Map<String, String> headers,
+		int successStatus, Instant expiresAt) {
+
+	public PublicImageUploadUrlView {
+		headers = Map.copyOf(headers);
+	}
+}

--- a/src/main/java/com/buyeoon/common/storage/S3PublicImageObjectStore.java
+++ b/src/main/java/com/buyeoon/common/storage/S3PublicImageObjectStore.java
@@ -1,0 +1,58 @@
+package com.buyeoon.common.storage;
+
+import jakarta.annotation.PreDestroy;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+@Service
+public class S3PublicImageObjectStore implements PublicImageObjectStore {
+
+	private static final String DECLARED_FILE_SIZE_METADATA_KEY = "declared-file-size-bytes";
+	private static final String DECLARED_CONTENT_TYPE_METADATA_KEY = "declared-content-type";
+
+	private final String bucket;
+	private final S3Client s3Client;
+
+	public S3PublicImageObjectStore(@Value("${storage.images.bucket:}") String bucket,
+			@Value("${storage.images.region:ap-northeast-2}") String region) {
+		this.bucket = bucket;
+		this.s3Client = S3Client.builder().region(Region.of(region)).build();
+	}
+
+	@Override
+	public Optional<PublicImageObject> head(String objectKey) {
+		if (bucket.isBlank()) {
+			throw new IllegalStateException("IMAGE_BUCKET 설정이 필요합니다.");
+		}
+		try {
+			HeadObjectResponse response = s3Client
+					.headObject(HeadObjectRequest.builder().bucket(bucket).key(objectKey).build());
+			Map<String, String> metadata = response.metadata();
+			String declaredContentType = metadata.get(DECLARED_CONTENT_TYPE_METADATA_KEY);
+			String declaredFileSizeBytes = metadata.get(DECLARED_FILE_SIZE_METADATA_KEY);
+			if (declaredFileSizeBytes == null) {
+				// 발급 경로를 거치지 않아 서명된 메타데이터가 없는 객체다. 존재하지 않는 것과 동일하게 취급한다.
+				return Optional.empty();
+			}
+			return Optional.of(new PublicImageObject(response.contentType(), response.contentLength(),
+					declaredContentType, Long.parseLong(declaredFileSizeBytes)));
+		} catch (NoSuchKeyException exception) {
+			return Optional.empty();
+		} catch (IllegalArgumentException exception) {
+			// 손상된 메타데이터(숫자 형식 오류)다. 존재하지 않는 것과 동일하게 취급한다.
+			return Optional.empty();
+		}
+	}
+
+	@PreDestroy
+	void close() {
+		s3Client.close();
+	}
+}

--- a/src/main/java/com/buyeoon/common/storage/S3PublicImageUploadPresigner.java
+++ b/src/main/java/com/buyeoon/common/storage/S3PublicImageUploadPresigner.java
@@ -1,0 +1,57 @@
+package com.buyeoon.common.storage;
+
+import jakarta.annotation.PreDestroy;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Service
+public class S3PublicImageUploadPresigner implements PublicImageUploadPresigner {
+
+	private static final Duration VALIDITY = Duration.ofMinutes(10);
+	private static final String DECLARED_FILE_SIZE_METADATA_KEY = "declared-file-size-bytes";
+	private static final String DECLARED_CONTENT_TYPE_METADATA_KEY = "declared-content-type";
+
+	private final String bucket;
+	private final S3Presigner presigner;
+
+	public S3PublicImageUploadPresigner(@Value("${storage.images.bucket:}") String bucket,
+			@Value("${storage.images.region:ap-northeast-2}") String region) {
+		this.bucket = bucket;
+		this.presigner = S3Presigner.builder().region(Region.of(region)).build();
+	}
+
+	@Override
+	public PublicImageUploadTarget presign(String objectKey, String contentType, long fileSizeBytes) {
+		if (bucket.isBlank()) {
+			throw new IllegalStateException("IMAGE_BUCKET 설정이 필요합니다.");
+		}
+		if (!objectKey.startsWith("public/")) {
+			throw new IllegalArgumentException("공개 이미지 객체 키가 아닙니다.");
+		}
+		Map<String, String> metadata = new LinkedHashMap<>();
+		metadata.put(DECLARED_FILE_SIZE_METADATA_KEY, Long.toString(fileSizeBytes));
+		metadata.put(DECLARED_CONTENT_TYPE_METADATA_KEY, contentType);
+		PutObjectRequest putObjectRequest = PutObjectRequest.builder().bucket(bucket).key(objectKey)
+				.contentType(contentType).metadata(metadata).build();
+		var presigned = presigner.presignPutObject(PutObjectPresignRequest.builder().signatureDuration(VALIDITY)
+				.putObjectRequest(putObjectRequest).build());
+
+		Map<String, String> headers = new LinkedHashMap<>();
+		headers.put("Content-Type", contentType);
+		metadata.forEach((key, value) -> headers.put("x-amz-meta-" + key, value));
+		return new PublicImageUploadTarget(presigned.url().toExternalForm(), headers, Instant.now().plus(VALIDITY));
+	}
+
+	@PreDestroy
+	void close() {
+		presigner.close();
+	}
+}

--- a/src/main/java/com/buyeoon/place/api/PlaceAdminController.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceAdminController.java
@@ -1,6 +1,7 @@
 package com.buyeoon.place.api;
 
 import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.common.storage.PublicImageUploadUrlView;
 import com.buyeoon.place.application.PlaceAdminCommandService;
 import com.buyeoon.place.application.PlaceAdminQueryService;
 import com.buyeoon.place.entity.PlaceCategory;
@@ -63,6 +64,13 @@ public class PlaceAdminController {
 	@GetMapping("/admin/places/{placeId}")
 	public SuccessResponse<PlaceAdminView> get(@PathVariable UUID placeId) {
 		return SuccessResponse.of(placeAdminQueryService.get(placeId));
+	}
+
+	@PostMapping("/admin/places/images/upload-url")
+	public SuccessResponse<PublicImageUploadUrlView> createImageUploadUrl(
+			@RequestBody PlaceAdminImageUploadUrlRequest request) {
+		return SuccessResponse
+				.of(placeAdminCommandService.createImageUploadUrl(request.contentType(), request.fileSizeBytes()));
 	}
 
 	private PlaceCategory parseCategory(String category) {

--- a/src/main/java/com/buyeoon/place/api/PlaceAdminImageUploadUrlRequest.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceAdminImageUploadUrlRequest.java
@@ -1,0 +1,4 @@
+package com.buyeoon.place.api;
+
+public record PlaceAdminImageUploadUrlRequest(String contentType, long fileSizeBytes) {
+}

--- a/src/main/java/com/buyeoon/place/api/PlaceAdminView.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceAdminView.java
@@ -5,6 +5,6 @@ import java.time.LocalTime;
 import java.util.UUID;
 
 public record PlaceAdminView(UUID placeId, PlaceCategory category, String name, String summary, String description,
-		String address, String imageKey, double latitude, double longitude, String operatingHoursRaw,
+		String address, String imageUrl, double latitude, double longitude, String operatingHoursRaw,
 		boolean alwaysOpen, LocalTime opensAt, LocalTime closesAt, Integer admissionFee, boolean deleted) {
 }

--- a/src/main/java/com/buyeoon/place/application/PlaceAdminCommandService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceAdminCommandService.java
@@ -1,5 +1,10 @@
 package com.buyeoon.place.application;
 
+import com.buyeoon.common.storage.PublicImageObjectStore;
+import com.buyeoon.common.storage.PublicImageObjectStore.PublicImageObject;
+import com.buyeoon.common.storage.PublicImageUploadPresigner;
+import com.buyeoon.common.storage.PublicImageUploadPresigner.PublicImageUploadTarget;
+import com.buyeoon.common.storage.PublicImageUploadUrlView;
 import com.buyeoon.place.api.InvalidPlaceRequestException;
 import com.buyeoon.place.api.PlaceAdminCreateRequest;
 import com.buyeoon.place.api.PlaceAdminUpdateRequest;
@@ -9,22 +14,38 @@ import com.buyeoon.place.repository.PlaceQueryRepository;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PlaceAdminCommandService {
 
+	private static final Set<String> ALLOWED_IMAGE_CONTENT_TYPES = Set.of("image/jpeg", "image/png", "image/webp");
+	private static final Map<String, String> CONTENT_TYPE_EXTENSIONS = Map.of("image/jpeg", "jpg", "image/png", "png",
+			"image/webp", "webp");
+	private static final String IMAGE_KEY_PREFIX = "public/places/";
+
 	private final PlaceQueryRepository placeQueryRepository;
+	private final PublicImageUploadPresigner publicImageUploadPresigner;
+	private final PublicImageObjectStore publicImageObjectStore;
+	private final long maxUploadBytes;
 	private final GeometryFactory geometryFactory = new GeometryFactory();
 
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
-	public PlaceAdminCommandService(PlaceQueryRepository placeQueryRepository) {
+	public PlaceAdminCommandService(PlaceQueryRepository placeQueryRepository,
+			PublicImageUploadPresigner publicImageUploadPresigner, PublicImageObjectStore publicImageObjectStore,
+			@Value("${storage.images.max-upload-bytes:10485760}") long maxUploadBytes) {
 		this.placeQueryRepository = placeQueryRepository;
+		this.publicImageUploadPresigner = publicImageUploadPresigner;
+		this.publicImageObjectStore = publicImageObjectStore;
+		this.maxUploadBytes = maxUploadBytes;
 	}
 
 	@Transactional
@@ -32,9 +53,10 @@ public class PlaceAdminCommandService {
 		PlaceCategory category = category(request.category());
 		String name = requiredText(request.name());
 		Point location = point(request.latitude(), request.longitude());
+		String imageKey = verifiedImageKey(request.imageKey());
 
 		PlaceEntity place = PlaceEntity.create(category, name, request.summary(), request.description(),
-				request.address(), request.imageKey(), location, null, null, null);
+				request.address(), imageKey, location, null, null, null);
 		place.applyOperatingInfo(request.operatingHoursRaw(), alwaysOpen(request.alwaysOpen()),
 				time(request.opensAt()), time(request.closesAt()), request.admissionFee());
 		return placeQueryRepository.save(place).getId();
@@ -48,11 +70,41 @@ public class PlaceAdminCommandService {
 		PlaceCategory category = category(request.category());
 		String name = requiredText(request.name());
 		Point location = point(request.latitude(), request.longitude());
+		String imageKey = verifiedImageKey(request.imageKey());
 
-		place.applyAdminUpdate(category, name, request.summary(), request.description(), request.address(),
-				request.imageKey(), location);
+		place.applyAdminUpdate(category, name, request.summary(), request.description(), request.address(), imageKey,
+				location);
 		place.applyOperatingInfo(request.operatingHoursRaw(), alwaysOpen(request.alwaysOpen()),
 				time(request.opensAt()), time(request.closesAt()), request.admissionFee());
+	}
+
+	public PublicImageUploadUrlView createImageUploadUrl(String contentType, long fileSizeBytes) {
+		if (contentType == null || !ALLOWED_IMAGE_CONTENT_TYPES.contains(contentType)) {
+			throw new InvalidPlaceRequestException();
+		}
+		if (fileSizeBytes <= 0 || fileSizeBytes > maxUploadBytes) {
+			throw new InvalidPlaceRequestException();
+		}
+		String imageKey = IMAGE_KEY_PREFIX + UUID.randomUUID() + "." + CONTENT_TYPE_EXTENSIONS.get(contentType);
+		PublicImageUploadTarget target = publicImageUploadPresigner.presign(imageKey, contentType, fileSizeBytes);
+		return new PublicImageUploadUrlView(imageKey, target.uploadUrl(), "PUT", target.headers(), 200,
+				target.expiresAt());
+	}
+
+	private String verifiedImageKey(String imageKey) {
+		if (imageKey == null) {
+			return null;
+		}
+		if (!imageKey.startsWith("public/")) {
+			throw new InvalidPlaceRequestException();
+		}
+		PublicImageObject object = publicImageObjectStore.head(imageKey).orElseThrow(InvalidPlaceRequestException::new);
+		if (object.fileSizeBytes() != object.declaredFileSizeBytes()
+				|| !object.contentType().equals(object.declaredContentType())
+				|| !ALLOWED_IMAGE_CONTENT_TYPES.contains(object.contentType())) {
+			throw new InvalidPlaceRequestException();
+		}
+		return imageKey;
 	}
 
 	@Transactional

--- a/src/main/java/com/buyeoon/place/application/PlaceAdminQueryService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceAdminQueryService.java
@@ -1,5 +1,6 @@
 package com.buyeoon.place.application;
 
+import com.buyeoon.common.storage.PublicImageUrlService;
 import com.buyeoon.place.api.PlaceAdminListView;
 import com.buyeoon.place.api.PlaceAdminView;
 import com.buyeoon.place.entity.PlaceCategory;
@@ -17,10 +18,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlaceAdminQueryService {
 
 	private final PlaceQueryRepository placeQueryRepository;
+	private final PublicImageUrlService imageUrls;
 
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
-	public PlaceAdminQueryService(PlaceQueryRepository placeQueryRepository) {
+	public PlaceAdminQueryService(PlaceQueryRepository placeQueryRepository, PublicImageUrlService imageUrls) {
 		this.placeQueryRepository = placeQueryRepository;
+		this.imageUrls = imageUrls;
 	}
 
 	public PlaceAdminListView list(PlaceCategory category, int page, int size) {
@@ -39,8 +42,10 @@ public class PlaceAdminQueryService {
 	}
 
 	private PlaceAdminView toView(PlaceEntity place) {
+		String imageUrl = place.getImageKey() != null ? imageUrls.create(place.getImageKey())
+				: place.getSourceImageHref();
 		return new PlaceAdminView(place.getId(), place.getCategory(), place.getName(), place.getSummary(),
-				place.getDescription(), place.getAddress(), place.getImageKey(), place.getLocation().getY(),
+				place.getDescription(), place.getAddress(), imageUrl, place.getLocation().getY(),
 				place.getLocation().getX(), place.getOperatingHoursRaw(), place.isAlwaysOpen(), place.getOpensAt(),
 				place.getClosesAt(), place.getAdmissionFee(), place.isDeleted());
 	}

--- a/src/test/java/com/buyeoon/badge/BadgeAdminControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/badge/BadgeAdminControllerIntegrationTests.java
@@ -1,14 +1,26 @@
 package com.buyeoon.badge;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.buyeoon.common.storage.PublicImageObjectStore;
+import com.buyeoon.common.storage.PublicImageObjectStore.PublicImageObject;
+import com.buyeoon.common.storage.PublicImageUploadPresigner;
+import com.buyeoon.common.storage.PublicImageUploadPresigner.PublicImageUploadTarget;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +30,7 @@ import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -51,10 +64,22 @@ class BadgeAdminControllerIntegrationTests {
 	@Autowired
 	private ObjectMapper objectMapper;
 
+	@MockitoBean
+	private PublicImageObjectStore publicImageObjectStore;
+
+	@MockitoBean
+	private PublicImageUploadPresigner publicImageUploadPresigner;
+
 	@BeforeAll
 	static void configureAwsCredentials() {
 		System.setProperty("aws.accessKeyId", "test-access-key");
 		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	@BeforeEach
+	void stubPublicImageObjectStore() {
+		when(publicImageObjectStore.head(anyString()))
+				.thenReturn(Optional.of(new PublicImageObject("image/png", 100, "image/png", 100)));
 	}
 
 	@AfterAll
@@ -158,6 +183,35 @@ class BadgeAdminControllerIntegrationTests {
 	void returns404WhenBadgeDoesNotExist() throws Exception {
 		mockMvc.perform(getDetailRequest(java.util.UUID.randomUUID().toString())).andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	@Test
+	@DisplayName("이미지 업로드 URL을 발급받는다")
+	void issuesImageUploadUrl() throws Exception {
+		when(publicImageUploadPresigner.presign(anyString(), anyString(), anyLong()))
+				.thenReturn(new PublicImageUploadTarget("https://s3.example.com/upload",
+						Map.of("Content-Type", "image/png"), Instant.now().plusSeconds(600)));
+
+		MvcResult result = mockMvc
+				.perform(post("/admin/badges/images/upload-url").header("X-Admin-Api-Key", VALID_API_KEY)
+						.contentType(MediaType.APPLICATION_JSON).content("""
+								{"contentType":"image/png","fileSizeBytes":100}"""))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.uploadUrl").value("https://s3.example.com/upload")).andReturn();
+		String imageKey = objectMapper.readTree(result.getResponse().getContentAsString()).path("data")
+				.path("imageKey").asString();
+		assertThat(imageKey).startsWith("public/badges/");
+	}
+
+	@Test
+	@DisplayName("S3에 존재하지 않는 imageKey로 생성하면 400을 받는다")
+	void returns400WhenImageKeyDoesNotExistInS3() throws Exception {
+		when(publicImageObjectStore.head("public/missing.png")).thenReturn(Optional.empty());
+
+		mockMvc.perform(createRequest("""
+				{"category":"EXPLORATION","name":"테스트 배지","description":"설명","imageKey":"public/missing.png",
+				"conditionText":"조건","active":false,"conditions":[]}
+				""")).andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
 	}
 
 	private MockHttpServletRequestBuilder createRequest(String body) {

--- a/src/test/java/com/buyeoon/place/PlaceAdminControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/place/PlaceAdminControllerIntegrationTests.java
@@ -1,6 +1,9 @@
 package com.buyeoon.place;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -8,10 +11,18 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.buyeoon.common.storage.PublicImageObjectStore;
+import com.buyeoon.common.storage.PublicImageObjectStore.PublicImageObject;
+import com.buyeoon.common.storage.PublicImageUploadPresigner;
+import com.buyeoon.common.storage.PublicImageUploadPresigner.PublicImageUploadTarget;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +32,7 @@ import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -54,10 +66,22 @@ class PlaceAdminControllerIntegrationTests {
 	@Autowired
 	private ObjectMapper objectMapper;
 
+	@MockitoBean
+	private PublicImageObjectStore publicImageObjectStore;
+
+	@MockitoBean
+	private PublicImageUploadPresigner publicImageUploadPresigner;
+
 	@BeforeAll
 	static void configureAwsCredentials() {
 		System.setProperty("aws.accessKeyId", "test-access-key");
 		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	@BeforeEach
+	void stubPublicImageObjectStore() {
+		when(publicImageObjectStore.head(anyString()))
+				.thenReturn(Optional.of(new PublicImageObject("image/jpeg", 100, "image/jpeg", 100)));
 	}
 
 	@AfterAll
@@ -137,6 +161,44 @@ class PlaceAdminControllerIntegrationTests {
 	void returns404WhenPlaceDoesNotExist() throws Exception {
 		mockMvc.perform(getDetailRequest(UUID.randomUUID().toString())).andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	@Test
+	@DisplayName("이미지 업로드 URL을 발급받는다")
+	void issuesImageUploadUrl() throws Exception {
+		when(publicImageUploadPresigner.presign(anyString(), anyString(), anyLong()))
+				.thenReturn(new PublicImageUploadTarget("https://s3.example.com/upload",
+						Map.of("Content-Type", "image/jpeg"), Instant.now().plusSeconds(600)));
+
+		MvcResult result = mockMvc
+				.perform(post("/admin/places/images/upload-url").header("X-Admin-Api-Key", VALID_API_KEY)
+						.contentType(MediaType.APPLICATION_JSON).content("""
+								{"contentType":"image/jpeg","fileSizeBytes":100}"""))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.uploadUrl").value("https://s3.example.com/upload")).andReturn();
+		String imageKey = objectMapper.readTree(result.getResponse().getContentAsString()).path("data")
+				.path("imageKey").asString();
+		assertThat(imageKey).startsWith("public/places/");
+	}
+
+	@Test
+	@DisplayName("S3에 존재하지 않는 imageKey로 생성하면 400을 받는다")
+	void returns400WhenImageKeyDoesNotExistInS3() throws Exception {
+		when(publicImageObjectStore.head("public/missing.jpg")).thenReturn(Optional.empty());
+
+		mockMvc.perform(createRequest("""
+				{"category":"HERITAGE","name":"장소","summary":"요약","description":"설명",
+				"address":"주소","imageKey":"public/missing.jpg","latitude":-75.0,"longitude":0.0}"""))
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	@Test
+	@DisplayName("public/로 시작하지 않는 imageKey로 생성하면 400을 받는다")
+	void returns400WhenImageKeyPrefixInvalid() throws Exception {
+		mockMvc.perform(createRequest("""
+				{"category":"HERITAGE","name":"장소","summary":"요약","description":"설명",
+				"address":"주소","imageKey":"private/place.jpg","latitude":-75.0,"longitude":0.0}"""))
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
 	}
 
 	private MockHttpServletRequestBuilder createRequest(String body) {


### PR DESCRIPTION
## Summary
- 장소/배지 관리자 CRUD의 `imageKey`가 지금까지는 관리자가 어딘가에서 S3에 직접 올린 뒤 키 문자열을 붙여넣기만 하는 방식이었고, 존재 검증도 없었습니다(장소는 `public/` prefix 검증조차 없었음).
- 미션 사진 업로드(ADR-008)의 "presigned PUT 발급 → 클라이언트가 S3에 직접 PUT → 확정 시점 HeadObject로 크기/타입 대조" 패턴을 `public/`(관리자용 공개 이미지) prefix에 맞게 일반화해서 재사용했습니다(회원 소유 개념이 없으므로 owner 메타데이터는 뺐습니다).
- 관리자 조회 API(`PlaceAdminQueryService`/`BadgeAdminQueryService`)도 회원용 API와 동일하게 `PublicImageUrlService`로 `imageKey`를 presigned GET URL로 변환해서 `imageUrl`로 내려주도록 고쳤습니다(기존엔 원본 키 문자열만 그대로 반환해서 관리자 화면에서 이미지를 바로 볼 수 없었음).

## 신규 엔드포인트
- `POST /admin/places/images/upload-url`
- `POST /admin/badges/images/upload-url`
- 둘 다 `{contentType, fileSizeBytes}` → `{imageKey, uploadUrl, method, headers, expiresAt}` 반환. 응답의 `imageKey`를 그대로 create/update 요청에 넣으면 됩니다.

## 신규 공통 인프라 (`common/storage/`)
- `PublicImageUploadPresigner`/`S3PublicImageUploadPresigner` — `public/` prefix PUT presign (`MissionPhotoUploadPresigner` 패턴, owner 메타데이터 제외)
- `PublicImageObjectStore`/`S3PublicImageObjectStore` — HeadObject로 크기/타입 대조 (`MissionPhotoObjectStore` 패턴)
- `PublicImageUploadUrlView` — place/badge가 공유하는 응답 DTO

## Test plan
- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `PlaceAdminControllerIntegrationTests`, `BadgeAdminControllerIntegrationTests`(업로드 URL 발급, S3 미존재/`public/` prefix 위반 시 400 케이스 포함) 통과
- [x] 전체 `./gradlew test` 스위트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DG8nZiKUW9NuBWdJqdjiQB