### PR TITLE
feat: 군민증 발급 시 알림 발송

### DIFF
--- a/src/main/java/com/buyeoon/member/application/CitizenCardCreationService.java
+++ b/src/main/java/com/buyeoon/member/application/CitizenCardCreationService.java
@@ -4,6 +4,7 @@ import com.buyeoon.common.api.SuccessResponse;
 import com.buyeoon.common.storage.PublicImageUrlService;
 import com.buyeoon.member.api.InvalidCitizenCardRequestException;
 import com.buyeoon.member.application.CitizenCardQueryService.CardOptionView;
+import com.buyeoon.notification.NotificationCreationService;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -40,15 +41,18 @@ public final class CitizenCardCreationService implements CitizenCardCreator {
 	private final TransactionTemplate transactions;
 	private final CitizenCardLocationVerifier locationVerifier;
 	private final PublicImageUrlService imageUrls;
+	private final NotificationCreationService notificationCreationService;
 	private final ObjectReader objectReader;
 	private final ObjectWriter objectWriter;
 
 	public CitizenCardCreationService(JdbcOperations jdbcOperations, PlatformTransactionManager transactionManager,
-			CitizenCardLocationVerifier locationVerifier, PublicImageUrlService imageUrls, ObjectMapper objectMapper) {
+			CitizenCardLocationVerifier locationVerifier, PublicImageUrlService imageUrls,
+			NotificationCreationService notificationCreationService, ObjectMapper objectMapper) {
 		this.jdbcOperations = jdbcOperations;
 		this.transactions = new TransactionTemplate(transactionManager);
 		this.locationVerifier = locationVerifier;
 		this.imageUrls = imageUrls;
+		this.notificationCreationService = notificationCreationService;
 		this.objectReader = objectMapper.reader();
 		this.objectWriter = objectMapper.writer();
 	}
@@ -101,6 +105,7 @@ public final class CitizenCardCreationService implements CitizenCardCreator {
 				INSERT INTO citizen_cards (id, member_id, theme_id, barcode_value, issued_at)
 				VALUES (?, ?, ?, ?, ?)
 				""", cardId, memberId, command.themeId(), barcodeValue, timestamp);
+		notificationCreationService.createCitizenCardIssued(memberId, cardId);
 
 		CitizenCardView result = new CitizenCardView(cardId, command.displayName(), toView(character), toView(theme),
 				issuedAt.atZone(ASIA_SEOUL));

--- a/src/main/java/com/buyeoon/notification/NotificationCreationService.java
+++ b/src/main/java/com/buyeoon/notification/NotificationCreationService.java
@@ -21,4 +21,10 @@ public class NotificationCreationService {
 		notifications.save(NotificationEntity.create(memberId, NotificationType.BADGE, "새로운 배지를 획득했어요!",
 				badgeName + " 배지를 획득했어요.", "BADGE", badgeId));
 	}
+
+	/** 군민증을 발급할 때마다 {@code CITIZEN_CARD} 알림을 한 건 생성한다. */
+	public void createCitizenCardIssued(UUID memberId, UUID cardId) {
+		notifications.save(NotificationEntity.create(memberId, NotificationType.CITIZEN_CARD, "군민증이 발급됐어요!",
+				"디지털 군민증이 발급됐어요.", "CITIZEN_CARD", cardId));
+	}
 }

--- a/src/test/java/com/buyeoon/member/CitizenCardCreationIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/CitizenCardCreationIntegrationTests.java
@@ -73,6 +73,7 @@ class CitizenCardCreationIntegrationTests {
 	@BeforeEach
 	void cleanUp() {
 		jdbcTemplate.update("DELETE FROM idempotency_requests");
+		jdbcTemplate.update("DELETE FROM notifications");
 		jdbcTemplate.update("DELETE FROM citizen_cards");
 		jdbcTemplate.update("DELETE FROM member_profiles");
 		jdbcTemplate.update("DELETE FROM term_consents");
@@ -108,6 +109,11 @@ class CitizenCardCreationIntegrationTests {
 		assertThat(
 				jdbcTemplate.queryForObject("SELECT barcode_value::uuid IS NOT NULL FROM citizen_cards", Boolean.class))
 				.isTrue();
+		assertThat(jdbcTemplate.queryForObject("""
+				SELECT count(*) FROM notifications n
+				JOIN citizen_cards c ON c.id = n.target_id
+				WHERE n.member_id = c.member_id AND n.type = 'CITIZEN_CARD' AND n.target_type = 'CITIZEN_CARD'
+				""", Long.class)).isEqualTo(1L);
 		assertThat(jdbcTemplate.queryForObject("""
 				SELECT profile.updated_at = card.issued_at
 				   AND card.issued_at = request.created_at
@@ -201,6 +207,8 @@ class CitizenCardCreationIntegrationTests {
 
 		assertThat(retried).isEqualTo(first);
 		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM citizen_cards", Long.class)).isEqualTo(1L);
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM notifications WHERE type = 'CITIZEN_CARD'",
+				Long.class)).isEqualTo(1L);
 	}
 
 	/** 보관 중인 키를 다른 본문·작업에 쓰거나 발급 후 다른 키로 다시 만들 수 없다. */
@@ -430,6 +438,8 @@ class CitizenCardCreationIntegrationTests {
 				memberId)).isZero();
 		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM idempotency_requests WHERE member_id = ?",
 				Long.class, memberId)).isZero();
+		assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM notifications WHERE member_id = ?", Long.class,
+				memberId)).isZero();
 	}
 
 	@DynamicPropertySource


### PR DESCRIPTION
## Summary
- `NotificationType.CITIZEN_CARD` 값은 이미 존재했지만 실제로 발송하는 코드가 없어서, 군민증을 발급해도 알림이 가지 않던 갭을 채움
- `NotificationCreationService.createCitizenCardIssued(memberId, cardId)` 추가 (배지 획득 알림과 동일한 패턴)
- `CitizenCardCreationService.createInTransaction()`이 `citizen_cards` INSERT 직후 같은 트랜잭션 안에서 호출

## Test plan
- [x] `./gradlew compileJava compileTestJava`
- [x] `CitizenCardCreationIntegrationTests` (알림 1건 생성 확인, 멱등 재시도 시 중복 발송 안 됨, 실패/거부 케이스에서 알림 미생성 확인)
- [x] 전체 `./gradlew test` 스위트

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DG8nZiKUW9NuBWdJqdjiQB