### PR TITLE
feat: 미션 참여 반경을 30m로 바꾼다

### DIFF
--- a/src/main/java/com/buyeoon/mission/application/MissionQueryService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionQueryService.java
@@ -16,11 +16,13 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/** UC-06 주변 미션 목록과 상세 조회 서비스다. */
 @Service
 @Transactional(readOnly = true)
 public class MissionQueryService {
 
-	private static final int PARTICIPATION_RADIUS_METERS = 100;
+	/** 미션 참여를 허용하는 고정 반경(m). 경계를 포함하며 위치 인증 정책과 같다. */
+	private static final int PARTICIPATION_RADIUS_METERS = 30;
 
 	private final MissionQueryRepository missionQueryRepository;
 	private final MissionChoiceRepository missionChoiceRepository;
@@ -114,8 +116,8 @@ public class MissionQueryService {
 	}
 
 	/**
-	 * 스페셜 퀴즈(최대 도전 횟수가 있는 객관식·OX 미션)는 여행·KST 날짜·미션 ID로 정해지는 시드로 하루 20%만
-	 * 노출한다. 완료·기회 소진 상태는 이미 참여한 기록이라 노출 대상에서 빼지 않고 항상 보여준다.
+	 * 스페셜 퀴즈(최대 도전 횟수가 있는 객관식·OX 미션)는 여행·KST 날짜·미션 ID로 정해지는 시드로 하루 20%만 노출한다. 완료·기회
+	 * 소진 상태는 이미 참여한 기록이라 노출 대상에서 빼지 않고 항상 보여준다.
 	 */
 	private boolean isExposedToday(UUID tripId, NearbyMissionProjection row) {
 		MissionEntity mission = row.mission();

--- a/src/main/java/com/buyeoon/mission/application/MissionSubmissionService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionSubmissionService.java
@@ -65,7 +65,8 @@ public class MissionSubmissionService {
 
 	private static final String OPERATION = "SUBMIT_MISSION";
 	private static final Duration RETENTION = Duration.ofHours(24);
-	private static final int PARTICIPATION_RADIUS_METERS = 100;
+	/** 미션 참여를 허용하는 고정 반경(m). 경계를 포함하며 위치 인증 정책과 같다. */
+	private static final int PARTICIPATION_RADIUS_METERS = 30;
 	private static final Set<String> ALLOWED_PHOTO_CONTENT_TYPES = Set.of("image/jpeg", "image/png", "image/webp");
 
 	private final JdbcOperations jdbcOperations;

--- a/src/test/java/com/buyeoon/mission/MissionBadgeAwardIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionBadgeAwardIntegrationTests.java
@@ -123,7 +123,7 @@ class MissionBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("탐험가", "public/badges/explorer.png", "미션 1회 완료");
 		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		MvcResult result = mockMvc.perform(submit(missionId, "award-first", oxRequest(tripId, true)))
@@ -158,7 +158,7 @@ class MissionBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("탐험가", null, "미션 1회 완료");
 		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "award-notif", oxRequest(tripId, true))).andExpect(status().isOk());
@@ -178,7 +178,7 @@ class MissionBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("무이미지 배지", null, "미션 1회 완료");
 		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "award-no-image", oxRequest(tripId, true))).andExpect(status().isOk())
@@ -192,7 +192,7 @@ class MissionBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("두 번 완료", null, "미션 2회 완료");
 		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 2);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "below-threshold", oxRequest(tripId, true))).andExpect(status().isOk())
@@ -209,7 +209,7 @@ class MissionBadgeAwardIntegrationTests {
 	void completingSameMissionInAnotherTripIncreasesLifetimeCount() throws Exception {
 		UUID badgeId = insertBadge("두 번 완료", null, "미션 2회 완료");
 		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 2);
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		UUID firstTrip = startTrip(member.memberId());
@@ -240,7 +240,7 @@ class MissionBadgeAwardIntegrationTests {
 		UUID expectedSecond = ascending.get(1);
 
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "multi-badge", oxRequest(tripId, true))).andExpect(status().isOk())
@@ -255,7 +255,7 @@ class MissionBadgeAwardIntegrationTests {
 	void alreadyEarnedBadgeIsNotAwardedAgain() throws Exception {
 		UUID badgeId = insertBadge("탐험가", null, "미션 1회 완료");
 		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 
 		UUID firstTrip = startTrip(member.memberId());
 		UUID firstMission = insertOxMission(place, "미션1", 100, null, true);
@@ -285,7 +285,7 @@ class MissionBadgeAwardIntegrationTests {
 		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
 		jdbcTemplate.update("UPDATE badges SET retired_at = now() WHERE id = ?", badgeId);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "retired-badge", oxRequest(tripId, true))).andExpect(status().isOk())
@@ -302,7 +302,7 @@ class MissionBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("탐험가", null, "미션 1회 완료");
 		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID firstMission = insertOxMission(place, "미션1", 100, null, true);
 		UUID secondMission = insertOxMission(place, "미션2", 100, null, true);
 		CountDownLatch ready = new CountDownLatch(2);
@@ -338,7 +338,7 @@ class MissionBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("탐험가", "public/badges/explorer.png", "미션 1회 완료");
 		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 		String key = "replay-badge-key";
 		String body = oxRequest(tripId, true);

--- a/src/test/java/com/buyeoon/mission/MissionCompletionistBadgeAwardIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionCompletionistBadgeAwardIntegrationTests.java
@@ -126,7 +126,7 @@ class MissionCompletionistBadgeAwardIntegrationTests {
 		// 15곳의 고유 문화재에서 각각 OX 퀴즈를 정답으로 완료한다.
 		// 이 과정에서 HERITAGE_VISITED_COUNT=15, QUIZ_CORRECT_COUNT=15를 함께 채운다.
 		for (int i = 1; i <= 15; i++) {
-			UUID place = insertProjectedPlace("문화재 " + i, 50 + i * 3.0);
+			UUID place = insertProjectedPlace("문화재 " + i, 5 + i * 1.0);
 			submitOx(tripId, place, i).andExpect(status().isOk());
 		}
 
@@ -134,7 +134,7 @@ class MissionCompletionistBadgeAwardIntegrationTests {
 		assertThat(memberBadgeCount(COMPLETIONIST_BADGE_ID)).isZero();
 
 		// 인증 사진 14회까지는 세 조건을 모두 충족하지 못한다.
-		UUID photoPlace = insertProjectedPlace("사진 장소", 50);
+		UUID photoPlace = insertProjectedPlace("사진 장소", 20);
 		for (int i = 1; i <= 14; i++) {
 			submitPhoto(tripId, photoPlace, i).andExpect(status().isOk());
 		}
@@ -246,9 +246,9 @@ class MissionCompletionistBadgeAwardIntegrationTests {
 	}
 
 	private int memberBadgeCount(UUID badgeId) {
-		return Objects.requireNonNull(jdbcTemplate.queryForObject(
-				"SELECT count(*) FROM member_badges WHERE member_id = ? AND badge_id = ?", Integer.class,
-				member.memberId(), badgeId));
+		return Objects.requireNonNull(
+				jdbcTemplate.queryForObject("SELECT count(*) FROM member_badges WHERE member_id = ? AND badge_id = ?",
+						Integer.class, member.memberId(), badgeId));
 	}
 
 	private String badgeName(UUID badgeId) {

--- a/src/test/java/com/buyeoon/mission/MissionControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionControllerIntegrationTests.java
@@ -181,7 +181,7 @@ class MissionControllerIntegrationTests {
 	@DisplayName("목록 항목에 필요한 모든 필드가 포함된다")
 	void includesAllRequiredFieldsInResponse() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("부소산성", 50);
+		UUID place = insertProjectedPlace("부소산성", 20);
 		UUID missionId = insertOxMission(place, "OX 퀴즈", 100, null, true);
 
 		mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk())
@@ -196,23 +196,29 @@ class MissionControllerIntegrationTests {
 				.andExpect(jsonPath("$.data.items[0].title").value("OX 퀴즈"))
 				.andExpect(jsonPath("$.data.items[0].rewardPoints").value(100))
 				.andExpect(jsonPath("$.data.items[0].availability").value("AVAILABLE"))
-				.andExpect(jsonPath("$.data.items[0].participationRadiusMeters").value(100))
+				.andExpect(jsonPath("$.data.items[0].participationRadiusMeters").value(30))
 				.andExpect(jsonPath("$.data.items[0].remainingAttempts").isEmpty());
 	}
 
-	/** 참여 기록이 없는 미션은 100m 이내면 AVAILABLE, 초과면 LOCKED이며 100m 경계는 AVAILABLE이다. */
+	/** 참여 기록이 없는 미션은 30m 이내면 AVAILABLE, 초과면 LOCKED이며 30m 경계는 AVAILABLE이다. */
 	@Test
-	@DisplayName("참여 기록이 없으면 100m 이내는 AVAILABLE, 초과는 LOCKED로 표시된다")
+	@DisplayName("참여 기록이 없으면 30m 이내는 AVAILABLE, 초과는 LOCKED로 표시된다")
 	void marksAvailableWithinParticipationRadiusAndLockedBeyond() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID availablePlace = insertProjectedPlace("참여 가능", 99.9);
-		UUID lockedPlace = insertProjectedPlace("잠김", 100.1);
+		UUID availablePlace = insertProjectedPlace("참여 가능", 29.9);
+		UUID boundaryPlace = insertProjectedPlace("경계", 30.0);
+		UUID justBeyondPlace = insertProjectedPlace("직후 잠김", 30.1);
+		UUID formerlyInsidePlace = insertProjectedPlace("이전 참여 가능", 50);
 		UUID availableMission = insertOxMission(availablePlace, "참여 가능 미션", 100, null, true);
-		UUID lockedMission = insertOxMission(lockedPlace, "잠긴 미션", 100, null, true);
+		UUID boundaryMission = insertOxMission(boundaryPlace, "경계 미션", 100, null, true);
+		UUID justBeyondMission = insertOxMission(justBeyondPlace, "직후 잠긴 미션", 100, null, true);
+		UUID formerlyInsideMission = insertOxMission(formerlyInsidePlace, "50m 잠긴 미션", 100, null, true);
 
 		MvcResult result = mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk()).andReturn();
 		assertThat(itemFor(result, availableMission).get("availability").stringValue()).isEqualTo("AVAILABLE");
-		assertThat(itemFor(result, lockedMission).get("availability").stringValue()).isEqualTo("LOCKED");
+		assertThat(itemFor(result, boundaryMission).get("availability").stringValue()).isEqualTo("AVAILABLE");
+		assertThat(itemFor(result, justBeyondMission).get("availability").stringValue()).isEqualTo("LOCKED");
+		assertThat(itemFor(result, formerlyInsideMission).get("availability").stringValue()).isEqualTo("LOCKED");
 	}
 
 	/** 완료·기회 소진 기록은 현재 위치와 무관하게 유지된다. */
@@ -384,12 +390,12 @@ class MissionControllerIntegrationTests {
 				.andExpect(jsonPath("$.data.code").value("TRIP_NOT_IN_PROGRESS"));
 	}
 
-	/** 반올림 전 거리가 100m 이내인 객관식 미션은 문제와 정답 표시 없는 선택지를 포함한 전체 상세를 받는다. */
+	/** 반올림 전 거리가 30m 이내인 객관식 미션은 문제와 정답 표시 없는 선택지를 포함한 전체 상세를 받는다. */
 	@Test
-	@DisplayName("100m 이내 객관식 미션은 문제와 선택지를 포함한 전체 상세를 받고 정답 값은 노출하지 않는다")
-	void returnsFullDetailWithChoicesForMultipleChoiceMissionWithin100m() throws Exception {
+	@DisplayName("30m 이내 객관식 미션은 문제와 선택지를 포함한 전체 상세를 받고 정답 값은 노출하지 않는다")
+	void returnsFullDetailWithChoicesForMultipleChoiceMissionWithin30m() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("객관식 장소", 50);
+		UUID place = insertProjectedPlace("객관식 장소", 20);
 		UUID missionId = insertMultipleChoiceMission(place, "객관식 미션", 100, null);
 		insertChoice(missionId, "예", true, 0);
 		insertChoice(missionId, "아니요", false, 1);
@@ -404,12 +410,12 @@ class MissionControllerIntegrationTests {
 				.andExpect(jsonPath("$.data.choices[1].correct").doesNotExist());
 	}
 
-	/** 반올림 전 거리가 100m 이내인 OX 미션은 문제를 포함한 전체 상세를 받고 선택지 필드는 없다. */
+	/** 반올림 전 거리가 30m 이내인 OX 미션은 문제를 포함한 전체 상세를 받고 선택지 필드는 없다. */
 	@Test
-	@DisplayName("100m 이내 OX 미션은 문제를 포함한 전체 상세를 받고 정답 값은 노출하지 않는다")
-	void returnsFullDetailForOxMissionWithin100m() throws Exception {
+	@DisplayName("30m 이내 OX 미션은 문제를 포함한 전체 상세를 받고 정답 값은 노출하지 않는다")
+	void returnsFullDetailForOxMissionWithin30m() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("OX 장소", 50);
+		UUID place = insertProjectedPlace("OX 장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(detailRequest(missionId, tripId)).andExpect(status().isOk())
@@ -418,24 +424,24 @@ class MissionControllerIntegrationTests {
 				.andExpect(jsonPath("$.data.oxCorrectAnswer").doesNotExist());
 	}
 
-	/** 반올림 전 거리가 100m 이내인 사진 인증 미션은 촬영 안내를 포함한 전체 상세를 받는다. */
+	/** 반올림 전 거리가 30m 이내인 사진 인증 미션은 촬영 안내를 포함한 전체 상세를 받는다. */
 	@Test
-	@DisplayName("100m 이내 사진 미션은 촬영 안내를 포함한 전체 상세를 받는다")
-	void returnsFullDetailForPhotoMissionWithin100m() throws Exception {
+	@DisplayName("30m 이내 사진 미션은 촬영 안내를 포함한 전체 상세를 받는다")
+	void returnsFullDetailForPhotoMissionWithin30m() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 
 		mockMvc.perform(detailRequest(missionId, tripId)).andExpect(status().isOk())
 				.andExpect(jsonPath("$.data.description").value("설명"));
 	}
 
-	/** 실제 거리가 100m를 초과하면 문제와 선택지가 없는 제한 상세를 받는다. */
+	/** 실제 거리가 30m를 초과하면 문제와 선택지가 없는 제한 상세를 받는다. */
 	@Test
-	@DisplayName("100m를 초과하면 description과 choices가 없는 제한 상세를 받는다")
-	void returnsRestrictedDetailBeyond100m() throws Exception {
+	@DisplayName("30m를 초과하면 description과 choices가 없는 제한 상세를 받는다")
+	void returnsRestrictedDetailBeyond30m() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("잠긴 장소", 100.1);
+		UUID place = insertProjectedPlace("잠긴 장소", 30.1);
 		UUID missionId = insertMultipleChoiceMission(place, "객관식 미션", 100, null);
 		insertChoice(missionId, "예", true, 0);
 		insertChoice(missionId, "아니요", false, 1);
@@ -460,10 +466,10 @@ class MissionControllerIntegrationTests {
 				.andExpect(jsonPath("$.data.description").doesNotExist());
 	}
 
-	/** 완료·기회 소진 미션도 100m 밖이면 상태와 남은 횟수는 유지하되 제한 상세만 받는다. */
+	/** 완료·기회 소진 미션도 30m 밖이면 상태와 남은 횟수는 유지하되 제한 상세만 받는다. */
 	@Test
-	@DisplayName("완료·소진 미션도 100m 밖이면 상태는 유지하되 제한 상세만 받는다")
-	void completedAndExhaustedMissionsBeyond100mReturnRestrictedDetailWithPreservedStatus() throws Exception {
+	@DisplayName("완료·소진 미션도 30m 밖이면 상태는 유지하되 제한 상세만 받는다")
+	void completedAndExhaustedMissionsBeyond30mReturnRestrictedDetailWithPreservedStatus() throws Exception {
 		UUID tripId = startTrip(member.memberId());
 		UUID place = insertProjectedPlace("먼 장소", 200);
 		UUID completedMission = insertOxMission(place, "완료 미션", 100, null, true);
@@ -485,7 +491,7 @@ class MissionControllerIntegrationTests {
 	@DisplayName("목록과 상세의 공통 필드는 동일한 값을 반환한다")
 	void listAndDetailShareTheSameComputedFields() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("공통 장소", 50);
+		UUID place = insertProjectedPlace("공통 장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		MvcResult listResult = mockMvc.perform(nearbyRequest(tripId)).andExpect(status().isOk()).andReturn();
@@ -507,7 +513,7 @@ class MissionControllerIntegrationTests {
 	@DisplayName("반복 상세 조회 전후 DB 상태가 동일하다")
 	void repeatedDetailRequestsDoNotChangeDbState() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX", 100, null, true);
 
 		mockMvc.perform(detailRequest(missionId, tripId)).andExpect(status().isOk());
@@ -523,7 +529,7 @@ class MissionControllerIntegrationTests {
 	@DisplayName("좌표, tripId, missionId 형식이 잘못되면 400을 받는다")
 	void returns400WhenDetailRequestParametersAreInvalid() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX", 100, null, true);
 
 		mockMvc.perform(
@@ -570,7 +576,7 @@ class MissionControllerIntegrationTests {
 	@Test
 	@DisplayName("본인 여행이 진행 중이 아니면 상세 조회도 409를 받는다")
 	void returns409WhenOwnTripIsNotInProgressForDetailRequest() throws Exception {
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX", 100, null, true);
 		UUID endedTripId = UUID.randomUUID();
 		jdbcTemplate.update("INSERT INTO trips (id, member_id, status, ended_at) VALUES (?, ?, 'ENDED', now())",

--- a/src/test/java/com/buyeoon/mission/MissionHeritageBadgeAwardIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionHeritageBadgeAwardIntegrationTests.java
@@ -113,7 +113,7 @@ class MissionHeritageBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("문화탐방가", "미문화재 1곳 방문");
 		insertCondition(badgeId, "HERITAGE_VISITED_COUNT", 1);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소A", 50);
+		UUID place = insertProjectedPlace("장소A", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, true);
 
 		mockMvc.perform(submit(missionId, "heritage-first", oxRequest(tripId, true))).andExpect(status().isOk())
@@ -137,7 +137,7 @@ class MissionHeritageBadgeAwardIntegrationTests {
 		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 1);
 		insertCondition(badgeId, "HERITAGE_VISITED_COUNT", 1);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소A", 50);
+		UUID place = insertProjectedPlace("장소A", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, true);
 
 		mockMvc.perform(submit(missionId, "both-metrics", oxRequest(tripId, true))).andExpect(status().isOk())
@@ -152,7 +152,7 @@ class MissionHeritageBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("문화탐방가", "문화재 2곳 방문");
 		insertCondition(badgeId, "HERITAGE_VISITED_COUNT", 2);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소A", 50);
+		UUID place = insertProjectedPlace("장소A", 20);
 		UUID firstMission = insertOxMission(place, "미션1", 100, true);
 		UUID secondMission = insertOxMission(place, "미션2", 100, true);
 
@@ -174,8 +174,8 @@ class MissionHeritageBadgeAwardIntegrationTests {
 	void revisitingSamePlaceInAnotherTripDoesNotIncreaseLifetimeCountButDifferentPlaceDoes() throws Exception {
 		UUID badgeId = insertBadge("문화탐방가", "문화재 2곳 방문");
 		insertCondition(badgeId, "HERITAGE_VISITED_COUNT", 2);
-		UUID placeA = insertProjectedPlace("장소A", 50);
-		UUID placeB = insertProjectedPlace("장소B", 60);
+		UUID placeA = insertProjectedPlace("장소A", 20);
+		UUID placeB = insertProjectedPlace("장소B", 15);
 
 		UUID firstTrip = startTrip(member.memberId());
 		UUID missionAtPlaceAFirst = insertOxMission(placeA, "미션A1", 100, true);
@@ -206,8 +206,8 @@ class MissionHeritageBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("탐험 마스터", "미션 2회 완료 및 문화재 2곳 방문");
 		insertCondition(badgeId, "MISSION_COMPLETED_COUNT", 2);
 		insertCondition(badgeId, "HERITAGE_VISITED_COUNT", 2);
-		UUID placeA = insertProjectedPlace("장소A", 50);
-		UUID placeB = insertProjectedPlace("장소B", 60);
+		UUID placeA = insertProjectedPlace("장소A", 20);
+		UUID placeB = insertProjectedPlace("장소B", 15);
 		UUID tripId = startTrip(member.memberId());
 		UUID missionA1 = insertOxMission(placeA, "미션A1", 100, true);
 		UUID missionA2 = insertOxMission(placeA, "미션A2", 100, true);
@@ -240,7 +240,7 @@ class MissionHeritageBadgeAwardIntegrationTests {
 		List<UUID> ascending = jdbcTemplate.queryForList("SELECT id FROM badges WHERE id IN (?, ?) ORDER BY id ASC",
 				UUID.class, missionBadgeId, heritageBadgeId);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소A", 50);
+		UUID place = insertProjectedPlace("장소A", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, true);
 
 		mockMvc.perform(submit(missionId, "both-badges", oxRequest(tripId, true))).andExpect(status().isOk())

--- a/src/test/java/com/buyeoon/mission/MissionPhotoBadgeAwardIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionPhotoBadgeAwardIntegrationTests.java
@@ -118,7 +118,7 @@ class MissionPhotoBadgeAwardIntegrationTests {
 	@DisplayName("인증 사진 15회 제출을 달성하면 '추억 수집가' 배지를 획득한다")
 	void fifteenthPhotoSubmissionAwardsMemoryCollectorBadge() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 
 		for (int i = 1; i < 15; i++) {
 			submitPhotoMission(tripId, place, i).andExpect(status().isOk())
@@ -141,7 +141,7 @@ class MissionPhotoBadgeAwardIntegrationTests {
 	@DisplayName("PHOTO가 아닌 제출은 인증 사진 집계에 포함되지 않는다")
 	void nonPhotoSubmissionsDoNotCountTowardPhotoMetric() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("퀴즈 장소", 50);
+		UUID place = insertProjectedPlace("퀴즈 장소", 20);
 
 		for (int i = 1; i <= 15; i++) {
 			UUID missionId = insertOxMission(place, "OX 미션 " + i, 10);

--- a/src/test/java/com/buyeoon/mission/MissionPhotoSubmissionIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionPhotoSubmissionIntegrationTests.java
@@ -116,7 +116,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("사진 미션 발급 요청은 201과 업로드 대상을 받고 mission_photos row를 만들지 않는다")
 	void issuesUploadUrlWithoutCreatingMissionPhotoRow() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 
 		mockMvc.perform(presignRequest(tripId, missionId, "issue-key")).andExpect(status().isCreated())
@@ -135,7 +135,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("PHOTO가 아닌 미션에 발급을 요청하면 400을 받는다")
 	void returns400WhenMissionIsNotPhotoType() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("OX 장소", 50);
+		UUID place = insertProjectedPlace("OX 장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(presignRequest(tripId, missionId, "not-photo-key")).andExpect(status().isBadRequest())
@@ -146,7 +146,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@Test
 	@DisplayName("본인 소유가 아니거나 존재하지 않는 여행으로 발급을 요청하면 404를 받는다")
 	void returns404WhenTripIsNotOwnedOrMissing() throws Exception {
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 
 		mockMvc.perform(presignRequest(UUID.randomUUID(), missionId, "missing-trip-key"))
@@ -157,7 +157,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@Test
 	@DisplayName("진행 중이 아닌 본인 여행으로 발급을 요청하면 409를 받는다")
 	void returns409WhenOwnTripIsNotInProgress() throws Exception {
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 		UUID endedTripId = UUID.randomUUID();
 		jdbcTemplate.update("INSERT INTO trips (id, member_id, status, ended_at) VALUES (?, ?, 'ENDED', now())",
@@ -172,7 +172,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("설정된 최대 크기를 초과하면 413을 받는다")
 	void returns413WhenFileSizeExceedsConfiguredMax() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 
 		mockMvc.perform(presignRequestBody(tripId, missionId, "too-large-key",
@@ -185,7 +185,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("발급 요청도 동일한 멱등성 키·본문 재요청은 최초 응답을 재사용한다")
 	void presignReplaysFirstResponseForSameIdempotentRequest() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 
 		String first = mockMvc.perform(presignRequest(tripId, missionId, "replay-key")).andExpect(status().isCreated())
@@ -201,8 +201,8 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("발급 요청도 멱등성 키를 다른 본문에 재사용하면 409를 받는다")
 	void presignReusedKeyWithDifferentBodyConflicts() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
-		UUID otherPlace = insertProjectedPlace("다른 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
+		UUID otherPlace = insertProjectedPlace("다른 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 		UUID otherMissionId = insertPhotoMission(otherPlace, "다른 사진 미션", 150);
 
@@ -226,7 +226,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("검증에 성공한 사진 제출은 완료 처리되고 보상·방문 기록을 받는다")
 	void verifiedPhotoSubmissionCompletesMissionAndGrantsRewardAndVisit() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 		UUID photoId = UUID.randomUUID();
 		stubMatchingPhoto(tripId, missionId, photoId, member.memberId(), "image/jpeg", 1024);
@@ -252,7 +252,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("존재하지 않는 photoId로 제출하면 404를 받는다")
 	void returns404WhenPhotoObjectDoesNotExist() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 		when(photoObjectStore.head(anyString())).thenReturn(Optional.empty());
 
@@ -268,7 +268,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("다른 회원의 photoId로 제출하면 404를 받는다")
 	void returns404WhenPhotoOwnedByAnotherMember() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 		UUID photoId = UUID.randomUUID();
 		stubMatchingPhoto(tripId, missionId, photoId, UUID.randomUUID(), "image/jpeg", 1024);
@@ -282,7 +282,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("실제 크기가 발급 요청과 다르면 400을 받고 상태를 바꾸지 않는다")
 	void returns400WhenFileSizeMismatches() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 		UUID photoId = UUID.randomUUID();
 		when(photoObjectStore.head(anyString())).thenReturn(
@@ -302,7 +302,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("Content-Type이 발급 요청과 다르면 400을 받는다")
 	void returns400WhenContentTypeMismatches() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 		UUID photoId = UUID.randomUUID();
 		when(photoObjectStore.head(anyString())).thenReturn(
@@ -317,7 +317,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("완료된 사진 미션에 재제출하면 409를 받는다")
 	void resubmittingCompletedPhotoMissionReturns409() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 		UUID photoId = UUID.randomUUID();
 		stubMatchingPhoto(tripId, missionId, photoId, member.memberId(), "image/jpeg", 1024);
@@ -327,12 +327,12 @@ class MissionPhotoSubmissionIntegrationTests {
 				.andExpect(status().isConflict()).andExpect(jsonPath("$.data.code").value("INVALID_STATE_TRANSITION"));
 	}
 
-	/** 반올림 전 실제 거리가 100m를 초과하면 403을 받고 상태를 바꾸지 않는다. */
+	/** 반올림 전 실제 거리가 30m를 초과하면 403을 받고 상태를 바꾸지 않는다. */
 	@Test
-	@DisplayName("100m를 초과한 사진 제출은 403을 받고 상태를 바꾸지 않는다")
+	@DisplayName("30m를 초과한 사진 제출은 403을 받고 상태를 바꾸지 않는다")
 	void returns403WhenBeyondParticipationRadius() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("먼 사진 장소", 100.1);
+		UUID place = insertProjectedPlace("먼 사진 장소", 30.1);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 		UUID photoId = UUID.randomUUID();
 		stubMatchingPhoto(tripId, missionId, photoId, member.memberId(), "image/jpeg", 1024);
@@ -350,7 +350,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("사진 제출도 동일한 멱등성 요청은 최초 응답을 재사용한다")
 	void sameIdempotentPhotoSubmissionReplaysFirstResponse() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("사진 장소", 50);
+		UUID place = insertProjectedPlace("사진 장소", 20);
 		UUID missionId = insertPhotoMission(place, "사진 미션", 150);
 		UUID photoId = UUID.randomUUID();
 		stubMatchingPhoto(tripId, missionId, photoId, member.memberId(), "image/jpeg", 1024);
@@ -371,7 +371,7 @@ class MissionPhotoSubmissionIntegrationTests {
 	@DisplayName("같은 문화재의 다른 사진 미션을 완료해도 방문 기록은 한 번만 생성된다")
 	void completingAnotherPhotoMissionForSamePlaceDoesNotDuplicateVisit() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("공통 장소", 50);
+		UUID place = insertProjectedPlace("공통 장소", 20);
 		UUID firstMission = insertPhotoMission(place, "사진 미션1", 100);
 		UUID secondMission = insertPhotoMission(place, "사진 미션2", 100);
 		UUID firstPhotoId = UUID.randomUUID();

--- a/src/test/java/com/buyeoon/mission/MissionQuizCorrectBadgeAwardIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionQuizCorrectBadgeAwardIntegrationTests.java
@@ -113,7 +113,7 @@ class MissionQuizCorrectBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("백제 박사", "public/badges/quiz-master.png", "퀴즈 15개 정답");
 		insertCondition(badgeId, "QUIZ_CORRECT_COUNT", 15);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 
 		for (int index = 1; index <= 14; index++) {
 			UUID missionId = insertOxMission(place, "OX 미션 " + index, 10, null, true);
@@ -139,7 +139,7 @@ class MissionQuizCorrectBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("백제 박사", null, "퀴즈 15개 정답");
 		insertCondition(badgeId, "QUIZ_CORRECT_COUNT", 15);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 
 		for (int index = 1; index <= 14; index++) {
 			UUID missionId = insertOxMission(place, "OX 미션 " + index, 10, null, true);

--- a/src/test/java/com/buyeoon/mission/MissionQuizStreakBadgeAwardIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionQuizStreakBadgeAwardIntegrationTests.java
@@ -112,7 +112,7 @@ class MissionQuizStreakBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("무결점", "퀴즈 5개 연속 정답");
 		insertCondition(badgeId, "QUIZ_CORRECT_STREAK", 5);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 
 		for (int i = 1; i <= 4; i++) {
 			UUID missionId = insertOxMission(place, "정답 미션 " + i, 100, true);
@@ -130,7 +130,7 @@ class MissionQuizStreakBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("무결점", "퀴즈 5개 연속 정답");
 		insertCondition(badgeId, "QUIZ_CORRECT_STREAK", 5);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 
 		// 정답 3회로 연속 3을 만든다.
 		for (int i = 1; i <= 3; i++) {

--- a/src/test/java/com/buyeoon/mission/MissionSubmissionIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionSubmissionIntegrationTests.java
@@ -107,7 +107,7 @@ class MissionSubmissionIntegrationTests {
 	@DisplayName("OX 미션에 정답을 제출하면 완료되고 보상·방문 기록을 받는다")
 	void correctOxSubmissionCompletesMissionAndGrantsRewardAndVisit() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("OX 장소", 50);
+		UUID place = insertProjectedPlace("OX 장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "submit-ox-correct", oxRequest(tripId, true))).andExpect(status().isOk())
@@ -141,7 +141,7 @@ class MissionSubmissionIntegrationTests {
 		UUID settledTripId = insertSettledTrip(member.memberId());
 		insertCarryOverSettlement(settledTripId, 200, Instant.now().minus(1, ChronoUnit.MINUTES));
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("만료 후 보상 장소", 50);
+		UUID place = insertProjectedPlace("만료 후 보상 장소", 20);
 		UUID missionId = insertOxMission(place, "만료 후 보상 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "expire-before-reward", oxRequest(tripId, true))).andExpect(status().isOk())
@@ -164,7 +164,7 @@ class MissionSubmissionIntegrationTests {
 		UUID settledTripId = insertSettledTrip(member.memberId());
 		insertCarryOverSettlement(settledTripId, 200, Instant.now().minus(1, ChronoUnit.MINUTES));
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("동시 만료 보상 장소", 50);
+		UUID place = insertProjectedPlace("동시 만료 보상 장소", 20);
 		UUID missionId = insertOxMission(place, "동시 만료 보상 미션", 100, null, true);
 		CountDownLatch ready = new CountDownLatch(2);
 		CountDownLatch start = new CountDownLatch(1);
@@ -215,7 +215,7 @@ class MissionSubmissionIntegrationTests {
 		UUID settledTripId = insertSettledTrip(member.memberId());
 		insertCarryOverSettlement(settledTripId, 200, Instant.now().minus(1, ChronoUnit.MINUTES));
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("먼 만료 보상 장소", 100.1);
+		UUID place = insertProjectedPlace("먼 만료 보상 장소", 30.1);
 		UUID missionId = insertOxMission(place, "실패하는 만료 보상 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "rollback-expiration", oxRequest(tripId, true)))
@@ -256,7 +256,7 @@ class MissionSubmissionIntegrationTests {
 	@DisplayName("객관식 미션에 정답을 제출하면 완료된다")
 	void correctMultipleChoiceSubmissionCompletesMission() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("객관식 장소", 50);
+		UUID place = insertProjectedPlace("객관식 장소", 20);
 		UUID missionId = insertMultipleChoiceMission(place, "객관식 미션", 100, null);
 		UUID correctChoice = insertChoice(missionId, "정답", true, 0);
 		insertChoice(missionId, "오답", false, 1);
@@ -271,7 +271,7 @@ class MissionSubmissionIntegrationTests {
 	@DisplayName("일반 퀴즈 오답은 AVAILABLE을 유지하고 재도전할 수 있다")
 	void incorrectAnswerToNormalQuizKeepsAvailableAndAllowsRetry() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("OX 장소", 50);
+		UUID place = insertProjectedPlace("OX 장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "submit-ox-wrong", oxRequest(tripId, false))).andExpect(status().isOk())
@@ -292,7 +292,7 @@ class MissionSubmissionIntegrationTests {
 	@DisplayName("스페셜 퀴즈는 기회를 모두 소진하면 EXHAUSTED로 전이하고 재제출은 409를 받는다")
 	void specialQuizExhaustsAttemptsAndRejectsFurtherSubmissions() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("스페셜 장소", 50);
+		UUID place = insertProjectedPlace("스페셜 장소", 20);
 		UUID missionId = insertOxMission(place, "스페셜 퀴즈", 100, 2, true);
 
 		mockMvc.perform(submit(missionId, "special-attempt-1", oxRequest(tripId, false))).andExpect(status().isOk())
@@ -316,7 +316,7 @@ class MissionSubmissionIntegrationTests {
 	@DisplayName("완료된 미션에 재제출하면 409를 받는다")
 	void resubmittingCompletedMissionReturns409() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("OX 장소", 50);
+		UUID place = insertProjectedPlace("OX 장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 		mockMvc.perform(submit(missionId, "first-complete", oxRequest(tripId, true))).andExpect(status().isOk());
 
@@ -329,7 +329,7 @@ class MissionSubmissionIntegrationTests {
 	@DisplayName("같은 문화재의 다른 미션을 완료해도 방문 기록은 한 번만 생성된다")
 	void completingAnotherMissionForSamePlaceDoesNotDuplicateVisit() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("공통 장소", 50);
+		UUID place = insertProjectedPlace("공통 장소", 20);
 		UUID firstMission = insertOxMission(place, "미션1", 100, null, true);
 		UUID secondMission = insertOxMission(place, "미션2", 100, null, true);
 
@@ -344,12 +344,12 @@ class MissionSubmissionIntegrationTests {
 				Integer.class, tripId, place)).isEqualTo(1);
 	}
 
-	/** 반올림 전 실제 거리가 100m를 초과하면 403을 받고 어떤 상태도 바뀌지 않는다. */
+	/** 반올림 전 실제 거리가 30m를 초과하면 403을 받고 어떤 상태도 바뀌지 않는다. */
 	@Test
-	@DisplayName("100m를 초과하면 403을 받고 상태를 바꾸지 않는다")
+	@DisplayName("30m를 초과하면 403을 받고 상태를 바꾸지 않는다")
 	void returns403WhenBeyondParticipationRadiusAndChangesNothing() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("먼 장소", 100.1);
+		UUID place = insertProjectedPlace("먼 장소", 30.1);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "too-far-key", oxRequest(tripId, true))).andExpect(status().isForbidden())
@@ -361,12 +361,12 @@ class MissionSubmissionIntegrationTests {
 				Integer.class, member.memberId())).isZero();
 	}
 
-	/** 100m 경계는 참여를 허용한다. */
+	/** 30m 경계는 참여를 허용한다. */
 	@Test
-	@DisplayName("100m 경계는 참여를 허용한다")
+	@DisplayName("30m 경계는 참여를 허용한다")
 	void allowsSubmissionExactlyAtParticipationBoundary() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("경계 장소", 100.0);
+		UUID place = insertProjectedPlace("경계 장소", 30.0);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "boundary", oxRequest(tripId, true))).andExpect(status().isOk())
@@ -377,7 +377,7 @@ class MissionSubmissionIntegrationTests {
 	@Test
 	@DisplayName("본인 소유가 아니거나 존재하지 않는 여행은 404를 받는다")
 	void returns404WhenTripIsNotOwnedOrMissing() throws Exception {
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 
 		mockMvc.perform(submit(missionId, "missing-trip", oxRequest(UUID.randomUUID(), true)))
@@ -388,7 +388,7 @@ class MissionSubmissionIntegrationTests {
 	@Test
 	@DisplayName("진행 중이 아닌 본인 여행은 409를 받는다")
 	void returns409WhenOwnTripIsNotInProgress() throws Exception {
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 		UUID endedTripId = UUID.randomUUID();
 		jdbcTemplate.update("INSERT INTO trips (id, member_id, status, ended_at) VALUES (?, ?, 'ENDED', now())",
@@ -413,7 +413,7 @@ class MissionSubmissionIntegrationTests {
 	@DisplayName("동일한 멱등성 요청은 최초 응답을 재사용하고 부작용을 반복하지 않는다")
 	void sameIdempotentRequestReplaysFirstResponseWithoutSideEffects() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("OX 장소", 50);
+		UUID place = insertProjectedPlace("OX 장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 		String key = "retry-submit-key";
 		String body = oxRequest(tripId, true);
@@ -436,7 +436,7 @@ class MissionSubmissionIntegrationTests {
 	@DisplayName("멱등성 키를 다른 본문에 재사용하면 409를 받는다")
 	void reusedKeyWithDifferentBodyConflicts() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("OX 장소", 50);
+		UUID place = insertProjectedPlace("OX 장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 		String key = "conflict-submit-key";
 
@@ -450,7 +450,7 @@ class MissionSubmissionIntegrationTests {
 	@DisplayName("동시 완료 요청은 완료·보상·방문 기록을 한 번만 확정한다")
 	void concurrentSubmissionsCompleteMissionExactlyOnce() throws Exception {
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("동시성 장소", 50);
+		UUID place = insertProjectedPlace("동시성 장소", 20);
 		UUID missionId = insertOxMission(place, "OX 미션", 100, null, true);
 		CountDownLatch ready = new CountDownLatch(2);
 		CountDownLatch start = new CountDownLatch(1);

--- a/src/test/java/com/buyeoon/mission/QuizFocusBadgeAwardIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/QuizFocusBadgeAwardIntegrationTests.java
@@ -113,7 +113,7 @@ class QuizFocusBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("집중력", "60분 내에 퀴즈 10개 정답");
 		insertCondition(badgeId, 10);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 
 		Instant base = Instant.now().minus(50, ChronoUnit.MINUTES);
 		for (int i = 0; i < 9; i++) {
@@ -136,7 +136,7 @@ class QuizFocusBadgeAwardIntegrationTests {
 		UUID badgeId = insertBadge("집중력", "60분 내에 퀴즈 10개 정답");
 		insertCondition(badgeId, 10);
 		UUID tripId = startTrip(member.memberId());
-		UUID place = insertProjectedPlace("장소", 50);
+		UUID place = insertProjectedPlace("장소", 20);
 
 		// 정답 9개를 서로 2시간씩 떨어뜨려 배치하면, 어떤 60분 구간에도 최대 1개의 과거 정답만 들어간다.
 		Instant base = Instant.now().minus(20, ChronoUnit.HOURS);
@@ -221,11 +221,9 @@ class QuizFocusBadgeAwardIntegrationTests {
 
 	private UUID insertOxMission(UUID placeId, String title, boolean correctAnswer) {
 		UUID id = UUID.randomUUID();
-		jdbcTemplate.update(
-				"INSERT INTO missions (id, place_id, location, type, title, description, reward_points, "
-						+ "ox_correct_answer) VALUES (?, ?, (SELECT location FROM places WHERE id = ?), "
-						+ "'OX'::mission_type, ?, '설명', 10, ?)",
-				id, placeId, placeId, title, correctAnswer);
+		jdbcTemplate.update("INSERT INTO missions (id, place_id, location, type, title, description, reward_points, "
+				+ "ox_correct_answer) VALUES (?, ?, (SELECT location FROM places WHERE id = ?), "
+				+ "'OX'::mission_type, ?, '설명', 10, ?)", id, placeId, placeId, title, correctAnswer);
 		return id;
 	}
 


### PR DESCRIPTION
## Summary
- 퀴즈·사진 인증 미션의 참여 반경을 100m에서 30m로 바꿔 목록 `AVAILABLE`/`LOCKED`, 상세 공개, 제출 가드를 같은 기준으로 맞춘다.
- 주변 미션 탐색 반경 500m는 유지한다.
- 통합 테스트 경계를 30.0/30.1로 옮기고, 참여 가능 픽스처를 30m 안으로 내린다.

Closes #248

## Test plan
- [x] `GET /missions/nearby`에서 29.9·30.0m는 `AVAILABLE`, 30.1·50m는 `LOCKED`인지 확인한다.
- [x] 목록·상세의 `participationRadiusMeters`가 30인지 확인한다.
- [x] 30m 이내 상세는 문제·선택지·촬영 안내를 주고, 밖은 제한 상세인지 확인한다.
- [x] OX·객관식·사진 제출이 30.0m에서 성공하고 30.1m에서 `403 LOCATION_VERIFICATION_FAILED`인지 확인한다.
- [x] 500m 경계 목록 포함/제외가 그대로인지 확인한다.