### PR TITLE
test: 소셜 탈퇴 재인증 회귀 테스트 수정

### DIFF
--- a/src/test/java/com/buyeoon/member/SocialLoginIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/SocialLoginIntegrationTests.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.buyeoon.member.application.WithdrawnMemberDataPurgeService;
 import com.buyeoon.member.auth.social.AppleSocialCredential;
+import com.buyeoon.member.auth.social.KakaoAuthorizationUnlinker;
 import com.buyeoon.member.auth.social.KakaoSocialCredential;
 import com.buyeoon.member.auth.social.SocialAuthenticationFailedException;
 import com.buyeoon.member.auth.social.SocialCredentialVerifier;
@@ -89,6 +90,9 @@ class SocialLoginIntegrationTests {
 
 	@MockitoBean(name = "appleSocialCredentialVerifier")
 	private SocialCredentialVerifier appleVerifier;
+
+	@MockitoBean
+	private KakaoAuthorizationUnlinker kakaoAuthorizationUnlinker;
 
 	@BeforeEach
 	void setUpVerifiers() {
@@ -278,8 +282,9 @@ class SocialLoginIntegrationTests {
 		UUID withdrawnMemberId = UUID.fromString(JsonPath.read(firstResponse, "$.data.member.memberId"));
 		String accessToken = JsonPath.read(firstResponse, "$.data.accessToken");
 
-		mockMvc.perform(delete("/members/me").header("Authorization", "Bearer " + accessToken))
-				.andExpect(status().isOk());
+		mockMvc.perform(delete("/members/me").header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"provider\":\"KAKAO\",\"accessToken\":\"kakao-rejoin\"}")).andExpect(status().isOk());
 		assertThat(jdbcTemplate.queryForObject("SELECT status::text FROM members WHERE id = ?", String.class,
 				withdrawnMemberId)).isEqualTo("WITHDRAWN");
 		assertThat(count("social_accounts")).isZero();

--- a/src/test/java/com/buyeoon/member/WithdrawnMemberDataPurgeIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/WithdrawnMemberDataPurgeIntegrationTests.java
@@ -10,6 +10,8 @@ import static org.mockito.Mockito.verify;
 import com.buyeoon.common.storage.PrivateImageObjectStore;
 import com.buyeoon.member.application.MemberWithdrawalService;
 import com.buyeoon.member.application.WithdrawnMemberDataPurgeService;
+import com.buyeoon.member.auth.social.KakaoAuthorizationUnlinker;
+import com.buyeoon.member.auth.social.KakaoSocialCredential;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -56,6 +58,9 @@ class WithdrawnMemberDataPurgeIntegrationTests {
 
 	@MockitoBean
 	private PrivateImageObjectStore objectStore;
+
+	@MockitoBean
+	private KakaoAuthorizationUnlinker kakaoAuthorizationUnlinker;
 
 	@BeforeEach
 	void cleanUp() {
@@ -169,7 +174,7 @@ class WithdrawnMemberDataPurgeIntegrationTests {
 		Fixture withdrawn = insertRichActiveMember("private/missions/newly-withdrawn.webp");
 		Fixture active = insertRichActiveMember("private/missions/still-active.webp");
 
-		withdrawalService.withdraw(withdrawn.memberId());
+		withdrawalService.withdraw(withdrawn.memberId(), new KakaoSocialCredential("withdrawal-test-token"));
 
 		assertThat(purgeService.purgeDueMembers()).isEqualTo(1);
 		assertPurged(withdrawn);
@@ -197,7 +202,7 @@ class WithdrawnMemberDataPurgeIntegrationTests {
 			}
 			return null;
 		}).when(objectStore).delete(anyString());
-		withdrawalService.withdraw(fixture.memberId());
+		withdrawalService.withdraw(fixture.memberId(), new KakaoSocialCredential("withdrawal-test-token"));
 
 		assertThat(purgeService.purgeDueMembers()).isZero();
 		assertThat(member(fixture.memberId()).get("status").toString()).isEqualTo("WITHDRAWN");


### PR DESCRIPTION
## 변경 사항
- 카카오 탈퇴 통합 테스트가 재인증 본문을 전송하도록 수정했습니다.
- 회원 데이터 파기 테스트가 카카오 재인증 자격 증명을 포함하도록 수정했습니다.
- 실제 탈퇴 로직은 변경하지 않고, 강화된 소셜 연결 해제 계약에 테스트를 맞췄습니다.

## 검증
- 표적 통합 테스트 통과
- 전체 백엔드 테스트 600개 통과 (> Task :compileJava UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :compileTestJava UP-TO-DATE
> Task :processTestResources UP-TO-DATE
> Task :testClasses UP-TO-DATE
> Task :test UP-TO-DATE

BUILD SUCCESSFUL in 2s
5 actionable tasks: 5 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.5.1/userguide/configuration_cache_enabling.html)

## 배경
PR #265 병합 후 배포 테스트 게이트에서 기존 테스트 3개가 재인증 없이 탈퇴를 호출해 배포가 중단되었습니다.