### PR TITLE
feat: 누적 포인트 랭킹 조회를 추가한다

### DIFF
--- a/src/main/java/com/buyeoon/point/api/PointController.java
+++ b/src/main/java/com/buyeoon/point/api/PointController.java
@@ -5,6 +5,9 @@ import com.buyeoon.point.application.PointSettlementPreviewService;
 import com.buyeoon.point.application.PointSettlementPreviewService.PointSettlementPreviewView;
 import com.buyeoon.point.application.PointSettlementService;
 import com.buyeoon.point.application.PointSettlementService.TripSettlementView;
+import com.buyeoon.point.application.PointRankingCursor;
+import com.buyeoon.point.application.PointRankingQueryService;
+import com.buyeoon.point.application.PointRankingQueryService.PointRankingListView;
 import com.buyeoon.point.application.PointSummaryService;
 import com.buyeoon.point.application.PointSummaryService.PointSummaryView;
 import com.buyeoon.point.application.PointTransactionCursor;
@@ -25,7 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import tools.jackson.databind.JsonNode;
 
-/** 로그인 회원의 포인트 잔액 요약, 내역, 여행 정산 미리보기 조회와 여행 포인트 정산 확정을 담당하는 컨트롤러다. */
+/** 로그인 회원의 포인트 잔액·내역·랭킹·정산 미리보기 조회와 여행 포인트 정산 확정을 담당하는 컨트롤러다. */
 @RestController
 public class PointController {
 
@@ -35,16 +38,19 @@ public class PointController {
 
 	private final PointSummaryService pointSummaryService;
 	private final PointTransactionQueryService pointTransactionQueryService;
+	private final PointRankingQueryService pointRankingQueryService;
 	private final PointSettlementPreviewService pointSettlementPreviewService;
 	private final PointSettlementService pointSettlementService;
 
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
 	public PointController(PointSummaryService pointSummaryService,
 			PointTransactionQueryService pointTransactionQueryService,
+			PointRankingQueryService pointRankingQueryService,
 			PointSettlementPreviewService pointSettlementPreviewService,
 			PointSettlementService pointSettlementService) {
 		this.pointSummaryService = pointSummaryService;
 		this.pointTransactionQueryService = pointTransactionQueryService;
+		this.pointRankingQueryService = pointRankingQueryService;
 		this.pointSettlementPreviewService = pointSettlementPreviewService;
 		this.pointSettlementService = pointSettlementService;
 	}
@@ -60,6 +66,14 @@ public class PointController {
 			@RequestParam(required = false) String cursor, @RequestParam(required = false) String size) {
 		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
 		return SuccessResponse.of(pointTransactionQueryService.list(memberId, parseCursor(cursor), parseSize(size)));
+	}
+
+	/** 로그인 회원에게 누적 적립 랭킹 한 페이지와 자신의 전체 순위를 반환한다. */
+	@GetMapping("/point-rankings")
+	public SuccessResponse<PointRankingListView> getPointRanking(@AuthenticationPrincipal Jwt jwt,
+			@RequestParam(required = false) String cursor) {
+		UUID memberId = UUID.fromString(Objects.requireNonNull(jwt.getSubject()));
+		return SuccessResponse.of(pointRankingQueryService.list(memberId, parseRankingCursor(cursor)));
 	}
 
 	@GetMapping("/trips/{tripId}/settlement-preview")
@@ -109,6 +123,18 @@ public class PointController {
 		}
 		try {
 			return PointTransactionCursor.decode(cursor);
+		} catch (IllegalArgumentException exception) {
+			throw new InvalidPointRequestException();
+		}
+	}
+
+	/** 랭킹 커서가 없으면 첫 페이지를, 형식이 잘못되면 공통 400 오류를 선택한다. */
+	private PointRankingCursor parseRankingCursor(String cursor) {
+		if (cursor == null) {
+			return null;
+		}
+		try {
+			return PointRankingCursor.decode(cursor);
 		} catch (IllegalArgumentException exception) {
 			throw new InvalidPointRequestException();
 		}

--- a/src/main/java/com/buyeoon/point/application/PointRankingCursor.java
+++ b/src/main/java/com/buyeoon/point/application/PointRankingCursor.java
@@ -1,0 +1,31 @@
+package com.buyeoon.point.application;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
+
+/** 누적 적립과 회원 ID로 랭킹 페이지 경계를 표현하는 불투명 커서다. */
+public record PointRankingCursor(long cumulativeEarned, UUID memberId) {
+
+	/** URL-safe Base64 커서를 검증하고 랭킹 경계 값으로 복원한다. */
+	public static PointRankingCursor decode(String value) {
+		try {
+			String decoded = new String(Base64.getUrlDecoder().decode(value), StandardCharsets.UTF_8);
+			int separatorIndex = decoded.indexOf('_');
+			long cumulativeEarned = Long.parseLong(decoded.substring(0, separatorIndex));
+			UUID memberId = UUID.fromString(decoded.substring(separatorIndex + 1));
+			if (cumulativeEarned < 1) {
+				throw new IllegalArgumentException("누적 적립은 1 이상이어야 합니다.");
+			}
+			return new PointRankingCursor(cumulativeEarned, memberId);
+		} catch (RuntimeException exception) {
+			throw new IllegalArgumentException("잘못된 랭킹 커서입니다.", exception);
+		}
+	}
+
+	/** 랭킹 경계 값을 URL-safe Base64 문자열로 인코딩한다. */
+	public String encode() {
+		String raw = cumulativeEarned + "_" + memberId;
+		return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+	}
+}

--- a/src/main/java/com/buyeoon/point/application/PointRankingQueryService.java
+++ b/src/main/java/com/buyeoon/point/application/PointRankingQueryService.java
@@ -1,0 +1,83 @@
+package com.buyeoon.point.application;
+
+import com.buyeoon.common.storage.PublicImageUrlService;
+import com.buyeoon.point.repository.PointRankingQueryRepository;
+import com.buyeoon.point.repository.PointRankingRow;
+import com.buyeoon.point.repository.PointRankingSummary;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** UC-29 누적 포인트 랭킹과 현재 회원의 순위를 읽기 전용으로 조회한다. */
+@Service
+@Transactional(readOnly = true, isolation = Isolation.REPEATABLE_READ)
+public class PointRankingQueryService {
+
+	private static final int PAGE_SIZE = 20;
+
+	private final PointRankingQueryRepository pointRankingQueryRepository;
+	private final PublicImageUrlService publicImageUrlService;
+
+	/** 랭킹 projection과 공개 이미지 URL 생성 seam을 주입받는다. */
+	public PointRankingQueryService(PointRankingQueryRepository pointRankingQueryRepository,
+			PublicImageUrlService publicImageUrlService) {
+		this.pointRankingQueryRepository = pointRankingQueryRepository;
+		this.publicImageUrlService = publicImageUrlService;
+	}
+
+	/** 현재 페이지 20명, 내 랭킹과 전체 참여자 수를 같은 DB 스냅샷에서 조회한다. */
+	public PointRankingListView list(UUID memberId, PointRankingCursor cursor) {
+		List<PointRankingRow> rows = cursor == null
+				? pointRankingQueryRepository.findFirstPage(PAGE_SIZE + 1)
+				: pointRankingQueryRepository.findAfter(cursor, PAGE_SIZE + 1);
+		PointRankingSummary summary = pointRankingQueryRepository.findSummary(memberId);
+		boolean hasNext = rows.size() > PAGE_SIZE;
+		List<PointRankingRow> page = hasNext ? rows.subList(0, PAGE_SIZE) : rows;
+		String nextCursor = hasNext
+				? new PointRankingCursor(page.getLast().cumulativeEarned(), page.getLast().memberId()).encode()
+				: null;
+		List<PointRankingItemView> items = page.stream().map(row -> toItem(row, memberId)).toList();
+		return new PointRankingListView(items, toMyRanking(summary), summary.totalParticipants(),
+				new PageInfoView(nextCursor, hasNext));
+	}
+
+	/** 내부 회원 ID와 이미지 키를 API에 노출하지 않는 랭킹 항목으로 바꾼다. */
+	private PointRankingItemView toItem(PointRankingRow row, UUID memberId) {
+		return new PointRankingItemView(row.rank(), row.displayName(),
+				publicImageUrlService.create(row.characterImageKey()), row.cumulativeEarned(),
+				row.memberId().equals(memberId));
+	}
+
+	/** 참여 여부에 따라 문서화된 내 랭킹 응답을 만든다. */
+	private MyPointRankingView toMyRanking(PointRankingSummary summary) {
+		if (!summary.eligible()) {
+			return new MyPointRankingView(false, null, null, null, 0);
+		}
+		return new MyPointRankingView(true, summary.rank(), summary.displayName(),
+				publicImageUrlService.create(summary.characterImageKey()), summary.cumulativeEarned());
+	}
+
+	/** 랭킹 목록, 내 랭킹, 참여자 수와 페이지 정보를 담는 API 응답이다. */
+	public record PointRankingListView(List<PointRankingItemView> items, MyPointRankingView myRanking,
+			long totalParticipants, PageInfoView page) {
+		public PointRankingListView {
+			items = List.copyOf(items);
+		}
+	}
+
+	/** 다른 회원에게 공개할 수 있는 랭킹 항목이다. */
+	public record PointRankingItemView(long rank, String displayName, String characterImageUrl, long cumulativeEarned,
+			boolean isMe) {
+	}
+
+	/** 현재 회원의 랭킹 참여 여부와 순위 정보다. */
+	public record MyPointRankingView(boolean eligible, Long rank, String displayName, String characterImageUrl,
+			long cumulativeEarned) {
+	}
+
+	/** 다음 페이지 커서 존재 여부를 나타내는 페이지 정보다. */
+	public record PageInfoView(String nextCursor, boolean hasNext) {
+	}
+}

--- a/src/main/java/com/buyeoon/point/repository/PointRankingQueryRepository.java
+++ b/src/main/java/com/buyeoon/point/repository/PointRankingQueryRepository.java
@@ -1,0 +1,95 @@
+package com.buyeoon.point.repository;
+
+import com.buyeoon.point.application.PointRankingCursor;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcOperations;
+import org.springframework.stereotype.Repository;
+
+/** 포인트 원장과 현재 회원 프로필을 결합해 UC-29 랭킹 projection을 조회한다. */
+@Repository
+public class PointRankingQueryRepository {
+
+	private static final String RANKED_MEMBERS = """
+			WITH eligible AS (
+			    SELECT m.id AS member_id,
+			           profile.display_name,
+			           character.image_key AS character_image_key,
+			           SUM(point.amount)::bigint AS cumulative_earned
+			    FROM members m
+			    JOIN citizen_cards card ON card.member_id = m.id
+			    JOIN member_profiles profile ON profile.member_id = m.id
+			    JOIN card_characters character ON character.id = profile.character_id
+			    JOIN point_transactions point ON point.member_id = m.id AND point.type = 'EARN'
+			    WHERE m.status = 'ACTIVE'
+			    GROUP BY m.id, profile.display_name, character.image_key
+			    HAVING SUM(point.amount) > 0
+			), ranked AS (
+			    SELECT member_id,
+			           display_name,
+			           character_image_key,
+			           cumulative_earned,
+			           RANK() OVER (ORDER BY cumulative_earned DESC)::bigint AS rank_value
+			    FROM eligible
+			)
+			""";
+
+	private final JdbcOperations jdbcOperations;
+
+	/** 랭킹 집계에 사용할 JDBC 접근 seam을 주입받는다. */
+	public PointRankingQueryRepository(JdbcOperations jdbcOperations) {
+		this.jdbcOperations = jdbcOperations;
+	}
+
+	/** 첫 페이지를 누적 적립 내림차순과 회원 ID 오름차순으로 조회한다. */
+	public List<PointRankingRow> findFirstPage(int limit) {
+		return jdbcOperations.query(RANKED_MEMBERS + """
+				SELECT member_id, rank_value, display_name, character_image_key, cumulative_earned
+				FROM ranked
+				ORDER BY cumulative_earned DESC, member_id
+				LIMIT ?
+				""", this::mapRow, limit);
+	}
+
+	/** 커서 뒤의 참여자를 동일한 정렬 기준으로 이어서 조회한다. */
+	public List<PointRankingRow> findAfter(PointRankingCursor cursor, int limit) {
+		return jdbcOperations.query(RANKED_MEMBERS + """
+				SELECT member_id, rank_value, display_name, character_image_key, cumulative_earned
+				FROM ranked
+				WHERE cumulative_earned < ?
+				   OR (cumulative_earned = ? AND member_id > ?)
+				ORDER BY cumulative_earned DESC, member_id
+				LIMIT ?
+				""", this::mapRow, cursor.cumulativeEarned(), cursor.cumulativeEarned(), cursor.memberId(), limit);
+	}
+
+	/** 전체 참여자 수와 현재 회원의 전체 랭킹 기준 정보를 한 행으로 조회한다. */
+	public PointRankingSummary findSummary(UUID memberId) {
+		return jdbcOperations.queryForObject(RANKED_MEMBERS + """
+				SELECT COUNT(*)::bigint AS total_participants,
+				       MAX(rank_value) FILTER (WHERE member_id = ?) AS my_rank,
+				       MAX(display_name) FILTER (WHERE member_id = ?) AS my_display_name,
+				       MAX(character_image_key) FILTER (WHERE member_id = ?) AS my_character_image_key,
+				       COALESCE(MAX(cumulative_earned) FILTER (WHERE member_id = ?), 0)::bigint
+				           AS my_cumulative_earned
+				FROM ranked
+				""", this::mapSummary, memberId, memberId, memberId, memberId);
+	}
+
+	/** JDBC 결과 한 행을 랭킹 참여 회원 projection으로 변환한다. */
+	private PointRankingRow mapRow(ResultSet resultSet, int rowNumber) throws SQLException {
+		return new PointRankingRow(resultSet.getObject("member_id", UUID.class), resultSet.getLong("rank_value"),
+				resultSet.getString("display_name"), resultSet.getString("character_image_key"),
+				resultSet.getLong("cumulative_earned"));
+	}
+
+	/** 집계 결과 한 행을 전체 수와 내 랭킹 projection으로 변환한다. */
+	private PointRankingSummary mapSummary(ResultSet resultSet, int rowNumber) throws SQLException {
+		Long rank = resultSet.getObject("my_rank", Long.class);
+		return new PointRankingSummary(resultSet.getLong("total_participants"), rank,
+				resultSet.getString("my_display_name"), resultSet.getString("my_character_image_key"),
+				resultSet.getLong("my_cumulative_earned"));
+	}
+}

--- a/src/main/java/com/buyeoon/point/repository/PointRankingRow.java
+++ b/src/main/java/com/buyeoon/point/repository/PointRankingRow.java
@@ -1,0 +1,8 @@
+package com.buyeoon.point.repository;
+
+import java.util.UUID;
+
+/** 랭킹 페이지에 표시할 참여 회원의 읽기 projection이다. */
+public record PointRankingRow(UUID memberId, long rank, String displayName, String characterImageKey,
+		long cumulativeEarned) {
+}

--- a/src/main/java/com/buyeoon/point/repository/PointRankingSummary.java
+++ b/src/main/java/com/buyeoon/point/repository/PointRankingSummary.java
@@ -1,0 +1,11 @@
+package com.buyeoon.point.repository;
+
+/** 전체 참여자 수와 현재 회원의 랭킹 정보를 함께 담는 읽기 projection이다. */
+public record PointRankingSummary(long totalParticipants, Long rank, String displayName, String characterImageKey,
+		long cumulativeEarned) {
+
+	/** 현재 회원이 참여 자격을 갖는지 순위 존재 여부로 판단한다. */
+	public boolean eligible() {
+		return rank != null;
+	}
+}

--- a/src/test/java/com/buyeoon/point/PointRankingIntegrationTests.java
+++ b/src/test/java/com/buyeoon/point/PointRankingIntegrationTests.java
@@ -1,0 +1,341 @@
+package com.buyeoon.point;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.buyeoon.member.auth.AccessTokenService;
+import com.jayway.jsonpath.JsonPath;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/** UC-29 누적 포인트 랭킹 조회의 HTTP 계약을 실제 PostgreSQL에서 검증한다. */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class PointRankingIntegrationTests {
+
+	private static final String APPLICATION_USERNAME = "buyeoon_app";
+	private static final String APPLICATION_PASSWORD = "application-test-password";
+	private static final UUID FIRST_MEMBER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+	private static final UUID MY_MEMBER_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+
+	@Container
+	private static final PostgreSQLContainer POSTGIS = new PostgreSQLContainer(
+			DockerImageName.parse("postgis/postgis:17-3.5").asCompatibleSubstituteFor("postgres"))
+			.withDatabaseName("buyeoon_test").withUsername("buyeoon_admin").withPassword("admin-test-password")
+			.withInitScript("db/test-postgis-init.sql");
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private AccessTokenService accessTokenService;
+
+	/** 테스트에서 실제 AWS 호출 없이 Presigned URL을 만들 수 있도록 고정 자격증명을 설정한다. */
+	@BeforeAll
+	static void configureAwsCredentials() {
+		System.setProperty("aws.accessKeyId", "test-access-key");
+		System.setProperty("aws.secretAccessKey", "test-secret-key");
+	}
+
+	/** 다른 통합 테스트에 AWS 자격증명 시스템 속성을 남기지 않는다. */
+	@AfterAll
+	static void clearAwsCredentials() {
+		System.clearProperty("aws.accessKeyId");
+		System.clearProperty("aws.secretAccessKey");
+	}
+
+	/** 테스트마다 생성한 랭킹 회원과 포인트 데이터를 참조 역순으로 제거한다. */
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM point_settlements");
+		jdbcTemplate.update("DELETE FROM point_transactions");
+		jdbcTemplate.update("DELETE FROM trips");
+		jdbcTemplate.update("DELETE FROM citizen_cards");
+		jdbcTemplate.update("DELETE FROM member_profiles");
+		jdbcTemplate.update("DELETE FROM auth_sessions");
+		jdbcTemplate.update("DELETE FROM members");
+	}
+
+	/** 참여 자격을 적용하고 같은 누적 적립에는 공동 순위와 건너뛴 다음 순위를 부여한다. */
+	@Test
+	@DisplayName("참여 자격을 적용하고 공동 순위를 1, 2, 2 방식으로 반환한다")
+	void appliesEligibilityAndSharedRanks() throws Exception {
+		AuthenticatedMember me = insertMember(MY_MEMBER_ID, "수정 전", true);
+		UUID first = UUID.fromString("00000000-0000-0000-0000-000000000001");
+		UUID tied = UUID.fromString("00000000-0000-0000-0000-000000000003");
+		UUID zero = UUID.fromString("00000000-0000-0000-0000-000000000004");
+		UUID cardless = UUID.fromString("00000000-0000-0000-0000-000000000005");
+		UUID withdrawn = UUID.fromString("00000000-0000-0000-0000-000000000006");
+		insertMember(first, "일등", false);
+		insertMember(tied, "수정 전 동점", false);
+		insertMember(zero, "영점", false);
+		insertMemberWithoutCard(cardless, false);
+		insertMember(withdrawn, "탈퇴", false);
+		insertTransaction(first, "EARN", 500);
+		insertTransaction(me.memberId(), "EARN", 300);
+		insertTransaction(me.memberId(), "ADJUST", 700);
+		insertTransaction(tied, "EARN", 300);
+		insertTransaction(cardless, "EARN", 900);
+		insertTransaction(withdrawn, "EARN", 1000);
+		jdbcTemplate.update("""
+				UPDATE member_profiles
+				SET display_name = '현재 동점', character_id = '10000000-0000-4000-8000-000000000002'
+				WHERE member_id = ?
+				""", tied);
+		withdraw(withdrawn);
+
+		mockMvc.perform(rankingRequest(me)).andExpect(status().isOk()).andExpect(jsonPath("$.data.items", hasSize(3)))
+				.andExpect(jsonPath("$.data.items[0].displayName").value("일등"))
+				.andExpect(jsonPath("$.data.items[0].rank").value(1))
+				.andExpect(jsonPath("$.data.items[1].displayName").value("수정 전"))
+				.andExpect(jsonPath("$.data.items[1].rank").value(2))
+				.andExpect(jsonPath("$.data.items[1].cumulativeEarned").value(300))
+				.andExpect(jsonPath("$.data.items[2].displayName").value("현재 동점"))
+				.andExpect(jsonPath("$.data.items[2].rank").value(2))
+				.andExpect(
+						jsonPath("$.data.items[2].characterImageUrl", containsString("public/characters/geumyong.png")))
+				.andExpect(jsonPath("$.data.totalParticipants").value(3));
+	}
+
+	/** 공동 순위가 20명 경계에 걸려도 다음 페이지에서 전체 기준 순위를 유지한다. */
+	@Test
+	@DisplayName("20명 고정 커서 페이지네이션에서 공동 순위의 전체 순위를 유지한다")
+	void paginatesTwentyMembersAndKeepsSharedRank() throws Exception {
+		AuthenticatedMember viewer = insertMemberWithoutCard(UUID.fromString("00000000-0000-0000-0000-000000000099"),
+				true);
+		for (int index = 1; index <= 22; index++) {
+			UUID memberId = UUID.fromString("00000000-0000-0000-0000-" + String.format("%012d", 100 + index));
+			insertMember(memberId, "회원" + index, false);
+			long points = index <= 19 ? 2000L - index : index <= 21 ? 1000L : 900L;
+			insertTransaction(memberId, "EARN", points);
+		}
+
+		MvcResult firstPage = mockMvc.perform(rankingRequest(viewer)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items", hasSize(20)))
+				.andExpect(jsonPath("$.data.items[19].displayName").value("회원20"))
+				.andExpect(jsonPath("$.data.items[19].rank").value(20))
+				.andExpect(jsonPath("$.data.page.hasNext").value(true))
+				.andExpect(jsonPath("$.data.page.nextCursor").isString())
+				.andExpect(jsonPath("$.data.totalParticipants").value(22)).andReturn();
+		String cursor = JsonPath.read(firstPage.getResponse().getContentAsString(), "$.data.page.nextCursor");
+
+		mockMvc.perform(rankingRequest(viewer).param("cursor", cursor)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items", hasSize(2)))
+				.andExpect(jsonPath("$.data.items[0].displayName").value("회원21"))
+				.andExpect(jsonPath("$.data.items[0].rank").value(20))
+				.andExpect(jsonPath("$.data.items[1].displayName").value("회원22"))
+				.andExpect(jsonPath("$.data.items[1].rank").value(22))
+				.andExpect(jsonPath("$.data.page.hasNext").value(false))
+				.andExpect(jsonPath("$.data.page.nextCursor").doesNotExist())
+				.andExpect(jsonPath("$.data.totalParticipants").value(22));
+	}
+
+	/** 랭킹 참여자가 없고 조회 회원도 미참여이면 문서화된 빈 상태를 반환한다. */
+	@Test
+	@DisplayName("참여자가 없으면 빈 목록과 미참여 내 랭킹을 반환한다")
+	void returnsEmptyRankingAndIneligibleMyRanking() throws Exception {
+		AuthenticatedMember viewer = insertMemberWithoutCard(MY_MEMBER_ID, true);
+
+		mockMvc.perform(rankingRequest(viewer)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.items", hasSize(0)))
+				.andExpect(jsonPath("$.data.myRanking.eligible").value(false))
+				.andExpect(jsonPath("$.data.myRanking.rank").value(nullValue()))
+				.andExpect(jsonPath("$.data.myRanking.displayName").value(nullValue()))
+				.andExpect(jsonPath("$.data.myRanking.characterImageUrl").value(nullValue()))
+				.andExpect(jsonPath("$.data.myRanking.cumulativeEarned").value(0))
+				.andExpect(jsonPath("$.data.totalParticipants").value(0))
+				.andExpect(jsonPath("$.data.page.hasNext").value(false));
+	}
+
+	/** 해석할 수 없거나 참여자 경계가 될 수 없는 커서를 공통 400 오류로 거절한다. */
+	@Test
+	@DisplayName("잘못된 랭킹 커서는 400 INVALID_REQUEST를 반환한다")
+	void rejectsInvalidCursor() throws Exception {
+		AuthenticatedMember viewer = insertMemberWithoutCard(MY_MEMBER_ID, true);
+		String nonPositive = java.util.Base64.getUrlEncoder().withoutPadding()
+				.encodeToString(("0_" + MY_MEMBER_ID).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+		for (String cursor : List.of("not-base64!!", "MTIz", nonPositive)) {
+			mockMvc.perform(rankingRequest(viewer).param("cursor", cursor)).andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.data.code").value("INVALID_REQUEST"));
+		}
+	}
+
+	/** 인증 정보가 없는 랭킹 요청은 다른 회원의 랭킹 정보를 공개하지 않는다. */
+	@Test
+	@DisplayName("인증하지 않으면 401 UNAUTHORIZED를 반환한다")
+	void requiresAuthentication() throws Exception {
+		mockMvc.perform(get("/point-rankings")).andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.data.code").value("UNAUTHORIZED"));
+	}
+
+	/** 만료 시각이 지난 이월 정산이 있어도 랭킹 조회는 EXPIRE 내역이나 만료 확정을 만들지 않는다. */
+	@Test
+	@DisplayName("랭킹 조회는 이월 포인트 만료와 다른 DB 변경을 수행하지 않는다")
+	void doesNotExpirePointsOrChangeDatabaseState() throws Exception {
+		AuthenticatedMember me = insertMember(MY_MEMBER_ID, "금동이", true);
+		insertTransaction(MY_MEMBER_ID, "EARN", 100);
+		UUID tripId = insertExpiredCarryOver(MY_MEMBER_ID, 100);
+		List<Map<String, Object>> beforeTransactions = jdbcTemplate
+				.queryForList("SELECT id, member_id, type::text, amount FROM point_transactions ORDER BY id");
+
+		mockMvc.perform(rankingRequest(me)).andExpect(status().isOk());
+
+		assertThat(jdbcTemplate
+				.queryForList("SELECT id, member_id, type::text, amount FROM point_transactions ORDER BY id"))
+				.isEqualTo(beforeTransactions);
+		assertThat(jdbcTemplate.queryForObject("SELECT expired_at FROM point_settlements WHERE trip_id = ?",
+				Timestamp.class, tripId)).isNull();
+	}
+
+	/** 누적 EARN 내림차순 랭킹과 현재 회원의 순위를 필요한 공개 필드만으로 반환한다. */
+	@Test
+	@DisplayName("누적 적립 순으로 랭킹 목록과 내 순위를 반환한다")
+	void returnsRankingAndMyRankingByCumulativeEarned() throws Exception {
+		AuthenticatedMember me = insertMember(MY_MEMBER_ID, "금동이", true);
+		insertMember(FIRST_MEMBER_ID, "사비", false);
+		insertTransaction(FIRST_MEMBER_ID, "EARN", 200);
+		insertTransaction(MY_MEMBER_ID, "EARN", 100);
+		insertTransaction(MY_MEMBER_ID, "LEAVE_TO_BUYEO", -80);
+
+		mockMvc.perform(get("/point-rankings").header("Authorization", "Bearer " + me.accessToken()))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.items", hasSize(2))).andExpect(jsonPath("$.data.items[0].rank").value(1))
+				.andExpect(jsonPath("$.data.items[0].displayName").value("사비"))
+				.andExpect(jsonPath("$.data.items[0].cumulativeEarned").value(200))
+				.andExpect(jsonPath("$.data.items[0].isMe").value(false))
+				.andExpect(jsonPath("$.data.items[0].characterImageUrl", containsString("public/characters/")))
+				.andExpect(jsonPath("$.data.items[0].memberId").doesNotExist())
+				.andExpect(jsonPath("$.data.items[0].balance").doesNotExist())
+				.andExpect(jsonPath("$.data.items[1].rank").value(2))
+				.andExpect(jsonPath("$.data.items[1].displayName").value("금동이"))
+				.andExpect(jsonPath("$.data.items[1].cumulativeEarned").value(100))
+				.andExpect(jsonPath("$.data.items[1].isMe").value(true))
+				.andExpect(jsonPath("$.data.myRanking.eligible").value(true))
+				.andExpect(jsonPath("$.data.myRanking.rank").value(2))
+				.andExpect(jsonPath("$.data.myRanking.displayName").value("금동이"))
+				.andExpect(jsonPath("$.data.myRanking.cumulativeEarned").value(100))
+				.andExpect(jsonPath("$.data.totalParticipants").value(2))
+				.andExpect(jsonPath("$.data.page.hasNext").value(false));
+	}
+
+	/** 활성 회원과 선택적으로 인증 세션·군민증·프로필 fixture를 만든다. */
+	private AuthenticatedMember insertMember(UUID memberId, String displayName, boolean authenticated) {
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		UUID characterId = jdbcTemplate.queryForObject("SELECT id FROM card_characters ORDER BY sort_order LIMIT 1",
+				UUID.class);
+		UUID themeId = jdbcTemplate.queryForObject("SELECT id FROM card_themes ORDER BY sort_order LIMIT 1",
+				UUID.class);
+		jdbcTemplate.update("INSERT INTO member_profiles (member_id, display_name, character_id) VALUES (?, ?, ?)",
+				memberId, displayName, characterId);
+		jdbcTemplate.update("INSERT INTO citizen_cards (member_id, theme_id, barcode_value) VALUES (?, ?, ?)", memberId,
+				themeId, UUID.randomUUID().toString());
+		return authenticate(memberId, authenticated);
+	}
+
+	/** 군민증과 프로필 없이 활성 회원과 선택적인 인증 세션만 만든다. */
+	private AuthenticatedMember insertMemberWithoutCard(UUID memberId, boolean authenticated) {
+		jdbcTemplate.update("INSERT INTO members (id, status) VALUES (?, 'ACTIVE')", memberId);
+		return authenticate(memberId, authenticated);
+	}
+
+	/** 요청자로 사용할 회원에만 활성 인증 세션과 액세스 토큰을 발급한다. */
+	private AuthenticatedMember authenticate(UUID memberId, boolean authenticated) {
+		if (!authenticated) {
+			return new AuthenticatedMember(memberId, null);
+		}
+		UUID sessionId = UUID.randomUUID();
+		jdbcTemplate.update("""
+				INSERT INTO auth_sessions (id, member_id, refresh_token_hash, expires_at)
+				VALUES (?, ?, ?, ?)
+				""", sessionId, memberId, UUID.randomUUID().toString(),
+				Timestamp.from(Instant.now().plus(30, ChronoUnit.DAYS)));
+		return new AuthenticatedMember(memberId, accessTokenService.issue(memberId, sessionId));
+	}
+
+	/** 활성 회원을 탈퇴 상태로 전이해 랭킹 제외 fixture를 만든다. */
+	private void withdraw(UUID memberId) {
+		jdbcTemplate.update("""
+				UPDATE members
+				SET status = 'WITHDRAWN', withdrawn_at = CURRENT_TIMESTAMP,
+				    purge_after = CURRENT_TIMESTAMP + INTERVAL '30 days'
+				WHERE id = ?
+				""", memberId);
+	}
+
+	/** 만료 도래 이월 정산을 만들어 랭킹 조회의 무변경 조건을 검증한다. */
+	private UUID insertExpiredCarryOver(UUID memberId, long points) {
+		UUID tripId = UUID.randomUUID();
+		jdbcTemplate.update(
+				"INSERT INTO trips (id, member_id, status, ended_at, settled_at) VALUES (?, ?, 'SETTLED', now(), now())",
+				tripId, memberId);
+		jdbcTemplate.update("""
+				INSERT INTO point_settlements (trip_id, choice, settled_points, expires_at, settled_at)
+				VALUES (?, 'CARRY_OVER', ?, CURRENT_TIMESTAMP - INTERVAL '1 minute',
+				        CURRENT_TIMESTAMP - INTERVAL '240 hours 1 minute')
+				""", tripId, points);
+		return tripId;
+	}
+
+	/** 인증된 회원의 누적 포인트 랭킹 요청을 만든다. */
+	private org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder rankingRequest(
+			AuthenticatedMember member) {
+		return get("/point-rankings").header("Authorization", "Bearer " + member.accessToken());
+	}
+
+	/** 회원의 랭킹 계산용 포인트 내역을 저장한다. */
+	private void insertTransaction(UUID memberId, String type, long amount) {
+		jdbcTemplate.update("""
+				INSERT INTO point_transactions (member_id, type, amount, description)
+				VALUES (?, ?::point_transaction_type, ?, '랭킹 테스트')
+				""", memberId, type, amount);
+	}
+
+	/** 테스트 요청에 사용할 회원 ID와 액세스 토큰이다. */
+	private record AuthenticatedMember(UUID memberId, String accessToken) {
+	}
+
+	/** 통합 테스트용 PostgreSQL 연결과 이미지 버킷 설정을 제공한다. */
+	@DynamicPropertySource
+	static void registerProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", POSTGIS::getJdbcUrl);
+		registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+		registry.add("spring.datasource.username", () -> APPLICATION_USERNAME);
+		registry.add("spring.datasource.password", () -> APPLICATION_PASSWORD);
+		registry.add("spring.flyway.enabled", () -> true);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+		registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+		registry.add("storage.images.bucket", () -> "test-images");
+		registry.add("point.expiration.initial-delay", () -> "PT24H");
+	}
+}


### PR DESCRIPTION
## Parent Epic

- #255

Closes #256

## 변경 사항

- `GET /point-rankings`에서 누적 `EARN` 기준 전체 랭킹과 내 순위를 함께 반환합니다.
- 활성 상태·군민증 발급·누적 적립 1점 이상 조건과 공동 순위 규칙을 적용합니다.
- 회원 ID 보조 정렬을 사용하는 20명 고정 불투명 커서 페이지네이션을 추가합니다.
- 현재 표시 이름과 캐릭터의 10분 유효 Presigned GET URL을 반환합니다.
- 조회 과정에서 이월 포인트 만료나 다른 데이터 변경이 발생하지 않도록 읽기 전용으로 처리합니다.

## 검증

- `./gradlew test --tests com.buyeoon.point.PointRankingIntegrationTests`
- `./scripts/test/test.sh`
- `./scripts/test/docker-build.sh` 및 Compose health check
- `git diff --check`

`./scripts/test/static-check.sh`의 compile과 Spotless는 통과했습니다. 전체 Checkstyle은 이번 변경과 무관하게 `TripQueryService` 및 기존 mission/persistence 테스트의 선행 LineLength 오류 13건으로 실패하며, 이번 변경 파일에는 위반이 없습니다.
