### PR TITLE
feat: 스페셜 퀴즈 근접 알림을 추가한다

### DIFF
--- a/docs/domains/mission/api.md
+++ b/docs/domains/mission/api.md
@@ -5,6 +5,7 @@ API 계약의 원본은 [`docs/raw/openapi.yaml`](../../raw/openapi.yaml)이다.
 | Operation ID | Method | Path |
 | --- | --- | --- |
 | `getNearbyMissions` | GET | `/missions/nearby` |
+| `getTodaySpecialQuizzes` | GET | `/missions/special-quizzes` |
 | `getMission` | GET | `/missions/{missionId}` |
 | `createMissionPhotoUploadUrl` | POST | `/mission-photos/presigned-url` |
 | `submitMission` | POST | `/missions/{missionId}/submissions` |

--- a/docs/domains/notification/api.md
+++ b/docs/domains/notification/api.md
@@ -8,5 +8,6 @@ API 계약의 원본은 [`docs/raw/openapi.yaml`](../../raw/openapi.yaml)이다.
 | `readNotification` | PATCH | `/members/me/notifications/{notificationId}` |
 | `notifyBuyeoEntry` | POST | `/notifications/buyeo-entry-events` |
 | `notifyBuyeoExit` | POST | `/notifications/buyeo-exit-events` |
+| `notifySpecialQuizNearby` | POST | `/notifications/missions/{missionId}/nearby-events` |
 
 알림 동의(근처 퀴즈 알림 설정에서 유래한 단일 필드)는 회원 설정과 인증 세션의 푸시 토큰 API를 함께 사용한다. 해당 operation은 [회원 API](../member/api.md)가 소유한다.

--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -581,6 +581,34 @@ paths:
           $ref: '#/components/responses/TripResourceNotFound'
         '409':
           $ref: '#/components/responses/TripNotInProgress'
+  /missions/special-quizzes:
+    get:
+      tags: [Missions]
+      summary: 오늘의 스페셜 퀴즈 지오펜스 좌표 목록 조회
+      description: |
+        클라이언트가 지오펜스를 등록할 수 있도록 500m 반경 제한 없이 오늘 노출된 스페셜 퀴즈의 좌표를 반환한다.
+        최대 도전 횟수가 없는 일반 미션과 오늘 노출 대상이 아닌 스페셜 퀴즈, 이미 완료·소진해 더 알릴 필요가
+        없는 스페셜 퀴즈는 제외한다.
+      operationId: getTodaySpecialQuizzes
+      parameters:
+        - name: tripId
+          in: query
+          required: true
+          description: 현재 회원이 소유한 진행 중 여행 ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          $ref: '#/components/responses/SpecialQuizGeofenceListSuccess'
+        '400':
+          $ref: '#/components/responses/InvalidRequest'
+        '401':
+          $ref: '#/components/responses/AuthenticationRequired'
+        '404':
+          $ref: '#/components/responses/TripResourceNotFound'
+        '409':
+          $ref: '#/components/responses/TripNotInProgress'
   /missions/{missionId}:
     get:
       tags: [Missions]
@@ -778,6 +806,36 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /notifications/missions/{missionId}/nearby-events:
+    post:
+      tags: [Notifications]
+      summary: 스페셜 퀴즈 근접 알림 이벤트
+      description: |
+        클라이언트가 오늘 노출된 스페셜 퀴즈를 지오펜스로 등록해두었다가 참여 반경(30m) 진입을 감지하면 호출한다.
+        서버는 요청 회원이 소유한 진행 중 여행인지, 오늘 이 회원에게 노출된 스페셜 퀴즈인지, 아직 참여하지
+        않았는지, 좌표가 참여 반경 이내인지, 같은 미션에 대한 쿨다운(12시간)이 지났는지를 모두 재검증한 뒤에만
+        NEARBY_QUIZ 알림을 생성하고 FCM push를 발송한다.
+      operationId: notifySpecialQuizNearby
+      parameters:
+        - $ref: '#/components/parameters/MissionId'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SpecialQuizNearbyEventRequest'
+      responses:
+        '200':
+          $ref: '#/components/responses/SpecialQuizNearbyEventSuccess'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/ResourceNotFound'
+        '409':
+          $ref: '#/components/responses/TripNotInProgress'
   /members/me/notifications:
     get:
       tags: [Notifications]
@@ -1558,6 +1616,29 @@ components:
             success: true
             data:
               notificationSent: true
+    SpecialQuizNearbyEventSuccess:
+      description: 스페셜 퀴즈 근접 알림 이벤트 처리 결과
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SpecialQuizNearbyEventEnvelope'
+          example:
+            success: true
+            data:
+              notificationSent: true
+    SpecialQuizGeofenceListSuccess:
+      description: 오늘의 스페셜 퀴즈 지오펜스 좌표 목록
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/SpecialQuizGeofenceListEnvelope'
+          example:
+            success: true
+            data:
+              items:
+                - missionId: 550e8400-e29b-41d4-a716-446655440000
+                  latitude: 36.2851
+                  longitude: 126.9103
     EmptySuccess:
       description: 처리 성공
       content:
@@ -2151,6 +2232,15 @@ components:
       type: object
       required: [location]
       properties:
+        location:
+          $ref: '#/components/schemas/Location'
+    SpecialQuizNearbyEventRequest:
+      type: object
+      required: [tripId, location]
+      properties:
+        tripId:
+          type: string
+          format: uuid
         location:
           $ref: '#/components/schemas/Location'
     Trip:
@@ -3198,6 +3288,47 @@ components:
       properties:
         notificationSent:
           type: boolean
+    SpecialQuizNearbyEventEnvelope:
+      allOf:
+        - $ref: '#/components/schemas/SuccessEnvelope'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/SpecialQuizNearbyEventResult'
+    SpecialQuizNearbyEventResult:
+      type: object
+      required: [notificationSent]
+      properties:
+        notificationSent:
+          type: boolean
+    SpecialQuizGeofenceListEnvelope:
+      allOf:
+        - $ref: '#/components/schemas/SuccessEnvelope'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/SpecialQuizGeofenceListData'
+    SpecialQuizGeofenceListData:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SpecialQuizGeofence'
+    SpecialQuizGeofence:
+      type: object
+      required: [missionId, latitude, longitude]
+      properties:
+        missionId:
+          type: string
+          format: uuid
+        latitude:
+          type: number
+          format: double
+        longitude:
+          type: number
+          format: double
     EmptyEnvelope:
       allOf:
         - $ref: '#/components/schemas/SuccessEnvelope'

--- a/src/main/java/com/buyeoon/common/location/ParticipationRadiusPolicy.java
+++ b/src/main/java/com/buyeoon/common/location/ParticipationRadiusPolicy.java
@@ -1,0 +1,11 @@
+package com.buyeoon.common.location;
+
+/** 미션 참여·근접 알림에 공통으로 쓰는 위치 인증 반경 정책이다. */
+public final class ParticipationRadiusPolicy {
+
+	/** 미션 참여와 스페셜 퀴즈 근접 알림을 허용하는 고정 반경(m). 경계를 포함한다. */
+	public static final int PARTICIPATION_RADIUS_METERS = 30;
+
+	private ParticipationRadiusPolicy() {
+	}
+}

--- a/src/main/java/com/buyeoon/mission/api/MissionController.java
+++ b/src/main/java/com/buyeoon/mission/api/MissionController.java
@@ -6,6 +6,7 @@ import com.buyeoon.mission.application.MissionPhotoUploadUrlService.MissionPhoto
 import com.buyeoon.mission.application.MissionPhotoUploadUrlService.MissionPhotoUploadUrlView;
 import com.buyeoon.mission.application.MissionQueryService;
 import com.buyeoon.mission.application.MissionQueryService.MissionListView;
+import com.buyeoon.mission.application.MissionQueryService.SpecialQuizGeofenceListView;
 import com.buyeoon.mission.application.MissionSubmissionService;
 import com.buyeoon.mission.application.MissionSubmissionService.LocationCommand;
 import com.buyeoon.mission.application.MissionSubmissionService.MissionSubmissionCommand;
@@ -53,6 +54,14 @@ public class MissionController {
 		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
 		return SuccessResponse
 				.of(missionQueryService.listNearby(memberId, tripId, latitude(latitude), longitude(longitude)));
+	}
+
+	/** 클라이언트가 지오펜스를 등록할 오늘의 스페셜 퀴즈 좌표 목록을 500m 반경 제한 없이 조회한다. */
+	@GetMapping("/missions/special-quizzes")
+	public SuccessResponse<SpecialQuizGeofenceListView> getTodaySpecialQuizzes(@AuthenticationPrincipal Jwt jwt,
+			@RequestParam UUID tripId) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		return SuccessResponse.of(missionQueryService.listTodaySpecialQuizzes(memberId, tripId));
 	}
 
 	@GetMapping("/missions/{missionId}")

--- a/src/main/java/com/buyeoon/mission/application/MissionQueryService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionQueryService.java
@@ -9,6 +9,7 @@ import com.buyeoon.mission.entity.MissionType;
 import com.buyeoon.mission.repository.MissionChoiceRepository;
 import com.buyeoon.mission.repository.MissionQueryRepository;
 import com.buyeoon.mission.repository.NearbyMissionProjection;
+import com.buyeoon.mission.repository.SpecialQuizGeofenceProjection;
 import com.buyeoon.place.entity.PlaceEntity;
 import com.buyeoon.trip.TripQueryService;
 import com.buyeoon.trip.entity.TripStatus;
@@ -69,6 +70,37 @@ public class MissionQueryService {
 			return toMultipleChoiceDetailView(tripId, common, choices);
 		}
 		return toDetailView(tripId, common);
+	}
+
+	/**
+	 * 클라이언트가 지오펜스를 등록할 스페셜 퀴즈 좌표 목록을 조회한다. 500m 반경 제한 없이 오늘 노출된 스페셜 퀴즈 전체를
+	 * 대상으로 하며, 이미 완료·소진해 더 알릴 필요가 없는 퀴즈는 제외한다.
+	 */
+	public SpecialQuizGeofenceListView listTodaySpecialQuizzes(UUID memberId, UUID tripId) {
+		TripStatus status = tripQueryService.findOwnedTripStatus(memberId, tripId)
+				.orElseThrow(TripNotFoundException::new);
+		if (status != TripStatus.IN_PROGRESS) {
+			throw new TripNotInProgressException();
+		}
+
+		List<SpecialQuizGeofenceView> items = missionQueryRepository.findSpecialQuizzes(tripId).stream()
+				.filter(row -> isChallengeableToday(tripId, row)).map(this::toGeofenceView).toList();
+		return new SpecialQuizGeofenceListView(items);
+	}
+
+	/** 아직 도전 가능한 상태이면서 오늘 노출 대상인 스페셜 퀴즈만 지오펜스 등록 대상으로 남긴다. */
+	private boolean isChallengeableToday(UUID tripId, SpecialQuizGeofenceProjection row) {
+		MissionParticipationEntity participation = row.participation();
+		MissionStatus persistedStatus = participation == null ? MissionStatus.AVAILABLE : participation.getStatus();
+		if (persistedStatus != MissionStatus.AVAILABLE) {
+			return false;
+		}
+		return specialQuizExposureDecider.isExposedToday(tripId, row.mission().getId());
+	}
+
+	private SpecialQuizGeofenceView toGeofenceView(SpecialQuizGeofenceProjection row) {
+		MissionEntity mission = row.mission();
+		return new SpecialQuizGeofenceView(mission.getId(), mission.getLocation().getY(), mission.getLocation().getX());
 	}
 
 	/**
@@ -193,6 +225,16 @@ public class MissionQueryService {
 	/** {@link #checkSpecialQuizNearby}의 검증 결과다. */
 	public record SpecialQuizNearbyCheck(boolean specialQuiz, boolean exposedToday, boolean alreadyParticipated,
 			boolean withinParticipationRadius) {
+	}
+
+	/** {@link #listTodaySpecialQuizzes}의 지오펜스 등록용 최소 응답이다. */
+	public record SpecialQuizGeofenceListView(List<SpecialQuizGeofenceView> items) {
+		public SpecialQuizGeofenceListView {
+			items = List.copyOf(items);
+		}
+	}
+
+	public record SpecialQuizGeofenceView(UUID missionId, double latitude, double longitude) {
 	}
 
 	public record MissionListView(List<MissionItemView> items) {

--- a/src/main/java/com/buyeoon/mission/application/MissionQueryService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionQueryService.java
@@ -1,5 +1,6 @@
 package com.buyeoon.mission.application;
 
+import com.buyeoon.common.location.ParticipationRadiusPolicy;
 import com.buyeoon.mission.entity.MissionChoiceEntity;
 import com.buyeoon.mission.entity.MissionEntity;
 import com.buyeoon.mission.entity.MissionParticipationEntity;
@@ -20,9 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 public class MissionQueryService {
-
-	/** 미션 참여를 허용하는 고정 반경(m). 경계를 포함하며 위치 인증 정책과 같다. */
-	private static final int PARTICIPATION_RADIUS_METERS = 30;
 
 	private final MissionQueryRepository missionQueryRepository;
 	private final MissionChoiceRepository missionChoiceRepository;
@@ -73,14 +71,42 @@ public class MissionQueryService {
 		return toDetailView(tripId, common);
 	}
 
+	/**
+	 * notification 도메인이 스페셜 퀴즈 근접 알림을 검증할 때 사용하는 공개 seam이다. 여행 소유·진행 중 여부를 먼저 확인한
+	 * 뒤, 오늘 이 회원에게 노출된 스페셜 퀴즈인지·이미 참여했는지·참여 반경 이내인지를 함께 판정한다.
+	 */
+	public SpecialQuizNearbyCheck checkSpecialQuizNearby(UUID memberId, UUID tripId, UUID missionId, double latitude,
+			double longitude) {
+		TripStatus status = tripQueryService.findOwnedTripStatus(memberId, tripId)
+				.orElseThrow(TripNotFoundException::new);
+		if (status != TripStatus.IN_PROGRESS) {
+			throw new TripNotInProgressException();
+		}
+
+		NearbyMissionProjection row = missionQueryRepository.findDetail(missionId, tripId, latitude, longitude)
+				.orElseThrow(MissionNotFoundException::new);
+		MissionEntity mission = row.mission();
+		boolean specialQuiz = mission.getMaxAttempts() != null;
+		boolean exposedToday = specialQuiz && specialQuizExposureDecider.isExposedToday(tripId, missionId);
+
+		MissionParticipationEntity participation = row.participation();
+		MissionStatus persistedStatus = participation == null ? MissionStatus.AVAILABLE : participation.getStatus();
+		boolean alreadyParticipated = persistedStatus != MissionStatus.AVAILABLE;
+
+		boolean withinParticipationRadius = row
+				.distanceMeters() <= ParticipationRadiusPolicy.PARTICIPATION_RADIUS_METERS;
+
+		return new SpecialQuizNearbyCheck(specialQuiz, exposedToday, alreadyParticipated, withinParticipationRadius);
+	}
+
 	private MissionItemView toView(UUID tripId, NearbyMissionProjection row) {
 		MissionCommon common = computeCommon(row);
 		MissionEntity mission = common.mission();
 		PlaceEntity place = common.place();
 		return new MissionItemView(mission.getId(), tripId, place.getId(), place.getName(),
 				mission.getLocation().getY(), mission.getLocation().getX(), common.distanceMeters(), mission.getType(),
-				mission.getTitle(), mission.getRewardPoints(), common.availability(), PARTICIPATION_RADIUS_METERS,
-				common.remainingAttempts());
+				mission.getTitle(), mission.getRewardPoints(), common.availability(),
+				ParticipationRadiusPolicy.PARTICIPATION_RADIUS_METERS, common.remainingAttempts());
 	}
 
 	private MissionRestrictedView toRestrictedView(UUID tripId, MissionCommon common) {
@@ -88,8 +114,8 @@ public class MissionQueryService {
 		PlaceEntity place = common.place();
 		return new MissionRestrictedView(mission.getId(), tripId, place.getId(), place.getName(),
 				mission.getLocation().getY(), mission.getLocation().getX(), common.distanceMeters(), mission.getType(),
-				mission.getTitle(), mission.getRewardPoints(), common.availability(), PARTICIPATION_RADIUS_METERS,
-				common.remainingAttempts());
+				mission.getTitle(), mission.getRewardPoints(), common.availability(),
+				ParticipationRadiusPolicy.PARTICIPATION_RADIUS_METERS, common.remainingAttempts());
 	}
 
 	private MissionDetailView toDetailView(UUID tripId, MissionCommon common) {
@@ -97,8 +123,9 @@ public class MissionQueryService {
 		PlaceEntity place = common.place();
 		return new MissionDetailView(mission.getId(), tripId, place.getId(), place.getName(),
 				mission.getLocation().getY(), mission.getLocation().getX(), common.distanceMeters(), mission.getType(),
-				mission.getTitle(), mission.getRewardPoints(), common.availability(), PARTICIPATION_RADIUS_METERS,
-				common.remainingAttempts(), mission.getDescription());
+				mission.getTitle(), mission.getRewardPoints(), common.availability(),
+				ParticipationRadiusPolicy.PARTICIPATION_RADIUS_METERS, common.remainingAttempts(),
+				mission.getDescription());
 	}
 
 	private MissionMultipleChoiceDetailView toMultipleChoiceDetailView(UUID tripId, MissionCommon common,
@@ -107,8 +134,9 @@ public class MissionQueryService {
 		PlaceEntity place = common.place();
 		return new MissionMultipleChoiceDetailView(mission.getId(), tripId, place.getId(), place.getName(),
 				mission.getLocation().getY(), mission.getLocation().getX(), common.distanceMeters(), mission.getType(),
-				mission.getTitle(), mission.getRewardPoints(), common.availability(), PARTICIPATION_RADIUS_METERS,
-				common.remainingAttempts(), mission.getDescription(), choices);
+				mission.getTitle(), mission.getRewardPoints(), common.availability(),
+				ParticipationRadiusPolicy.PARTICIPATION_RADIUS_METERS, common.remainingAttempts(),
+				mission.getDescription(), choices);
 	}
 
 	private MissionChoiceView toChoiceView(MissionChoiceEntity choice) {
@@ -139,7 +167,7 @@ public class MissionQueryService {
 
 		MissionStatus persistedStatus = participation == null ? MissionStatus.AVAILABLE : participation.getStatus();
 		int attemptCount = participation == null ? 0 : participation.getAttemptCount();
-		boolean withinParticipationRadius = row.distanceMeters() <= PARTICIPATION_RADIUS_METERS;
+		boolean withinParticipationRadius = row.distanceMeters() <= ParticipationRadiusPolicy.PARTICIPATION_RADIUS_METERS;
 
 		MissionAvailability availability = switch (persistedStatus) {
 			case COMPLETED -> MissionAvailability.COMPLETED;
@@ -160,6 +188,11 @@ public class MissionQueryService {
 
 	private record MissionCommon(MissionEntity mission, PlaceEntity place, int distanceMeters,
 			MissionAvailability availability, Integer remainingAttempts, boolean withinParticipationRadius) {
+	}
+
+	/** {@link #checkSpecialQuizNearby}의 검증 결과다. */
+	public record SpecialQuizNearbyCheck(boolean specialQuiz, boolean exposedToday, boolean alreadyParticipated,
+			boolean withinParticipationRadius) {
 	}
 
 	public record MissionListView(List<MissionItemView> items) {

--- a/src/main/java/com/buyeoon/mission/application/MissionSubmissionService.java
+++ b/src/main/java/com/buyeoon/mission/application/MissionSubmissionService.java
@@ -6,6 +6,7 @@ import com.buyeoon.badge.BadgeMetric;
 import com.buyeoon.common.api.SuccessResponse;
 import com.buyeoon.common.entity.IdempotencyRequestEntity;
 import com.buyeoon.common.entity.IdempotencyRequestId;
+import com.buyeoon.common.location.ParticipationRadiusPolicy;
 import com.buyeoon.common.storage.MissionPhotoObjectStore;
 import com.buyeoon.common.storage.MissionPhotoObjectStore.MissionPhotoObject;
 import com.buyeoon.common.storage.PublicImageUrlService;
@@ -65,8 +66,6 @@ public class MissionSubmissionService {
 
 	private static final String OPERATION = "SUBMIT_MISSION";
 	private static final Duration RETENTION = Duration.ofHours(24);
-	/** 미션 참여를 허용하는 고정 반경(m). 경계를 포함하며 위치 인증 정책과 같다. */
-	private static final int PARTICIPATION_RADIUS_METERS = 30;
 	private static final Set<String> ALLOWED_PHOTO_CONTENT_TYPES = Set.of("image/jpeg", "image/png", "image/webp");
 
 	private final JdbcOperations jdbcOperations;
@@ -163,7 +162,7 @@ public class MissionSubmissionService {
 		if (participation.getStatus() != MissionStatus.AVAILABLE) {
 			throw new InvalidStateTransitionException();
 		}
-		if (detail.distanceMeters() > PARTICIPATION_RADIUS_METERS) {
+		if (detail.distanceMeters() > ParticipationRadiusPolicy.PARTICIPATION_RADIUS_METERS) {
 			throw new OutsideParticipationRadiusException();
 		}
 

--- a/src/main/java/com/buyeoon/mission/repository/MissionQueryRepository.java
+++ b/src/main/java/com/buyeoon/mission/repository/MissionQueryRepository.java
@@ -63,6 +63,20 @@ public interface MissionQueryRepository extends JpaRepository<MissionEntity, UUI
 	Optional<MissionPlaceDistanceProjection> findWithDistance(@Param("missionId") UUID missionId,
 			@Param("latitude") double latitude, @Param("longitude") double longitude);
 
+	/** 500m 반경 제한 없이 스페셜 퀴즈 지오펜스 등록에 필요한 미션·참여 상태만 조회한다. 거리 계산은 필요 없다. */
+	@Query("""
+			SELECT new com.buyeoon.mission.repository.SpecialQuizGeofenceProjection(m, participation)
+			FROM MissionEntity m
+			JOIN PlaceEntity p ON p.id = m.placeId
+			LEFT JOIN MissionParticipationEntity participation
+			    ON participation.missionId = m.id AND participation.tripId = :tripId
+			WHERE m.deletedAt IS NULL
+			  AND p.deletedAt IS NULL
+			  AND m.maxAttempts IS NOT NULL
+			ORDER BY m.id ASC
+			""")
+	List<SpecialQuizGeofenceProjection> findSpecialQuizzes(@Param("tripId") UUID tripId);
+
 	Page<MissionEntity> findByPlaceId(UUID placeId, Pageable pageable);
 
 	List<MissionEntity> findByPlaceIdAndDeletedAtIsNull(UUID placeId);

--- a/src/main/java/com/buyeoon/mission/repository/SpecialQuizGeofenceProjection.java
+++ b/src/main/java/com/buyeoon/mission/repository/SpecialQuizGeofenceProjection.java
@@ -1,0 +1,7 @@
+package com.buyeoon.mission.repository;
+
+import com.buyeoon.mission.entity.MissionEntity;
+import com.buyeoon.mission.entity.MissionParticipationEntity;
+
+public record SpecialQuizGeofenceProjection(MissionEntity mission, MissionParticipationEntity participation) {
+}

--- a/src/main/java/com/buyeoon/notification/NotificationCreationService.java
+++ b/src/main/java/com/buyeoon/notification/NotificationCreationService.java
@@ -57,4 +57,17 @@ public class NotificationCreationService {
 		pushNotificationPublisher.publish(memberId, NotificationType.BUYEO_EXIT, title, body, notification.getId(),
 				null, null);
 	}
+
+	/**
+	 * 스페셜 퀴즈 근접 알림 검증을 모두 통과했을 때 {@code NEARBY_QUIZ} 알림을 생성하고 즉시 FCM push도 발송한다.
+	 * 제목·본문은 임시 문구이며 별도 Design 이슈에서 확정한다.
+	 */
+	public void createNearbyQuiz(UUID memberId, UUID missionId) {
+		String title = "근처에 스페셜 퀴즈가 있어요!";
+		String body = "지금 도전하면 특별한 보상을 받을 수 있어요.";
+		NotificationEntity notification = notifications.save(
+				NotificationEntity.create(memberId, NotificationType.NEARBY_QUIZ, title, body, "MISSION", missionId));
+		pushNotificationPublisher.publish(memberId, NotificationType.NEARBY_QUIZ, title, body, notification.getId(),
+				"MISSION", missionId);
+	}
 }

--- a/src/main/java/com/buyeoon/notification/api/NotificationExceptionHandler.java
+++ b/src/main/java/com/buyeoon/notification/api/NotificationExceptionHandler.java
@@ -2,6 +2,9 @@ package com.buyeoon.notification.api;
 
 import com.buyeoon.common.api.ErrorResponse;
 import com.buyeoon.member.application.IdempotencyKeyReusedException;
+import com.buyeoon.mission.application.MissionNotFoundException;
+import com.buyeoon.mission.application.TripNotFoundException;
+import com.buyeoon.mission.application.TripNotInProgressException;
 import com.buyeoon.notification.application.NotificationNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -10,7 +13,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice(assignableTypes = {NotificationController.class, BuyeoEntryEventController.class,
-		BuyeoExitEventController.class})
+		BuyeoExitEventController.class, SpecialQuizNearbyEventController.class})
 public class NotificationExceptionHandler {
 
 	@ExceptionHandler({InvalidNotificationRequestException.class, HttpMessageNotReadableException.class})
@@ -19,10 +22,17 @@ public class NotificationExceptionHandler {
 		return ErrorResponse.invalidRequest();
 	}
 
-	@ExceptionHandler(NotificationNotFoundException.class)
+	@ExceptionHandler({NotificationNotFoundException.class, TripNotFoundException.class,
+			MissionNotFoundException.class})
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	public ErrorResponse handleNotFound() {
 		return ErrorResponse.resourceNotFound();
+	}
+
+	@ExceptionHandler(TripNotInProgressException.class)
+	@ResponseStatus(HttpStatus.CONFLICT)
+	public ErrorResponse handleTripNotInProgress() {
+		return ErrorResponse.tripNotInProgress();
 	}
 
 	@ExceptionHandler(IdempotencyKeyReusedException.class)

--- a/src/main/java/com/buyeoon/notification/api/SpecialQuizNearbyEventController.java
+++ b/src/main/java/com/buyeoon/notification/api/SpecialQuizNearbyEventController.java
@@ -1,0 +1,113 @@
+package com.buyeoon.notification.api;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.notification.application.SpecialQuizNearbyEventService;
+import com.buyeoon.notification.application.SpecialQuizNearbyEventService.LocationCommand;
+import com.buyeoon.notification.application.SpecialQuizNearbyEventService.SpecialQuizNearbyEventCommand;
+import com.buyeoon.notification.application.SpecialQuizNearbyEventService.SpecialQuizNearbyEventView;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import tools.jackson.databind.JsonNode;
+
+@RestController
+public class SpecialQuizNearbyEventController {
+
+	private final SpecialQuizNearbyEventService specialQuizNearbyEventService;
+
+	public SpecialQuizNearbyEventController(SpecialQuizNearbyEventService specialQuizNearbyEventService) {
+		this.specialQuizNearbyEventService = specialQuizNearbyEventService;
+	}
+
+	@PostMapping("/notifications/missions/{missionId}/nearby-events")
+	public SuccessResponse<SpecialQuizNearbyEventView> notify(@AuthenticationPrincipal Jwt jwt,
+			@PathVariable UUID missionId,
+			@RequestHeader(name = "Idempotency-Key", required = false) String idempotencyKey,
+			@RequestBody JsonNode request) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		return SuccessResponse.of(
+				specialQuizNearbyEventService.notify(memberId, missionId, idempotencyKey, parseRequest(request)));
+	}
+
+	private SpecialQuizNearbyEventCommand parseRequest(JsonNode request) {
+		if (request == null || !request.isObject() || !hasOnlyProperties(request, Set.of("tripId", "location"))) {
+			throw new InvalidNotificationRequestException();
+		}
+		return new SpecialQuizNearbyEventCommand(tripId(request.get("tripId")), location(request.get("location")));
+	}
+
+	private UUID tripId(JsonNode node) {
+		if (node == null || !node.isString()) {
+			throw new InvalidNotificationRequestException();
+		}
+		try {
+			return UUID.fromString(node.stringValue());
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidNotificationRequestException();
+		}
+	}
+
+	private LocationCommand location(JsonNode node) {
+		Set<String> fields = Set.of("latitude", "longitude", "accuracyMeters", "capturedAt");
+		if (node == null || !node.isObject() || !hasOnlyOptionalProperties(node, fields, 3, 4)) {
+			throw new InvalidNotificationRequestException();
+		}
+		double latitude = finiteNumber(node.get("latitude"));
+		double longitude = finiteNumber(node.get("longitude"));
+		if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180) {
+			throw new InvalidNotificationRequestException();
+		}
+		Double accuracy = nullableAccuracy(node.get("accuracyMeters"));
+		OffsetDateTime capturedAt = dateTime(node.get("capturedAt"));
+		return new LocationCommand(latitude, longitude, accuracy, capturedAt);
+	}
+
+	private double finiteNumber(JsonNode node) {
+		if (node == null || !node.isNumber() || !Double.isFinite(node.doubleValue())) {
+			throw new InvalidNotificationRequestException();
+		}
+		return node.doubleValue();
+	}
+
+	private Double nullableAccuracy(JsonNode node) {
+		if (node == null || node.isNull()) {
+			return null;
+		}
+		double accuracy = finiteNumber(node);
+		if (accuracy < 0) {
+			throw new InvalidNotificationRequestException();
+		}
+		return accuracy;
+	}
+
+	private OffsetDateTime dateTime(JsonNode node) {
+		if (node == null || !node.isString()) {
+			throw new InvalidNotificationRequestException();
+		}
+		try {
+			return OffsetDateTime.parse(node.stringValue());
+		} catch (DateTimeParseException exception) {
+			throw new InvalidNotificationRequestException();
+		}
+	}
+
+	private boolean hasOnlyProperties(JsonNode node, Set<String> properties) {
+		return node.size() == properties.size()
+				&& node.properties().stream().allMatch(property -> properties.contains(property.getKey()));
+	}
+
+	private boolean hasOnlyOptionalProperties(JsonNode node, Set<String> properties, int minimum, int maximum) {
+		return node.size() >= minimum && node.size() <= maximum
+				&& node.properties().stream().allMatch(property -> properties.contains(property.getKey()))
+				&& node.has("latitude") && node.has("longitude") && node.has("capturedAt");
+	}
+}

--- a/src/main/java/com/buyeoon/notification/application/SpecialQuizNearbyEventService.java
+++ b/src/main/java/com/buyeoon/notification/application/SpecialQuizNearbyEventService.java
@@ -1,0 +1,218 @@
+package com.buyeoon.notification.application;
+
+import com.buyeoon.common.api.SuccessResponse;
+import com.buyeoon.common.entity.IdempotencyRequestEntity;
+import com.buyeoon.common.entity.IdempotencyRequestId;
+import com.buyeoon.member.application.IdempotencyKeyReusedException;
+import com.buyeoon.mission.application.MissionQueryService;
+import com.buyeoon.mission.application.MissionQueryService.SpecialQuizNearbyCheck;
+import com.buyeoon.notification.NotificationCreationService;
+import com.buyeoon.notification.api.InvalidNotificationRequestException;
+import com.buyeoon.notification.entity.NotificationType;
+import com.buyeoon.notification.repository.NotificationIdempotencyRequestRepository;
+import com.buyeoon.notification.repository.NotificationRepository;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.HexFormat;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.databind.ObjectWriter;
+
+/**
+ * 스페셜 퀴즈 근접 알림 커맨드 서비스다. 클라이언트가 오늘 자신에게 노출된 스페셜 퀴즈만 지오펜스로 등록해두었다가 참여 반경
+ * 진입을 알려오면, 서버가 노출 대상·참여 여부·거리를 재검증한 뒤 알림을 보낸다.
+ */
+@Service
+public class SpecialQuizNearbyEventService {
+
+	private static final String OPERATION = "NOTIFY_NEARBY_QUIZ";
+	private static final Duration RETENTION = Duration.ofHours(24);
+	private static final Duration COOLDOWN = Duration.ofHours(12);
+	private static final int SUCCESS_STATUS = 200;
+
+	private final JdbcOperations jdbcOperations;
+	private final TransactionTemplate transactions;
+	private final MissionQueryService missionQueryService;
+	private final NotificationRepository notifications;
+	private final NotificationCreationService notificationCreationService;
+	private final NotificationIdempotencyRequestRepository idempotencyRequests;
+	private final ObjectReader objectReader;
+	private final ObjectWriter objectWriter;
+
+	public SpecialQuizNearbyEventService(JdbcOperations jdbcOperations, PlatformTransactionManager transactionManager,
+			MissionQueryService missionQueryService, NotificationRepository notifications,
+			NotificationCreationService notificationCreationService,
+			NotificationIdempotencyRequestRepository idempotencyRequests, ObjectMapper objectMapper) {
+		this.jdbcOperations = jdbcOperations;
+		this.transactions = new TransactionTemplate(transactionManager);
+		this.missionQueryService = missionQueryService;
+		this.notifications = notifications;
+		this.notificationCreationService = notificationCreationService;
+		this.idempotencyRequests = idempotencyRequests;
+		this.objectReader = objectMapper.reader();
+		this.objectWriter = objectMapper.writer();
+	}
+
+	public SpecialQuizNearbyEventView notify(UUID memberId, UUID missionId, String idempotencyKey,
+			SpecialQuizNearbyEventCommand command) {
+		validateIdempotencyKey(idempotencyKey);
+		String requestHash = hash(missionId, command);
+		return Objects.requireNonNull(
+				transactions.execute(
+						status -> notifyInTransaction(memberId, missionId, idempotencyKey, requestHash, command)),
+				"스페셜 퀴즈 근접 알림 트랜잭션 결과가 없습니다.");
+	}
+
+	private SpecialQuizNearbyEventView notifyInTransaction(UUID memberId, UUID missionId, String idempotencyKey,
+			String requestHash, SpecialQuizNearbyEventCommand command) {
+		Instant now = clockTimestamp();
+
+		IdempotencyRequestId idempotencyId = new IdempotencyRequestId(memberId, idempotencyKey);
+		Optional<IdempotencyRequestEntity> existingRequest = idempotencyRequests.findById(idempotencyId);
+		if (existingRequest.isPresent()) {
+			IdempotencyRequestEntity request = existingRequest.get();
+			if (!request.getExpiresAt().isAfter(now)) {
+				idempotencyRequests.delete(request);
+			} else {
+				return replay(request, requestHash);
+			}
+		}
+
+		boolean notificationSent = evaluateAndNotify(memberId, missionId, command, now);
+
+		SpecialQuizNearbyEventView result = new SpecialQuizNearbyEventView(notificationSent);
+		String responseBody = writeResponse(result);
+		IdempotencyRequestEntity idempotencyRequest = IdempotencyRequestEntity.create(memberId, idempotencyKey,
+				OPERATION, requestHash, now.plus(RETENTION));
+		idempotencyRequest.complete(SUCCESS_STATUS, responseBody);
+		idempotencyRequests.save(idempotencyRequest);
+		return result;
+	}
+
+	/**
+	 * 오늘 노출된 스페셜 퀴즈인지 → 이미 참여했는지 → 참여 반경 이내인지 → 쿨다운 순으로 재검증한 뒤에만 알림을 보낸다. 클라이언트가
+	 * 보낸 missionId·좌표를 그대로 신뢰하지 않는다.
+	 */
+	private boolean evaluateAndNotify(UUID memberId, UUID missionId, SpecialQuizNearbyEventCommand command,
+			Instant now) {
+		SpecialQuizNearbyCheck check = missionQueryService.checkSpecialQuizNearby(memberId, command.tripId(),
+				missionId, command.location().latitude(), command.location().longitude());
+		if (!check.specialQuiz() || !check.exposedToday()) {
+			return false;
+		}
+		if (check.alreadyParticipated()) {
+			return false;
+		}
+		if (!check.withinParticipationRadius()) {
+			return false;
+		}
+		if (notifications.existsByMemberIdAndTypeAndTargetIdAndOccurredAtAfter(memberId, NotificationType.NEARBY_QUIZ,
+				missionId, now.minus(COOLDOWN))) {
+			return false;
+		}
+		notificationCreationService.createNearbyQuiz(memberId, missionId);
+		return true;
+	}
+
+	private SpecialQuizNearbyEventView replay(IdempotencyRequestEntity request, String requestHash) {
+		if (!OPERATION.equals(request.getOperation()) || !requestHash.equals(request.getRequestHash())) {
+			throw new IdempotencyKeyReusedException();
+		}
+		if (!Integer.valueOf(SUCCESS_STATUS).equals(request.getResponseStatus()) || request.getResponseBody() == null) {
+			throw new IllegalStateException("완료되지 않은 멱등성 요청이 남아 있습니다.");
+		}
+		return readResponse(request.getResponseBody());
+	}
+
+	private Instant clockTimestamp() {
+		return Objects.requireNonNull(jdbcOperations.queryForObject("SELECT clock_timestamp()", Timestamp.class))
+				.toInstant();
+	}
+
+	private void validateIdempotencyKey(String idempotencyKey) {
+		if (idempotencyKey == null || idempotencyKey.length() < 8 || idempotencyKey.length() > 128) {
+			throw new InvalidNotificationRequestException();
+		}
+	}
+
+	private String hash(UUID missionId, SpecialQuizNearbyEventCommand command) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			update(digest, missionId.toString());
+			update(digest, command.tripId().toString());
+			update(digest, Double.toHexString(command.location().latitude()));
+			update(digest, Double.toHexString(command.location().longitude()));
+			update(digest,
+					command.location().accuracyMeters() == null
+							? "null"
+							: Double.toHexString(command.location().accuracyMeters()));
+			update(digest, command.location().capturedAt().toInstant().toString());
+			return HexFormat.of().formatHex(digest.digest());
+		} catch (NoSuchAlgorithmException exception) {
+			throw new IllegalStateException("SHA-256을 사용할 수 없습니다.", exception);
+		}
+	}
+
+	private void update(MessageDigest digest, String value) {
+		byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+		digest.update(ByteBuffer.allocate(Integer.BYTES).putInt(bytes.length).array());
+		digest.update(bytes);
+	}
+
+	private String writeResponse(SpecialQuizNearbyEventView result) {
+		try {
+			return objectWriter.writeValueAsString(SuccessResponse.of(result));
+		} catch (JacksonException exception) {
+			throw new IllegalStateException("스페셜 퀴즈 근접 알림 응답을 저장할 수 없습니다.", exception);
+		}
+	}
+
+	private SpecialQuizNearbyEventView readResponse(String responseBody) {
+		try {
+			JsonNode data = required(objectReader.readTree(responseBody), "data");
+			return new SpecialQuizNearbyEventView(requiredBoolean(data, "notificationSent"));
+		} catch (JacksonException | IllegalArgumentException exception) {
+			throw new IllegalStateException("저장된 스페셜 퀴즈 근접 알림 응답을 읽을 수 없습니다.", exception);
+		}
+	}
+
+	private JsonNode required(JsonNode node, String field) {
+		JsonNode value = node == null ? null : node.get(field);
+		if (value == null) {
+			throw new IllegalStateException("저장된 스페셜 퀴즈 근접 알림 응답 필드가 누락되었습니다: " + field);
+		}
+		return value;
+	}
+
+	private boolean requiredBoolean(JsonNode node, String field) {
+		JsonNode value = required(node, field);
+		if (!value.isBoolean()) {
+			throw new IllegalStateException("저장된 스페셜 퀴즈 근접 알림 응답 필드가 boolean이 아닙니다: " + field);
+		}
+		return value.booleanValue();
+	}
+
+	public record SpecialQuizNearbyEventCommand(UUID tripId, LocationCommand location) {
+	}
+
+	public record LocationCommand(double latitude, double longitude, Double accuracyMeters, OffsetDateTime capturedAt) {
+	}
+
+	public record SpecialQuizNearbyEventView(boolean notificationSent) {
+	}
+}

--- a/src/main/java/com/buyeoon/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/buyeoon/notification/repository/NotificationRepository.java
@@ -13,4 +13,8 @@ public interface NotificationRepository extends JpaRepository<NotificationEntity
 
 	/** 쿨다운 판정에 사용한다. 회원에게 해당 유형의 알림이 기준 시각 이후로 발생했는지 확인한다. */
 	boolean existsByMemberIdAndTypeAndOccurredAtAfter(UUID memberId, NotificationType type, Instant occurredAtAfter);
+
+	/** 스페셜 퀴즈 근접 알림처럼 대상(미션)마다 독립적으로 쿨다운을 거는 알림의 재발송 여부 판정에 사용한다. */
+	boolean existsByMemberIdAndTypeAndTargetIdAndOccurredAtAfter(UUID memberId, NotificationType type, UUID targetId,
+			Instant occurredAtAfter);
 }

--- a/src/test/java/com/buyeoon/mission/MissionControllerIntegrationTests.java
+++ b/src/test/java/com/buyeoon/mission/MissionControllerIntegrationTests.java
@@ -308,6 +308,68 @@ class MissionControllerIntegrationTests {
 		assertThat(itemFor(result, photoMission).get("remainingAttempts").isNull()).isTrue();
 	}
 
+	/**
+	 * 지오펜스 등록용 목록은 500m를 넘는 스페셜 퀴즈도 좌표·missionId만 담아 반환한다. 시드 마이그레이션이 부여 지역에
+	 * 예시 스페셜 퀴즈를 채워둘 수 있으므로, 전체 개수 대신 이 테스트가 만든 미션이 포함되는지만 확인한다.
+	 */
+	@Test
+	@DisplayName("오늘 노출된 스페셜 퀴즈는 500m를 넘어도 지오펜스 목록에 좌표와 함께 나온다")
+	void specialQuizzesIncludesMissionsBeyond500m() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		double farLatitude = ORIGIN_LATITUDE + 0.01;
+		UUID place = insertPlace("먼 스페셜 퀴즈 장소", farLatitude, ORIGIN_LONGITUDE);
+		UUID missionId = insertOxMission(place, "먼 스페셜 퀴즈", 100, 3, true);
+
+		MvcResult result = mockMvc.perform(specialQuizzesRequest(tripId)).andExpect(status().isOk()).andReturn();
+		JsonNode item = specialQuizItemFor(result, missionId);
+		assertThat(item.get("latitude").doubleValue()).isEqualTo(farLatitude);
+		assertThat(item.get("longitude").doubleValue()).isEqualTo(ORIGIN_LONGITUDE);
+	}
+
+	/** 최대 도전 횟수가 없는 일반 미션은 지오펜스 목록에서 빠진다. */
+	@Test
+	@DisplayName("일반 미션은 지오펜스 목록에서 빠진다")
+	void specialQuizzesExcludesRegularMissions() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertPlace("일반 미션 장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE);
+		UUID missionId = insertOxMission(place, "일반 미션", 100, null, true);
+
+		MvcResult result = mockMvc.perform(specialQuizzesRequest(tripId)).andExpect(status().isOk()).andReturn();
+		assertThat(containsSpecialQuizItem(result, missionId)).isFalse();
+	}
+
+	/** 오늘 노출 대상이 아닌 스페셜 퀴즈는 지오펜스 목록에서 빠진다. */
+	@Test
+	@DisplayName("오늘 노출 대상이 아닌 스페셜 퀴즈는 지오펜스 목록에서 빠진다")
+	void specialQuizzesExcludesUnexposedQuizzes() throws Exception {
+		when(specialQuizExposureDecider.isExposedToday(any(), any())).thenReturn(false);
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertPlace("비노출 스페셜 퀴즈 장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE);
+		UUID missionId = insertOxMission(place, "비노출 스페셜 퀴즈", 100, 3, true);
+
+		MvcResult result = mockMvc.perform(specialQuizzesRequest(tripId)).andExpect(status().isOk()).andReturn();
+		assertThat(containsSpecialQuizItem(result, missionId)).isFalse();
+	}
+
+	/**
+	 * 이미 완료·소진한 스페셜 퀴즈는 더 알릴 필요가 없으므로, 오늘 노출 대상이어도 지오펜스 목록에서 빠진다.
+	 */
+	@Test
+	@DisplayName("이미 완료·소진한 스페셜 퀴즈는 지오펜스 목록에서 빠진다")
+	void specialQuizzesExcludesAlreadyParticipatedQuizzes() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID completedPlace = insertPlace("완료 스페셜 퀴즈 장소", ORIGIN_LATITUDE + 0.001, ORIGIN_LONGITUDE);
+		UUID completedMission = insertOxMission(completedPlace, "완료 스페셜 퀴즈", 100, 3, true);
+		insertParticipation(tripId, completedMission, "COMPLETED", 1);
+		UUID exhaustedPlace = insertPlace("소진 스페셜 퀴즈 장소", ORIGIN_LATITUDE + 0.002, ORIGIN_LONGITUDE);
+		UUID exhaustedMission = insertOxMission(exhaustedPlace, "소진 스페셜 퀴즈", 100, 3, true);
+		insertParticipation(tripId, exhaustedMission, "EXHAUSTED", 3);
+
+		MvcResult result = mockMvc.perform(specialQuizzesRequest(tripId)).andExpect(status().isOk()).andReturn();
+		assertThat(containsSpecialQuizItem(result, completedMission)).isFalse();
+		assertThat(containsSpecialQuizItem(result, exhaustedMission)).isFalse();
+	}
+
 	/** 조회는 참여 행을 생성하거나 기존 DB 상태를 바꾸지 않는다. */
 	@Test
 	@DisplayName("반복 조회 전후 mission_participations를 포함한 DB 상태가 동일하다")
@@ -596,6 +658,26 @@ class MissionControllerIntegrationTests {
 		throw new AssertionError("응답에서 미션을 찾을 수 없습니다: " + missionId);
 	}
 
+	private JsonNode specialQuizItemFor(MvcResult result, UUID missionId) throws Exception {
+		JsonNode items = objectMapper.readTree(result.getResponse().getContentAsString()).get("data").get("items");
+		for (JsonNode item : items) {
+			if (item.get("missionId").stringValue().equals(missionId.toString())) {
+				return item;
+			}
+		}
+		throw new AssertionError("지오펜스 목록에서 미션을 찾을 수 없습니다: " + missionId);
+	}
+
+	private boolean containsSpecialQuizItem(MvcResult result, UUID missionId) throws Exception {
+		JsonNode items = objectMapper.readTree(result.getResponse().getContentAsString()).get("data").get("items");
+		for (JsonNode item : items) {
+			if (item.get("missionId").stringValue().equals(missionId.toString())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	private MockHttpServletRequestBuilder nearbyRequest(UUID tripId) {
 		return get("/missions/nearby").header("Authorization", "Bearer " + member.accessToken())
 				.param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude", String.valueOf(ORIGIN_LONGITUDE))
@@ -605,6 +687,11 @@ class MissionControllerIntegrationTests {
 	private MockHttpServletRequestBuilder detailRequest(UUID missionId, UUID tripId) {
 		return get("/missions/{missionId}", missionId).header("Authorization", "Bearer " + member.accessToken())
 				.param("latitude", String.valueOf(ORIGIN_LATITUDE)).param("longitude", String.valueOf(ORIGIN_LONGITUDE))
+				.param("tripId", tripId.toString());
+	}
+
+	private MockHttpServletRequestBuilder specialQuizzesRequest(UUID tripId) {
+		return get("/missions/special-quizzes").header("Authorization", "Bearer " + member.accessToken())
 				.param("tripId", tripId.toString());
 	}
 

--- a/src/test/java/com/buyeoon/notification/SpecialQuizNearbyEventIntegrationTests.java
+++ b/src/test/java/com/buyeoon/notification/SpecialQuizNearbyEventIntegrationTests.java
@@ -1,0 +1,348 @@
+package com.buyeoon.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import com.buyeoon.mission.application.SpecialQuizExposureDecider;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * 스페셜 퀴즈 근접 알림의 공개 seam인 {@code POST /notifications/missions/{missionId}/nearby-events}를
+ * 검증한다.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class SpecialQuizNearbyEventIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+
+	// 시드 마이그레이션이 부여 지역에 장소·미션 예시 데이터를 채워두므로, 격리를 위해 남극 인근 좌표를
+	// 기준으로 테스트 데이터를 배치한다.
+	private static final double ORIGIN_LATITUDE = -75.0;
+	private static final double ORIGIN_LONGITUDE = 0.0;
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	@MockitoBean
+	private SpecialQuizExposureDecider specialQuizExposureDecider;
+
+	private AuthenticatedMember member;
+
+	@BeforeEach
+	void setUp() {
+		member = insertAuthenticatedMember();
+		when(specialQuizExposureDecider.isExposedToday(any(), any())).thenReturn(true);
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM idempotency_requests");
+		jdbcTemplate.update("DELETE FROM notifications");
+		jdbcTemplate.update("DELETE FROM mission_participations");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update(
+				"DELETE FROM missions WHERE place_id IN (SELECT id FROM places WHERE ST_Y(location::geometry) < -70)");
+		jdbcTemplate.update("DELETE FROM places WHERE ST_Y(location::geometry) < -70");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 오늘 노출된 스페셜 퀴즈에 반경 이내로 접근하면 알림을 생성한다. */
+	@Test
+	@DisplayName("노출된 스페셜 퀴즈 반경 이내 진입은 알림을 생성한다")
+	void withinRadiusExposedSpecialQuizCreatesNotification() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("스페셜 퀴즈 장소", 20);
+		UUID missionId = insertOxMission(place, "스페셜 퀴즈", 100, 3, true);
+
+		performNotify(missionId, "nearby-key-01", request(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.notificationSent").value(true));
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM notifications WHERE member_id = ? AND type = 'NEARBY_QUIZ' AND target_id = ?",
+				Long.class, member.memberId(), missionId)).isEqualTo(1L);
+	}
+
+	/** 최대 도전 횟수가 없는 일반 미션은 스페셜 퀴즈가 아니므로 알림을 생성하지 않는다. */
+	@Test
+	@DisplayName("일반 미션은 알림을 생성하지 않는다")
+	void regularMissionDoesNotCreateNotification() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("일반 미션 장소", 20);
+		UUID missionId = insertOxMission(place, "일반 미션", 100, null, true);
+
+		performNotify(missionId, "nearby-key-02", request(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.notificationSent").value(false));
+
+		assertNoNearbyQuizNotification(missionId);
+	}
+
+	/** 오늘 노출 대상이 아닌 스페셜 퀴즈는 클라이언트가 요청해도 알림을 생성하지 않는다. */
+	@Test
+	@DisplayName("오늘 노출 대상이 아니면 알림을 생성하지 않는다")
+	void notExposedTodaySkipsNotification() throws Exception {
+		when(specialQuizExposureDecider.isExposedToday(any(), any())).thenReturn(false);
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("비노출 스페셜 퀴즈 장소", 20);
+		UUID missionId = insertOxMission(place, "비노출 스페셜 퀴즈", 100, 3, true);
+
+		performNotify(missionId, "nearby-key-03", request(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.notificationSent").value(false));
+
+		assertNoNearbyQuizNotification(missionId);
+	}
+
+	/** 이미 완료·소진한 스페셜 퀴즈는 다시 알릴 이유가 없으므로 알림을 생성하지 않는다. */
+	@Test
+	@DisplayName("이미 참여한 스페셜 퀴즈는 알림을 생성하지 않는다")
+	void alreadyParticipatedSkipsNotification() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("완료된 스페셜 퀴즈 장소", 20);
+		UUID missionId = insertOxMission(place, "완료된 스페셜 퀴즈", 100, 3, true);
+		insertParticipation(tripId, missionId, "COMPLETED");
+
+		performNotify(missionId, "nearby-key-04", request(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.notificationSent").value(false));
+
+		assertNoNearbyQuizNotification(missionId);
+	}
+
+	/** 서버가 좌표로 재계산한 거리가 참여 반경(30m)을 넘으면 클라이언트 신고를 신뢰하지 않고 알림을 생성하지 않는다. */
+	@Test
+	@DisplayName("참여 반경 밖이면 알림을 생성하지 않는다")
+	void outsideParticipationRadiusSkipsNotification() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("먼 스페셜 퀴즈 장소", 40);
+		UUID missionId = insertOxMission(place, "먼 스페셜 퀴즈", 100, 3, true);
+
+		performNotify(missionId, "nearby-key-05", request(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.notificationSent").value(false));
+
+		assertNoNearbyQuizNotification(missionId);
+	}
+
+	/** 같은 미션에 대해 마지막 발송 후 12시간이 지나지 않았으면 재발송하지 않는다. */
+	@Test
+	@DisplayName("쿨다운 12시간 이내에는 같은 미션을 재발송하지 않는다")
+	void withinCooldownSkipsNotification() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("쿨다운 스페셜 퀴즈 장소", 20);
+		UUID missionId = insertOxMission(place, "쿨다운 스페셜 퀴즈", 100, 3, true);
+		insertNearbyQuizNotification(member.memberId(), missionId, Instant.now().minus(11, ChronoUnit.HOURS));
+
+		performNotify(missionId, "nearby-key-06", request(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.notificationSent").value(false));
+
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM notifications WHERE member_id = ? AND type = 'NEARBY_QUIZ' AND target_id = ?",
+				Long.class, member.memberId(), missionId)).isEqualTo(1L);
+	}
+
+	/** 다른 미션의 쿨다운은 서로 영향을 주지 않는다. */
+	@Test
+	@DisplayName("다른 미션의 쿨다운은 신규 알림을 막지 않는다")
+	void cooldownIsScopedPerMission() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID otherPlace = insertProjectedPlace("다른 스페셜 퀴즈 장소", 15);
+		UUID otherMissionId = insertOxMission(otherPlace, "다른 스페셜 퀴즈", 100, 3, true);
+		insertNearbyQuizNotification(member.memberId(), otherMissionId, Instant.now().minus(1, ChronoUnit.HOURS));
+
+		UUID place = insertProjectedPlace("새 스페셜 퀴즈 장소", 20);
+		UUID missionId = insertOxMission(place, "새 스페셜 퀴즈", 100, 3, true);
+
+		performNotify(missionId, "nearby-key-07", request(tripId)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.notificationSent").value(true));
+	}
+
+	/** 같은 키와 같은 본문의 재요청은 최초 처리 결과를 그대로 반환하며 알림을 다시 만들지 않는다. */
+	@Test
+	@DisplayName("동일한 멱등성 요청은 최초 응답을 재사용한다")
+	void sameIdempotentRequestReturnsFirstResponse() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+		UUID place = insertProjectedPlace("멱등성 스페셜 퀴즈 장소", 20);
+		UUID missionId = insertOxMission(place, "멱등성 스페셜 퀴즈", 100, 3, true);
+		String key = "retry-nearby-key";
+
+		String first = performNotify(missionId, key, request(tripId)).andExpect(status().isOk()).andReturn()
+				.getResponse().getContentAsString();
+		String retried = performNotify(missionId, key, request(tripId)).andExpect(status().isOk()).andReturn()
+				.getResponse().getContentAsString();
+
+		assertThat(retried).isEqualTo(first);
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM notifications WHERE member_id = ? AND type = 'NEARBY_QUIZ' AND target_id = ?",
+				Long.class, member.memberId(), missionId)).isEqualTo(1L);
+	}
+
+	/** 존재하지 않는 미션은 404를 반환한다. */
+	@Test
+	@DisplayName("존재하지 않는 미션은 404를 반환한다")
+	void unknownMissionReturnsNotFound() throws Exception {
+		UUID tripId = startTrip(member.memberId());
+
+		performNotify(UUID.randomUUID(), "nearby-key-08", request(tripId)).andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.data.code").value("RESOURCE_NOT_FOUND"));
+	}
+
+	/** 인증되지 않은 요청은 알림 계층에 도달하지 않는다. */
+	@Test
+	@DisplayName("스페셜 퀴즈 근접 알림에는 유효한 인증 세션이 필요하다")
+	void authenticationIsRequired() throws Exception {
+		mockMvc
+				.perform(post("/notifications/missions/" + UUID.randomUUID() + "/nearby-events")
+						.header("Idempotency-Key", "unauth-nearby-key").contentType(MediaType.APPLICATION_JSON)
+						.content(request(UUID.randomUUID())))
+				.andExpect(status().isUnauthorized()).andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** 알 수 없는 필드가 섞인 요청은 400 INVALID_REQUEST다. */
+	@Test
+	@DisplayName("잘못된 요청 형식은 400을 반환한다")
+	void invalidRequestBodyIsRejected() throws Exception {
+		performNotify(UUID.randomUUID(), "invalid-nearby-key",
+				"{\"tripId\":\"" + UUID.randomUUID() + "\",\"location\":{\"latitude\":36.27}}")
+				.andExpect(status().isBadRequest()).andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+	}
+
+	private ResultActions performNotify(UUID missionId, String key, String body) throws Exception {
+		var request = post("/notifications/missions/" + missionId + "/nearby-events")
+				.header("Authorization", "Bearer " + member.accessToken()).contentType(MediaType.APPLICATION_JSON)
+				.content(body);
+		if (key != null) {
+			request.header("Idempotency-Key", key);
+		}
+		return mockMvc.perform(request);
+	}
+
+	private AuthenticatedMember insertAuthenticatedMember() {
+		UUID memberId = UUID.randomUUID();
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	private UUID startTrip(UUID memberId) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update("INSERT INTO trips (id, member_id, status) VALUES (?, ?, 'IN_PROGRESS')", tripId, memberId);
+		return tripId;
+	}
+
+	private UUID insertPlace(String name, double latitude, double longitude) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate
+				.update("INSERT INTO places (id, category, name, location) VALUES (?, 'HERITAGE'::place_category, ?, "
+						+ "ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography)", id, name, longitude, latitude);
+		return id;
+	}
+
+	/**
+	 * 원점에서 지정한 거리(m)만큼 떨어진 지점에 장소를 만든다. 삽입과 조회가 같은 PostGIS geodesic 계산을 쓰므로 왕복 오차가
+	 * 없다.
+	 */
+	private UUID insertProjectedPlace(String name, double distanceMeters) {
+		Map<String, Object> point = jdbcTemplate.queryForMap(
+				"SELECT ST_Y(pt::geometry) AS lat, ST_X(pt::geometry) AS lon FROM "
+						+ "(SELECT ST_Project(ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?, 0) AS pt) t",
+				ORIGIN_LONGITUDE, ORIGIN_LATITUDE, distanceMeters);
+		return insertPlace(name, ((Number) point.get("lat")).doubleValue(), ((Number) point.get("lon")).doubleValue());
+	}
+
+	private UUID insertOxMission(UUID placeId, String title, int rewardPoints, Integer maxAttempts,
+			boolean correctAnswer) {
+		UUID id = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO missions (id, place_id, location, type, title, description, reward_points, "
+						+ "max_attempts, ox_correct_answer) VALUES (?, ?, "
+						+ "(SELECT location FROM places WHERE id = ?), 'OX'::mission_type, ?, '설명', ?, ?, ?)",
+				id, placeId, placeId, title, rewardPoints, maxAttempts, correctAnswer);
+		return id;
+	}
+
+	private void insertParticipation(UUID tripId, UUID missionId, String status) {
+		Timestamp completedAt = "COMPLETED".equals(status) ? Timestamp.from(Instant.now()) : null;
+		jdbcTemplate.update("""
+				INSERT INTO mission_participations (id, trip_id, mission_id, status, attempt_count, completed_at)
+				VALUES (?, ?, ?, ?::mission_status, 1, ?)
+				""", UUID.randomUUID(), tripId, missionId, status, completedAt);
+	}
+
+	private void insertNearbyQuizNotification(UUID memberId, UUID missionId, Instant occurredAt) {
+		jdbcTemplate.update("""
+				INSERT INTO notifications (id, member_id, type, title, body, target_type, target_id, occurred_at)
+				VALUES (?, ?, 'NEARBY_QUIZ', '근처에 스페셜 퀴즈가 있어요!', '지금 도전하면 특별한 보상을 받을 수 있어요.', 'MISSION', ?, ?)
+				""", UUID.randomUUID(), memberId, missionId, Timestamp.from(occurredAt));
+	}
+
+	private void assertNoNearbyQuizNotification(UUID missionId) {
+		assertThat(jdbcTemplate.queryForObject(
+				"SELECT count(*) FROM notifications WHERE member_id = ? AND type = 'NEARBY_QUIZ' AND target_id = ?",
+				Long.class, member.memberId(), missionId)).isZero();
+	}
+
+	private String request(UUID tripId) {
+		return "{\"tripId\":\"" + tripId + "\",\"location\":{\"latitude\":" + ORIGIN_LATITUDE + ",\"longitude\":"
+				+ ORIGIN_LONGITUDE + ",\"accuracyMeters\":5.5,\"capturedAt\":\"2026-08-12T15:30:00+09:00\"}}";
+	}
+
+	@DynamicPropertySource
+	static void properties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+	}
+
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+}


### PR DESCRIPTION
## Summary
- 클라이언트가 오늘 자신에게 노출된 스페셜 퀴즈(최대 도전 횟수가 있는 미션)만 지오펜스로 등록해두었다가, 참여 반경(30m) 진입을 `POST /notifications/missions/{missionId}/nearby-events`로 알려오면 서버가 노출 대상·참여 여부·거리를 모두 재검증한 뒤 `NEARBY_QUIZ` FCM 알림을 보낸다.
- 검증 순서: 여행 소유·진행 중 → 오늘 노출된 스페셜 퀴즈인지(`SpecialQuizExposureDecider`) → 이미 참여(완료/소진)했는지 → 참여 반경 이내인지(클라이언트 좌표 재검증) → 미션별 12시간 쿨다운. entry/exit 알림(UC-27/28)과 동일한 멱등키 + 요청해시 패턴을 따른다.
- `PARTICIPATION_RADIUS_METERS`가 `MissionQueryService`·`MissionSubmissionService`에 중복 정의돼 있던 것을 `common.location.ParticipationRadiusPolicy` 공통 상수로 뽑아냈다.
- `NotificationRepository`에 알림 대상(미션)별 쿨다운 조회 메서드를 추가하고, `MissionQueryService`에 notification 도메인이 사용하는 `checkSpecialQuizNearby` 공개 seam을 추가했다.

관련 이슈: #216

## Test plan
- [x] `./gradlew test --tests com.buyeoon.notification.SpecialQuizNearbyEventIntegrationTests` (신규 11개 케이스: 노출/미노출, 이미 참여, 반경 밖, 쿨다운, 미션별 쿨다운 독립성, 멱등성 재생, 404/400/401)
- [x] `./gradlew test` 전체 스위트 통과 확인 (공통 상수 추출로 인한 회귀 없음)
- [x] `./gradlew checkstyleMain checkstyleTest` — 이번 변경분에서는 위반 없음 (기존 다른 파일의 사전 위반은 그대로 남아 있음, 이번 변경과 무관)
- [ ] SpotBugs는 main 브랜치에서도 이미 실패 상태(사전 확인 완료)라 이번 PR 범위에서는 다루지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWH5tnCRnGLULWqxWFmQdB