### PR TITLE
fix: 관리자 미션 CRUD에 미션 좌표 반영

### DIFF
--- a/src/main/java/com/buyeoon/mission/api/MissionAdminCreateRequest.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionAdminCreateRequest.java
@@ -4,5 +4,6 @@ import java.util.List;
 import java.util.UUID;
 
 public record MissionAdminCreateRequest(UUID placeId, String type, String title, String description,
-		int rewardPoints, Integer maxAttempts, Boolean oxCorrectAnswer, List<MissionChoiceRequest> choices) {
+		int rewardPoints, Integer maxAttempts, Boolean oxCorrectAnswer, List<MissionChoiceRequest> choices,
+		Double latitude, Double longitude) {
 }

--- a/src/main/java/com/buyeoon/mission/api/MissionAdminUpdateRequest.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionAdminUpdateRequest.java
@@ -3,5 +3,5 @@ package com.buyeoon.mission.api;
 import java.util.List;
 
 public record MissionAdminUpdateRequest(String title, String description, int rewardPoints, Integer maxAttempts,
-		Boolean oxCorrectAnswer, List<MissionChoiceRequest> choices) {
+		Boolean oxCorrectAnswer, List<MissionChoiceRequest> choices, Double latitude, Double longitude) {
 }

--- a/src/main/java/com/buyeoon/mission/api/MissionAdminView.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionAdminView.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 
 public record MissionAdminView(UUID missionId, UUID placeId, MissionType type, String title, String description,
 		int rewardPoints, Integer maxAttempts, Boolean oxCorrectAnswer, List<MissionAdminChoiceView> choices,
-		boolean deleted) {
+		double latitude, double longitude, boolean deleted) {
 	public MissionAdminView {
 		choices = List.copyOf(choices);
 	}

--- a/src/main/java/com/buyeoon/mission/application/MissionAdminCommandService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionAdminCommandService.java
@@ -14,6 +14,9 @@ import com.buyeoon.place.repository.PlaceQueryRepository;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.UUID;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +26,7 @@ public class MissionAdminCommandService {
 	private final MissionQueryRepository missionQueryRepository;
 	private final MissionChoiceRepository missionChoiceRepository;
 	private final PlaceQueryRepository placeQueryRepository;
+	private final GeometryFactory geometryFactory = new GeometryFactory();
 
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
 	public MissionAdminCommandService(MissionQueryRepository missionQueryRepository,
@@ -42,13 +46,14 @@ public class MissionAdminCommandService {
 		MissionType type = missionType(request.type());
 		String title = requiredText(request.title());
 		String description = requiredText(request.description());
+		Point location = point(request.latitude(), request.longitude(), place.getLocation());
 
 		MissionEntity mission;
 		try {
 			mission = switch (type) {
 				case MULTIPLE_CHOICE -> {
 					requireNoOxAnswer(request.oxCorrectAnswer());
-					yield MissionEntity.multipleChoice(place.getId(), place.getLocation(), title, description,
+					yield MissionEntity.multipleChoice(place.getId(), location, title, description,
 							request.rewardPoints(), request.maxAttempts());
 				}
 				case OX -> {
@@ -56,8 +61,8 @@ public class MissionAdminCommandService {
 						throw new InvalidMissionRequestException();
 					}
 					requireNoChoices(request.choices());
-					yield MissionEntity.ox(place.getId(), place.getLocation(), title, description,
-							request.rewardPoints(), request.maxAttempts(), request.oxCorrectAnswer());
+					yield MissionEntity.ox(place.getId(), location, title, description, request.rewardPoints(),
+							request.maxAttempts(), request.oxCorrectAnswer());
 				}
 				case PHOTO -> {
 					requireNoOxAnswer(request.oxCorrectAnswer());
@@ -65,8 +70,7 @@ public class MissionAdminCommandService {
 					if (request.maxAttempts() != null) {
 						throw new InvalidMissionRequestException();
 					}
-					yield MissionEntity.photo(place.getId(), place.getLocation(), title, description,
-							request.rewardPoints());
+					yield MissionEntity.photo(place.getId(), location, title, description, request.rewardPoints());
 				}
 			};
 		} catch (IllegalArgumentException exception) {
@@ -86,6 +90,7 @@ public class MissionAdminCommandService {
 				.orElseThrow(MissionNotFoundException::new);
 		String title = requiredText(request.title());
 		String description = requiredText(request.description());
+		mission.updateLocation(point(request.latitude(), request.longitude(), mission.getLocation()));
 
 		try {
 			switch (mission.getType()) {
@@ -168,5 +173,19 @@ public class MissionAdminCommandService {
 			throw new InvalidMissionRequestException();
 		}
 		return value;
+	}
+
+	/** 좌표가 둘 다 없으면 {@code fallback}(장소 좌표 등)을 쓰고, 있으면 범위를 검증해 새 좌표를 만든다. */
+	private Point point(Double latitude, Double longitude, Point fallback) {
+		if (latitude == null && longitude == null) {
+			return fallback;
+		}
+		if (latitude == null || longitude == null) {
+			throw new InvalidMissionRequestException();
+		}
+		if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+			throw new InvalidMissionRequestException();
+		}
+		return geometryFactory.createPoint(new Coordinate(longitude, latitude));
 	}
 }

--- a/src/main/java/com/buyeoon/mission/application/MissionAdminQueryService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionAdminQueryService.java
@@ -54,6 +54,7 @@ public class MissionAdminQueryService {
 				.toList();
 		return new MissionAdminView(mission.getId(), mission.getPlaceId(), mission.getType(), mission.getTitle(),
 				mission.getDescription(), mission.getRewardPoints(), mission.getMaxAttempts(),
-				mission.getOxCorrectAnswer(), choiceViews, mission.isDeleted());
+				mission.getOxCorrectAnswer(), choiceViews, mission.getLocation().getY(), mission.getLocation().getX(),
+				mission.isDeleted());
 	}
 }

--- a/src/main/java/com/buyeoon/mission/entity/MissionEntity.java
+++ b/src/main/java/com/buyeoon/mission/entity/MissionEntity.java
@@ -120,6 +120,11 @@ public class MissionEntity {
 		this.rewardPoints = rewardPoints;
 	}
 
+	public void updateLocation(Point location) {
+		location.setSRID(4326);
+		this.location = location;
+	}
+
 	public void softDelete() {
 		this.deletedAt = Instant.now();
 	}

--- a/src/test/java/com/buyeoon/mission/MissionAdminControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionAdminControllerIntegrationTests.java
@@ -94,16 +94,21 @@ class MissionAdminControllerIntegrationTests {
 
 		mockMvc.perform(getDetailRequest(missionId)).andExpect(status().isOk())
 				.andExpect(jsonPath("$.data.type").value("MULTIPLE_CHOICE"))
-				.andExpect(jsonPath("$.data.choices.length()").value(2));
+				.andExpect(jsonPath("$.data.choices.length()").value(2))
+				.andExpect(jsonPath("$.data.latitude").value(-75.0))
+				.andExpect(jsonPath("$.data.longitude").value(0.0));
 
 		mockMvc.perform(updateRequest(missionId, """
 				{"title":"수정된 문제","description":"수정된 설명","rewardPoints":200,"maxAttempts":5,
-				"choices":[{"label":"새 보기","correct":true,"sortOrder":0}]}
+				"choices":[{"label":"새 보기","correct":true,"sortOrder":0}],
+				"latitude":-74.5,"longitude":1.0}
 				""")).andExpect(status().isOk());
 
 		mockMvc.perform(getDetailRequest(missionId)).andExpect(status().isOk())
 				.andExpect(jsonPath("$.data.title").value("수정된 문제"))
-				.andExpect(jsonPath("$.data.choices.length()").value(1));
+				.andExpect(jsonPath("$.data.choices.length()").value(1))
+				.andExpect(jsonPath("$.data.latitude").value(-74.5))
+				.andExpect(jsonPath("$.data.longitude").value(1.0));
 
 		mockMvc.perform(listRequest(placeId.toString())).andExpect(status().isOk())
 				.andExpect(jsonPath("$.data.items[?(@.missionId=='" + missionId + "')]").exists());
@@ -125,6 +130,34 @@ class MissionAdminControllerIntegrationTests {
 
 		mockMvc.perform(createRequest("""
 				{"placeId":"%s","type":"PHOTO","title":"사진미션","description":"설명","rewardPoints":100,"maxAttempts":3}
+				""".formatted(placeId))).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	@Test
+	@DisplayName("좌표를 지정해 생성하면 장소 좌표가 아니라 지정한 좌표가 저장된다")
+	void createsMissionWithCustomLocation() throws Exception {
+		UUID placeId = insertPlace();
+
+		MvcResult createResult = mockMvc.perform(createRequest("""
+				{"placeId":"%s","type":"OX","title":"OX 미션","description":"설명","rewardPoints":100,
+				"oxCorrectAnswer":true,"latitude":-74.9,"longitude":0.5}
+				""".formatted(placeId))).andExpect(status().isOk()).andReturn();
+		String missionId = objectMapper.readTree(createResult.getResponse().getContentAsString()).path("data")
+				.path("missionId").asString();
+
+		mockMvc.perform(getDetailRequest(missionId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.latitude").value(-74.9)).andExpect(jsonPath("$.data.longitude").value(0.5));
+	}
+
+	@Test
+	@DisplayName("위도만 있고 경도가 없으면 400을 받는다")
+	void returns400WhenOnlyLatitudeProvided() throws Exception {
+		UUID placeId = insertPlace();
+
+		mockMvc.perform(createRequest("""
+				{"placeId":"%s","type":"OX","title":"OX 미션","description":"설명","rewardPoints":100,
+				"oxCorrectAnswer":true,"latitude":-74.9}
 				""".formatted(placeId))).andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
 	}


### PR DESCRIPTION
## Summary
- `missions.location`(V25)은 장소 좌표와 별개로 관리되는 필드다 — "장소 규모가 제각각이라 장소 좌표와의 거리 제약은 두지 않는다"는 게 도입 취지였는데, 관리자 CRUD(#227)를 만들면서 이 필드를 완전히 놓쳤다. 생성 시 항상 장소 좌표를 그대로 썼고, 수정 API에는 좌표를 바꿀 방법이 아예 없었고, 조회 응답에도 좌표가 안 나갔다.
- 생성 요청에 `latitude`/`longitude`를 선택적으로 추가해서, 지정하면 그 좌표를 쓰고 없으면 기존처럼 장소 좌표를 기본값으로 쓴다.
- 수정 요청에도 `latitude`/`longitude`를 추가해서 미션 좌표를 바꿀 수 있게 했다(`MissionEntity.updateLocation(Point)` 신규).
- 조회 응답(`MissionAdminView`)에 `latitude`/`longitude`를 추가했다.

## Test plan
- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `MissionAdminControllerIntegrationTests`(좌표 기본값, 커스텀 좌표 생성, 수정 시 좌표 변경, 좌표 한쪽만 준 경우 400) 통과
- [x] 전체 `./gradlew test` 스위트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DG8nZiKUW9NuBWdJqdjiQB