### PR TITLE
feat: 발자취 사진 응답에 장소명을 포함한다

### DIFF
--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -2452,7 +2452,7 @@ components:
           format: date-time
     MissionPhotoData:
       type: object
-      required: [photoId, url, uploadedAt]
+      required: [photoId, url, uploadedAt, placeName]
       properties:
         photoId:
           type: string
@@ -2464,6 +2464,9 @@ components:
         uploadedAt:
           type: string
           format: date-time
+        placeName:
+          type: string
+          description: 사진을 찍은 미션이 연결된 문화재 장소명
     MultipleChoiceMissionSubmissionRequest:
       type: object
       additionalProperties: false

--- a/src/main/java/com/buyeoon/trip/FootprintQueryService.java
+++ b/src/main/java/com/buyeoon/trip/FootprintQueryService.java
@@ -125,12 +125,14 @@ public class FootprintQueryService {
 	}
 
 	private List<PhotoView> photos(UUID memberId, UUID tripId) {
-		return photoRepository.findByMemberIdAndTripIdOrderByUploadedAtAsc(memberId, tripId).stream()
-				.map(this::toPhotoView).toList();
+		return photoRepository.findWithPlaceNameByMemberIdAndTripId(memberId, tripId).stream().map(this::toPhotoView)
+				.toList();
 	}
 
-	private PhotoView toPhotoView(MissionPhotoEntity photo) {
-		return new PhotoView(photo.getId(), privateImageUrls.create(photo.getObjectKey()), photo.getUploadedAt());
+	private PhotoView toPhotoView(TripPhotoProjection projection) {
+		MissionPhotoEntity photo = projection.photo();
+		return new PhotoView(photo.getId(), privateImageUrls.create(photo.getObjectKey()), photo.getUploadedAt(),
+				projection.placeName());
 	}
 
 	public record FootprintView(FootprintTripView trip, TripStatisticsView statistics, List<VisitView> visits,
@@ -160,6 +162,6 @@ public class FootprintQueryService {
 	public record BadgeView(UUID badgeId, String name, String imageUrl, String condition, Instant earnedAt) {
 	}
 
-	public record PhotoView(UUID photoId, String url, Instant uploadedAt) {
+	public record PhotoView(UUID photoId, String url, Instant uploadedAt, String placeName) {
 	}
 }

--- a/src/main/java/com/buyeoon/trip/TripController.java
+++ b/src/main/java/com/buyeoon/trip/TripController.java
@@ -155,9 +155,9 @@ public class TripController {
 		}
 	}
 
-	private record FootprintPhotoResponse(UUID photoId, String url, Instant uploadedAt) {
+	private record FootprintPhotoResponse(UUID photoId, String url, Instant uploadedAt, String placeName) {
 		static FootprintPhotoResponse from(PhotoView photo) {
-			return new FootprintPhotoResponse(photo.photoId(), photo.url(), photo.uploadedAt());
+			return new FootprintPhotoResponse(photo.photoId(), photo.url(), photo.uploadedAt(), photo.placeName());
 		}
 	}
 

--- a/src/test/java/com/buyeoon/trip/FootprintIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/FootprintIntegrationTests.java
@@ -110,7 +110,8 @@ class FootprintIntegrationTests {
 				.andExpect(jsonPath("$.data.photos.length()").value(1))
 				.andExpect(jsonPath("$.data.photos[0].photoId").exists())
 				.andExpect(jsonPath("$.data.photos[0].uploadedAt").exists())
-				.andExpect(jsonPath("$.data.photos[0].url").value("https://signed-url.example.com/photo"));
+				.andExpect(jsonPath("$.data.photos[0].url").value("https://signed-url.example.com/photo"))
+				.andExpect(jsonPath("$.data.photos[0].placeName").value("정림사지"));
 	}
 
 	/** IN_PROGRESS 상태의 여행을 조회하면 409를 반환한다. */


### PR DESCRIPTION
## 배경

발자취 사진 뷰어 시안([final_04](https://www.figma.com/design/rl9vmWEv5PukINHuiLtSt9/?node-id=209-16231), node 209:16262)은 사진마다 **촬영 장소명**을 표시한다. 그런데 `GET /trips/{tripId}/footprint`의 `photos`에는 장소명이 없어서, 클라이언트가 `"부여에서 남긴 사진"` 고정 문구로 대체하고 있었다 — 사진을 넘겨도 제목이 바뀌지 않는 상태.

같은 사진을 내려주는 `GET /trips/{tripId}/photos`는 **이미 `placeName`을 포함**하고 있어서, 데이터는 있는데 발자취 응답에만 안 실리는 상황이었다.

## 변경

**1. 조회 쿼리 교체** (`FootprintQueryService`)

```
findByMemberIdAndTripIdOrderByUploadedAtAsc  →  findWithPlaceNameByMemberIdAndTripId
```

후자는 `TripQueryService`가 이미 쓰던 기존 쿼리라 새로 만들지 않았다. `ORDER BY photo.uploadedAt ASC`를 포함하고 있어 **정렬 순서도 그대로 유지**된다.

**2. 두 레이어 모두에 필드 추가**

| 위치 | 변경 |
|---|---|
| `FootprintQueryService.PhotoView` | `placeName` 추가 |
| `TripController.FootprintPhotoResponse` | `placeName` 추가 |

서비스만 고치면 응답 DTO에서 필드가 잘려 실제 API는 그대로다. 통합 테스트가 `No value at JSON path "$.data.photos[0].placeName"`로 이를 잡아냈다.

**3. 명세·테스트**
- `openapi.yaml` — `MissionPhotoData`에 `placeName` 추가 (이미 `placeName`을 가진 `TripPhotoData`와 동일 형식)
- `FootprintIntegrationTests` — `photos[0].placeName` 검증 추가

## 검증

- `FootprintIntegrationTests` 9개 통과 (최신 main 리베이스 후 재확인)
- `TripQueryService` 관련 테스트 통과

## 관련

클라이언트 대응 PR: Buyeo-On/buyeo-on-fe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rCSpcdNyrDafHAsx3eUMS