### PR TITLE
fix: 제출 기록이 있는 객관식 보기는 수정을 막는다

### DIFF
--- a/src/main/java/com/buyeoon/common/api/ErrorResponse.java
+++ b/src/main/java/com/buyeoon/common/api/ErrorResponse.java
@@ -66,6 +66,10 @@ public record ErrorResponse(boolean success, ErrorData data) {
 		return new ErrorResponse(false, new ErrorData("PAYLOAD_TOO_LARGE", "서버에 설정된 최대 업로드 크기를 초과했습니다."));
 	}
 
+	public static ErrorResponse missionChoiceInUse() {
+		return new ErrorResponse(false, new ErrorData("MISSION_CHOICE_IN_USE", "이미 제출 기록이 있는 보기는 수정할 수 없습니다."));
+	}
+
 	public record ErrorData(String code, String message) {
 	}
 }

--- a/src/main/java/com/buyeoon/mission/api/MissionExceptionHandler.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionExceptionHandler.java
@@ -4,6 +4,7 @@ import com.buyeoon.common.api.ErrorResponse;
 import com.buyeoon.member.application.IdempotencyKeyReusedException;
 import com.buyeoon.member.application.InvalidStateTransitionException;
 import com.buyeoon.mission.application.InvalidMissionSubmissionException;
+import com.buyeoon.mission.application.MissionChoiceInUseException;
 import com.buyeoon.mission.application.MissionNotFoundException;
 import com.buyeoon.mission.application.MissionPhotoNotFoundException;
 import com.buyeoon.mission.application.MissionPhotoTooLargeException;
@@ -65,6 +66,12 @@ public class MissionExceptionHandler {
 	@ResponseStatus(HttpStatus.CONFLICT)
 	public ErrorResponse handleIdempotencyKeyReused() {
 		return ErrorResponse.idempotencyKeyReused();
+	}
+
+	@ExceptionHandler(MissionChoiceInUseException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ErrorResponse handleMissionChoiceInUse() {
+		return ErrorResponse.missionChoiceInUse();
 	}
 
 	/** 회원 행 잠금 시 활성 상태가 아니면 인증 실패 응답을 반환한다. */

--- a/src/main/java/com/buyeoon/mission/application/MissionAdminCommandService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionAdminCommandService.java
@@ -9,11 +9,13 @@ import com.buyeoon.mission.entity.MissionEntity;
 import com.buyeoon.mission.entity.MissionType;
 import com.buyeoon.mission.repository.MissionChoiceRepository;
 import com.buyeoon.mission.repository.MissionQueryRepository;
+import com.buyeoon.mission.repository.MissionSubmissionRepository;
 import com.buyeoon.place.entity.PlaceEntity;
 import com.buyeoon.place.repository.PlaceQueryRepository;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
@@ -25,14 +27,17 @@ public class MissionAdminCommandService {
 
 	private final MissionQueryRepository missionQueryRepository;
 	private final MissionChoiceRepository missionChoiceRepository;
+	private final MissionSubmissionRepository missionSubmissionRepository;
 	private final PlaceQueryRepository placeQueryRepository;
 	private final GeometryFactory geometryFactory = new GeometryFactory();
 
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
 	public MissionAdminCommandService(MissionQueryRepository missionQueryRepository,
-			MissionChoiceRepository missionChoiceRepository, PlaceQueryRepository placeQueryRepository) {
+			MissionChoiceRepository missionChoiceRepository, MissionSubmissionRepository missionSubmissionRepository,
+			PlaceQueryRepository placeQueryRepository) {
 		this.missionQueryRepository = missionQueryRepository;
 		this.missionChoiceRepository = missionChoiceRepository;
+		this.missionSubmissionRepository = missionSubmissionRepository;
 		this.placeQueryRepository = placeQueryRepository;
 	}
 
@@ -96,6 +101,7 @@ public class MissionAdminCommandService {
 			switch (mission.getType()) {
 				case MULTIPLE_CHOICE -> {
 					requireNoOxAnswer(request.oxCorrectAnswer());
+					requireNoSubmittedChoices(missionId);
 					mission.updateMultipleChoice(title, description, request.rewardPoints(), request.maxAttempts());
 					missionChoiceRepository.deleteByMissionId(missionId);
 					missionChoiceRepository.flush();
@@ -152,6 +158,14 @@ public class MissionAdminCommandService {
 			String label = requiredText(choice.label());
 			missionChoiceRepository.save(MissionChoiceEntity.create(missionId, label, choice.correct(),
 					choice.sortOrder()));
+		}
+	}
+
+	private void requireNoSubmittedChoices(UUID missionId) {
+		List<UUID> choiceIds = missionChoiceRepository.findByMissionIdOrderBySortOrderAsc(missionId).stream()
+				.map(MissionChoiceEntity::getId).collect(Collectors.toList());
+		if (!choiceIds.isEmpty() && missionSubmissionRepository.existsByChoiceIdIn(choiceIds)) {
+			throw new MissionChoiceInUseException();
 		}
 	}
 

--- a/src/main/java/com/buyeoon/mission/application/MissionChoiceInUseException.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionChoiceInUseException.java
@@ -1,0 +1,8 @@
+package com.buyeoon.mission.application;
+
+public class MissionChoiceInUseException extends RuntimeException {
+
+	public MissionChoiceInUseException() {
+		super("이미 제출 기록이 있는 보기는 수정할 수 없습니다.");
+	}
+}

--- a/src/main/java/com/buyeoon/mission/repository/MissionSubmissionRepository.java
+++ b/src/main/java/com/buyeoon/mission/repository/MissionSubmissionRepository.java
@@ -82,4 +82,7 @@ public interface MissionSubmissionRepository extends JpaRepository<MissionSubmis
 			+ "ORDER BY s.submittedAt ASC")
 	List<QuizSubmissionRow> findQuizSubmissionsOrderedBySubmittedAtAsc(@Param("memberId") UUID memberId,
 			@Param("types") Collection<MissionType> types);
+
+	/** 주어진 보기 중 하나라도 제출 기록이 있으면 참이다. */
+	boolean existsByChoiceIdIn(Collection<UUID> choiceIds);
 }

--- a/src/test/java/com/buyeoon/mission/MissionAdminControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionAdminControllerIntegrationTests.java
@@ -68,6 +68,8 @@ class MissionAdminControllerIntegrationTests {
 
 	@AfterEach
 	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM members");
 		jdbcTemplate.update(
 				"DELETE FROM mission_choices WHERE mission_id IN "
 						+ "(SELECT id FROM missions WHERE place_id IN (SELECT id FROM places WHERE ST_Y(location::geometry) < -70))");
@@ -121,6 +123,50 @@ class MissionAdminControllerIntegrationTests {
 		Boolean deleted = jdbcTemplate.queryForObject("SELECT deleted_at IS NOT NULL FROM missions WHERE id = ?::uuid",
 				Boolean.class, missionId);
 		assertThat(deleted).isTrue();
+	}
+
+	@Test
+	@DisplayName("제출 기록이 있는 보기를 포함한 객관식 미션을 수정하면 409를 받는다")
+	void returns409WhenUpdatingMultipleChoiceMissionWithSubmittedChoice() throws Exception {
+		UUID placeId = insertPlace();
+
+		MvcResult createResult = mockMvc
+				.perform(createRequest("""
+						{"placeId":"%s","type":"MULTIPLE_CHOICE","title":"문제1","description":"설명",
+						"rewardPoints":100,"maxAttempts":3,
+						"choices":[{"label":"보기1","correct":true,"sortOrder":0},
+						           {"label":"보기2","correct":false,"sortOrder":1}]}
+						""".formatted(placeId)))
+				.andExpect(status().isOk()).andReturn();
+		String missionId = objectMapper.readTree(createResult.getResponse().getContentAsString()).path("data")
+				.path("missionId").asString();
+
+		UUID choiceId = jdbcTemplate.queryForObject(
+				"SELECT id FROM mission_choices WHERE mission_id = ?::uuid ORDER BY sort_order ASC LIMIT 1", UUID.class,
+				missionId);
+		submitChoice(UUID.fromString(missionId), choiceId);
+
+		mockMvc.perform(updateRequest(missionId, """
+				{"title":"수정된 문제","description":"수정된 설명","rewardPoints":200,"maxAttempts":5,
+				"choices":[{"label":"새 보기","correct":true,"sortOrder":0}]}
+				""")).andExpect(status().isConflict())
+				.andExpect(jsonPath("$.data.code").value("MISSION_CHOICE_IN_USE"));
+	}
+
+	private void submitChoice(UUID missionId, UUID choiceId) {
+		UUID memberId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status) VALUES (?, ?, 'IN_PROGRESS')", tripId, memberId);
+		UUID participationId = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO mission_participations (id, trip_id, mission_id, status, attempt_count, completed_at) "
+						+ "VALUES (?, ?, ?, 'COMPLETED'::mission_status, 1, now())",
+				participationId, tripId, missionId);
+		jdbcTemplate.update(
+				"INSERT INTO mission_submissions (participation_id, type, choice_id, correct) "
+						+ "VALUES (?, 'MULTIPLE_CHOICE'::mission_type, ?, true)",
+				participationId, choiceId);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- 미션 보기 수정 시 발생하던 401을 재현·분석한 결과, 실제 원인은 이미 제출 기록이 있는 객관식 보기를 삭제-후-재생성하려다 FK 제약(`DataIntegrityViolationException`)에 걸리는 것이었다. 이를 처리하는 핸들러가 없어 `/error`로 재디스패치되고, `/error`가 `permitAll` 대상이 아니라서 인증 미들웨어가 401로 응답하고 있었다.
- `MissionAdminCommandService.update()`에서 객관식 보기 삭제 전에 기존 보기 중 제출 기록이 있는 것이 있는지 먼저 확인해 수정을 막고, `MISSION_CHOICE_IN_USE`(409)로 명확히 구분해 응답하도록 변경했다.
- 장소(Place) 수정/삭제는 필드 갱신 및 소프트 삭제만 하므로 동일한 문제가 없음을 확인했다(변경 없음).

## Test plan
- [x] `./gradlew test --tests "com.buyeoon.mission.*" --tests "com.buyeoon.place.*"` 통과
- [x] 신규 통합 테스트: 제출 기록이 있는 보기를 포함한 미션을 수정하면 `409` + `MISSION_CHOICE_IN_USE` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BqZ15H9PCaE8kMFCwvgRp