### PR TITLE
feat: 장소 삭제 시 미션 cascade soft delete 및 장소/미션 restore 기능 추가

### DIFF
--- a/src/main/java/com/buyeoon/mission/api/MissionAdminController.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionAdminController.java
@@ -50,6 +50,12 @@ public class MissionAdminController {
 		return SuccessResponse.of(Map.of());
 	}
 
+	@PostMapping("/admin/missions/{missionId}/restore")
+	public SuccessResponse<Map<String, Object>> restore(@PathVariable UUID missionId) {
+		missionAdminCommandService.restore(missionId);
+		return SuccessResponse.of(Map.of());
+	}
+
 	@GetMapping("/admin/missions")
 	public SuccessResponse<MissionAdminListView> list(@RequestParam(required = false) UUID placeId,
 			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "20") int size) {

--- a/src/main/java/com/buyeoon/mission/application/MissionAdminCommandService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionAdminCommandService.java
@@ -130,6 +130,16 @@ public class MissionAdminCommandService {
 		mission.softDelete();
 	}
 
+	@Transactional
+	public void restore(UUID missionId) {
+		MissionEntity mission = missionQueryRepository.findById(missionId).orElseThrow(MissionNotFoundException::new);
+		PlaceEntity place = placeQueryRepository.findById(mission.getPlaceId()).orElseThrow(MissionNotFoundException::new);
+		if (place.isDeleted()) {
+			throw new InvalidMissionRequestException();
+		}
+		mission.restore();
+	}
+
 	private void saveChoices(UUID missionId, List<MissionChoiceRequest> choices) {
 		if (choices == null || choices.isEmpty()) {
 			throw new InvalidMissionRequestException();

--- a/src/main/java/com/buyeoon/mission/entity/MissionEntity.java
+++ b/src/main/java/com/buyeoon/mission/entity/MissionEntity.java
@@ -129,6 +129,10 @@ public class MissionEntity {
 		this.deletedAt = Instant.now();
 	}
 
+	public void restore() {
+		this.deletedAt = null;
+	}
+
 	public boolean isDeleted() {
 		return deletedAt != null;
 	}

--- a/src/main/java/com/buyeoon/mission/repository/MissionQueryRepository.java
+++ b/src/main/java/com/buyeoon/mission/repository/MissionQueryRepository.java
@@ -26,6 +26,7 @@ public interface MissionQueryRepository extends JpaRepository<MissionEntity, UUI
 			LEFT JOIN MissionParticipationEntity participation
 			    ON participation.missionId = m.id AND participation.tripId = :tripId
 			WHERE m.deletedAt IS NULL
+			  AND p.deletedAt IS NULL
 			  AND ST_Distance(m.location,
 			          ST_SetSRID(ST_MakePoint(cast(:longitude as double), cast(:latitude as double)), 4326)) <= 500
 			ORDER BY 3 ASC, m.id ASC
@@ -44,6 +45,7 @@ public interface MissionQueryRepository extends JpaRepository<MissionEntity, UUI
 			    ON participation.missionId = m.id AND participation.tripId = :tripId
 			WHERE m.id = :missionId
 			  AND m.deletedAt IS NULL
+			  AND p.deletedAt IS NULL
 			""")
 	Optional<NearbyMissionProjection> findDetail(@Param("missionId") UUID missionId, @Param("tripId") UUID tripId,
 			@Param("latitude") double latitude, @Param("longitude") double longitude);
@@ -56,9 +58,12 @@ public interface MissionQueryRepository extends JpaRepository<MissionEntity, UUI
 			JOIN PlaceEntity p ON p.id = m.placeId
 			WHERE m.id = :missionId
 			  AND m.deletedAt IS NULL
+			  AND p.deletedAt IS NULL
 			""")
 	Optional<MissionPlaceDistanceProjection> findWithDistance(@Param("missionId") UUID missionId,
 			@Param("latitude") double latitude, @Param("longitude") double longitude);
 
 	Page<MissionEntity> findByPlaceId(UUID placeId, Pageable pageable);
+
+	List<MissionEntity> findByPlaceIdAndDeletedAtIsNull(UUID placeId);
 }

--- a/src/main/java/com/buyeoon/place/api/PlaceAdminController.java
+++ b/src/main/java/com/buyeoon/place/api/PlaceAdminController.java
@@ -52,6 +52,12 @@ public class PlaceAdminController {
 		return SuccessResponse.of(Map.of());
 	}
 
+	@PostMapping("/admin/places/{placeId}/restore")
+	public SuccessResponse<Map<String, Object>> restore(@PathVariable UUID placeId) {
+		placeAdminCommandService.restore(placeId);
+		return SuccessResponse.of(Map.of());
+	}
+
 	@GetMapping("/admin/places")
 	public SuccessResponse<PlaceAdminListView> list(@RequestParam(required = false) String category,
 			@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "20") int size) {

--- a/src/main/java/com/buyeoon/place/application/PlaceAdminCommandService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceAdminCommandService.java
@@ -8,12 +8,15 @@ import com.buyeoon.common.storage.PublicImageUploadUrlView;
 import com.buyeoon.place.api.InvalidPlaceRequestException;
 import com.buyeoon.place.api.PlaceAdminCreateRequest;
 import com.buyeoon.place.api.PlaceAdminUpdateRequest;
+import com.buyeoon.mission.entity.MissionEntity;
+import com.buyeoon.mission.repository.MissionQueryRepository;
 import com.buyeoon.place.entity.PlaceCategory;
 import com.buyeoon.place.entity.PlaceEntity;
 import com.buyeoon.place.repository.PlaceQueryRepository;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -33,6 +36,7 @@ public class PlaceAdminCommandService {
 	private static final String IMAGE_KEY_PREFIX = "public/places/";
 
 	private final PlaceQueryRepository placeQueryRepository;
+	private final MissionQueryRepository missionQueryRepository;
 	private final PublicImageUploadPresigner publicImageUploadPresigner;
 	private final PublicImageObjectStore publicImageObjectStore;
 	private final long maxUploadBytes;
@@ -40,9 +44,11 @@ public class PlaceAdminCommandService {
 
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
 	public PlaceAdminCommandService(PlaceQueryRepository placeQueryRepository,
-			PublicImageUploadPresigner publicImageUploadPresigner, PublicImageObjectStore publicImageObjectStore,
+			MissionQueryRepository missionQueryRepository, PublicImageUploadPresigner publicImageUploadPresigner,
+			PublicImageObjectStore publicImageObjectStore,
 			@Value("${storage.images.max-upload-bytes:10485760}") long maxUploadBytes) {
 		this.placeQueryRepository = placeQueryRepository;
+		this.missionQueryRepository = missionQueryRepository;
 		this.publicImageUploadPresigner = publicImageUploadPresigner;
 		this.publicImageObjectStore = publicImageObjectStore;
 		this.maxUploadBytes = maxUploadBytes;
@@ -112,6 +118,14 @@ public class PlaceAdminCommandService {
 		PlaceEntity place = placeQueryRepository.findById(placeId).filter(candidate -> !candidate.isDeleted())
 				.orElseThrow(PlaceNotFoundException::new);
 		place.softDelete();
+		List<MissionEntity> missions = missionQueryRepository.findByPlaceIdAndDeletedAtIsNull(placeId);
+		missions.forEach(MissionEntity::softDelete);
+	}
+
+	@Transactional
+	public void restore(UUID placeId) {
+		PlaceEntity place = placeQueryRepository.findById(placeId).orElseThrow(PlaceNotFoundException::new);
+		place.restore();
 	}
 
 	private PlaceCategory category(String value) {

--- a/src/main/java/com/buyeoon/place/application/PlaceAdminQueryService.java
+++ b/src/main/java/com/buyeoon/place/application/PlaceAdminQueryService.java
@@ -28,16 +28,14 @@ public class PlaceAdminQueryService {
 
 	public PlaceAdminListView list(PlaceCategory category, int page, int size) {
 		PageRequest pageRequest = PageRequest.of(page, size);
-		Page<PlaceEntity> result = category == null
-				? placeQueryRepository.findByDeletedAtIsNull(pageRequest)
-				: placeQueryRepository.findByDeletedAtIsNullAndCategory(category, pageRequest);
+		Page<PlaceEntity> result = category == null ? placeQueryRepository.findAll(pageRequest)
+				: placeQueryRepository.findByCategory(category, pageRequest);
 		return new PlaceAdminListView(result.getContent().stream().map(this::toView).toList(), page, size,
 				result.getTotalElements(), result.getTotalPages());
 	}
 
 	public PlaceAdminView get(UUID placeId) {
-		PlaceEntity place = placeQueryRepository.findById(placeId).filter(candidate -> !candidate.isDeleted())
-				.orElseThrow(PlaceNotFoundException::new);
+		PlaceEntity place = placeQueryRepository.findById(placeId).orElseThrow(PlaceNotFoundException::new);
 		return toView(place);
 	}
 

--- a/src/main/java/com/buyeoon/place/entity/PlaceEntity.java
+++ b/src/main/java/com/buyeoon/place/entity/PlaceEntity.java
@@ -166,6 +166,10 @@ public class PlaceEntity {
 		this.deletedAt = Instant.now();
 	}
 
+	public void restore() {
+		this.deletedAt = null;
+	}
+
 	public boolean isDeleted() {
 		return deletedAt != null;
 	}

--- a/src/main/java/com/buyeoon/place/repository/PlaceQueryRepository.java
+++ b/src/main/java/com/buyeoon/place/repository/PlaceQueryRepository.java
@@ -93,4 +93,6 @@ public interface PlaceQueryRepository extends JpaRepository<PlaceEntity, UUID> {
 	Page<PlaceEntity> findByDeletedAtIsNull(Pageable pageable);
 
 	Page<PlaceEntity> findByDeletedAtIsNullAndCategory(PlaceCategory category, Pageable pageable);
+
+	Page<PlaceEntity> findByCategory(PlaceCategory category, Pageable pageable);
 }

--- a/src/test/java/com/buyeoon/mission/MissionAdminControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionAdminControllerIntegrationTests.java
@@ -194,6 +194,44 @@ class MissionAdminControllerIntegrationTests {
 				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
 	}
 
+	@Test
+	@DisplayName("삭제한 미션을 복구하면 다시 활성 상태가 된다")
+	void restoresDeletedMission() throws Exception {
+		UUID placeId = insertPlace();
+
+		MvcResult createResult = mockMvc.perform(createRequest("""
+				{"placeId":"%s","type":"OX","title":"OX 미션","description":"설명","rewardPoints":100,
+				"oxCorrectAnswer":true}
+				""".formatted(placeId))).andExpect(status().isOk()).andReturn();
+		String missionId = objectMapper.readTree(createResult.getResponse().getContentAsString()).path("data")
+				.path("missionId").asString();
+
+		mockMvc.perform(deleteRequest(missionId)).andExpect(status().isOk());
+		mockMvc.perform(restoreRequest(missionId)).andExpect(status().isOk());
+
+		mockMvc.perform(getDetailRequest(missionId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.deleted").value(false));
+	}
+
+	@Test
+	@DisplayName("소속 장소가 삭제된 상태면 미션을 복구할 수 없다")
+	void returns400WhenRestoringMissionWithDeletedPlace() throws Exception {
+		UUID placeId = insertPlace();
+
+		MvcResult createResult = mockMvc.perform(createRequest("""
+				{"placeId":"%s","type":"OX","title":"OX 미션","description":"설명","rewardPoints":100,
+				"oxCorrectAnswer":true}
+				""".formatted(placeId))).andExpect(status().isOk()).andReturn();
+		String missionId = objectMapper.readTree(createResult.getResponse().getContentAsString()).path("data")
+				.path("missionId").asString();
+
+		mockMvc.perform(deleteRequest(missionId)).andExpect(status().isOk());
+		jdbcTemplate.update("UPDATE places SET deleted_at = now() WHERE id = ?", placeId);
+
+		mockMvc.perform(restoreRequest(missionId)).andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
 	private UUID insertPlace() {
 		UUID id = UUID.randomUUID();
 		jdbcTemplate.update(
@@ -223,6 +261,10 @@ class MissionAdminControllerIntegrationTests {
 
 	private MockHttpServletRequestBuilder listRequest(String placeId) {
 		return get("/admin/missions").param("placeId", placeId).header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	private MockHttpServletRequestBuilder restoreRequest(String missionId) {
+		return post("/admin/missions/{missionId}/restore", missionId).header("X-Admin-Api-Key", VALID_API_KEY);
 	}
 
 	@DynamicPropertySource

--- a/src/test/java/com/buyeoon/place/PlaceAdminControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/place/PlaceAdminControllerIntegrationTests.java
@@ -128,11 +128,49 @@ class PlaceAdminControllerIntegrationTests {
 
 		mockMvc.perform(deleteRequest(placeId)).andExpect(status().isOk());
 
-		mockMvc.perform(getDetailRequest(placeId)).andExpect(status().isNotFound());
+		mockMvc.perform(getDetailRequest(placeId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.deleted").value(true));
 
 		Boolean deleted = jdbcTemplate.queryForObject("SELECT deleted_at IS NOT NULL FROM places WHERE id = ?::uuid",
 				Boolean.class, placeId);
 		assertThat(deleted).isTrue();
+
+		mockMvc.perform(restoreRequest(placeId)).andExpect(status().isOk());
+
+		mockMvc.perform(getDetailRequest(placeId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.deleted").value(false));
+	}
+
+	@Test
+	@DisplayName("장소를 삭제하면 딸린 미션도 함께 삭제되고, 장소를 복구해도 미션은 그대로 삭제 상태다")
+	void deletingPlaceCascadesToMissionsButRestoringPlaceDoesNot() throws Exception {
+		MvcResult createResult = mockMvc
+				.perform(createRequest("""
+						{"category":"HERITAGE","name":"관리자 생성 장소2","summary":"요약","description":"설명",
+						"address":"주소","latitude":-76.0,"longitude":0.0}"""))
+				.andExpect(status().isOk()).andReturn();
+		String placeId = objectMapper.readTree(createResult.getResponse().getContentAsString()).path("data")
+				.path("placeId").asString();
+
+		String missionId = jdbcTemplate.queryForObject("""
+				INSERT INTO missions (place_id, type, title, description, reward_points, location)
+				VALUES (?::uuid, 'PHOTO', '테스트 미션', '설명', 10, (SELECT location FROM places WHERE id = ?::uuid))
+				RETURNING id
+				""", String.class, placeId, placeId);
+
+		mockMvc.perform(deleteRequest(placeId)).andExpect(status().isOk());
+
+		Boolean missionDeleted = jdbcTemplate.queryForObject(
+				"SELECT deleted_at IS NOT NULL FROM missions WHERE id = ?::uuid", Boolean.class, missionId);
+		assertThat(missionDeleted).isTrue();
+
+		mockMvc.perform(restoreRequest(placeId)).andExpect(status().isOk());
+
+		Boolean stillDeleted = jdbcTemplate.queryForObject(
+				"SELECT deleted_at IS NOT NULL FROM missions WHERE id = ?::uuid", Boolean.class, missionId);
+		assertThat(stillDeleted).isTrue();
+
+		jdbcTemplate.update("DELETE FROM missions WHERE id = ?::uuid", missionId);
 	}
 
 	@Test
@@ -213,6 +251,10 @@ class PlaceAdminControllerIntegrationTests {
 
 	private MockHttpServletRequestBuilder deleteRequest(String placeId) {
 		return delete("/admin/places/{placeId}", placeId).header("X-Admin-Api-Key", VALID_API_KEY);
+	}
+
+	private MockHttpServletRequestBuilder restoreRequest(String placeId) {
+		return post("/admin/places/{placeId}/restore", placeId).header("X-Admin-Api-Key", VALID_API_KEY);
 	}
 
 	private MockHttpServletRequestBuilder getDetailRequest(String placeId) {


### PR DESCRIPTION
## Summary
- 장소를 soft delete해도 딸린 미션은 건드리지 않아, 관리자가 삭제한 장소의 미션을 회원이 계속 조회/수행할 수 있던 문제를 해결
- `PlaceAdminCommandService.delete()`가 해당 장소의 활성 미션들도 함께 cascade soft-delete하도록 수정
- `POST /admin/places/{placeId}/restore`, `POST /admin/missions/{missionId}/restore` 추가
  - 장소 restore는 미션을 건드리지 않음 — 미션은 cascade든 개별 삭제든 항상 별도로 restore
  - 미션 restore는 소속 장소가 여전히 삭제 상태면 400 (`InvalidMissionRequestException`) — 삭제된 장소에 "활성" 미션이 존재하지 않는다는 불변식 유지
- 회원용 미션 조회 3종(`findNearby`/`findDetail`/`findWithDistance`)에 `p.deletedAt IS NULL` 필터 추가 (방어적 보강, cascade가 있으면 사실상 열리지 않는 경로)
- restore한 항목을 admin이 찾을 수 있어야 하므로, 장소 admin 목록/상세 조회를 미션과 동일하게 삭제 여부 무관 조회로 변경 (`deleted` 플래그로 구분) — 기존엔 삭제된 장소가 목록/상세 모두에서 사라져서 restore가 사실상 불가능했음

## Test plan
- [x] `./gradlew compileJava compileTestJava`
- [x] `PlaceAdminControllerIntegrationTests` (신규: 삭제→restore 플로우, 장소 삭제 시 미션 cascade + restore는 미션에 영향 없음)
- [x] `MissionAdminControllerIntegrationTests` (신규: 미션 restore, 장소가 삭제 상태면 미션 restore 400)
- [x] `MissionControllerIntegrationTests`, `PlaceControllerIntegrationTests` (회원용 조회 회귀 확인)
- [x] 전체 `./gradlew test` 스위트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DG8nZiKUW9NuBWdJqdjiQB