### PR TITLE
fix: 배지 목록 조회 시 조건이 빈 배열로 반환되는 문제 수정

### DIFF
--- a/src/main/java/com/buyeoon/badge/application/BadgeAdminQueryService.java
+++ b/src/main/java/com/buyeoon/badge/application/BadgeAdminQueryService.java
@@ -10,7 +10,9 @@ import com.buyeoon.badge.repository.BadgeRepository;
 import com.buyeoon.common.storage.PublicImageUrlService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -35,7 +37,11 @@ public class BadgeAdminQueryService {
 	public BadgeAdminListView list(int page, int size) {
 		PageRequest pageRequest = PageRequest.of(page, size);
 		Page<BadgeEntity> result = badgeRepository.findAll(pageRequest);
-		List<BadgeAdminView> items = result.getContent().stream().map(badge -> toView(badge, List.of())).toList();
+		List<UUID> badgeIds = result.getContent().stream().map(BadgeEntity::getId).toList();
+		Map<UUID, List<BadgeConditionEntity>> conditionsByBadgeId = badgeConditionRepository.findByIdBadgeIdIn(badgeIds)
+				.stream().collect(Collectors.groupingBy(condition -> condition.getId().badgeId()));
+		List<BadgeAdminView> items = result.getContent().stream()
+				.map(badge -> toView(badge, conditionsByBadgeId.getOrDefault(badge.getId(), List.of()))).toList();
 		return new BadgeAdminListView(items, page, size, result.getTotalElements(), result.getTotalPages());
 	}
 

--- a/src/test/java/com/buyeoon/badge/BadgeAdminControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/badge/BadgeAdminControllerIntegrationTests.java
@@ -186,6 +186,25 @@ class BadgeAdminControllerIntegrationTests {
 	}
 
 	@Test
+	@DisplayName("목록 조회 시 각 배지의 조건이 함께 반환된다")
+	void listIncludesConditionsForEachBadge() throws Exception {
+		MvcResult createResult = mockMvc
+				.perform(createRequest("""
+						{"category":"EXPLORATION","name":"테스트 배지","description":"설명","conditionText":"조건 설명",
+						"active":true,
+						"conditions":[{"metricKey":"MISSION_COMPLETED_COUNT","threshold":5}]}
+						"""))
+				.andExpect(status().isOk()).andReturn();
+		String badgeId = objectMapper.readTree(createResult.getResponse().getContentAsString()).path("data")
+				.path("badgeId").asString();
+
+		mockMvc.perform(listRequest()).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items[?(@.badgeId=='" + badgeId + "')].conditions[0].metricKey")
+						.value("MISSION_COMPLETED_COUNT"))
+				.andExpect(jsonPath("$.data.items[?(@.badgeId=='" + badgeId + "')].conditions[0].threshold").value(5));
+	}
+
+	@Test
 	@DisplayName("이미지 업로드 URL을 발급받는다")
 	void issuesImageUploadUrl() throws Exception {
 		when(publicImageUploadPresigner.presign(anyString(), anyString(), anyLong()))
@@ -234,6 +253,10 @@ class BadgeAdminControllerIntegrationTests {
 
 	private MockHttpServletRequestBuilder getDetailRequest(String badgeId) {
 		return get("/admin/badges/{badgeId}", badgeId).header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	private MockHttpServletRequestBuilder listRequest() {
+		return get("/admin/badges").header("X-Admin-Api-Key", VALID_API_KEY);
 	}
 
 	@DynamicPropertySource


### PR DESCRIPTION
## Summary
- `BadgeAdminQueryService.list()`가 조건을 조회하지 않고 항상 빈 리스트(`List.of()`)를 넘겨서, 관리자용 배지 목록 API(`GET /admin/badges`)는 각 배지의 `conditions`가 항상 빈 배열로 반환되던 버그를 수정
- 목록에 포함된 badgeId들의 조건을 `findByIdBadgeIdIn`으로 일괄 조회 후 badgeId로 그룹핑하여 각 배지에 매칭 (N+1 방지)

## Test plan
- [x] `./gradlew compileJava compileTestJava`
- [x] `BadgeAdminControllerIntegrationTests` (신규 `listIncludesConditionsForEachBadge` 케이스 포함)
- [x] 전체 `./gradlew test` 스위트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DG8nZiKUW9NuBWdJqdjiQB