### PR TITLE
feat: 앱 심사 전용 계정 모드 추가

### DIFF
--- a/docs/raw/openapi.yaml
+++ b/docs/raw/openapi.yaml
@@ -1052,7 +1052,9 @@ components:
                 displayName: null
                 characterId: null
                 requiredTermsAgreed: false
+                locationTermsAgreed: false
                 citizenCardIssued: false
+                appReviewMode: false
                 createdAt: '2026-08-06T15:30:00+09:00'
     AuthRefreshSuccess:
       description: 인증 토큰 갱신 성공
@@ -1073,7 +1075,9 @@ components:
                 displayName: 부여여행자
                 characterId: 550e8400-e29b-41d4-a716-446655440001
                 requiredTermsAgreed: true
+                locationTermsAgreed: true
                 citizenCardIssued: true
+                appReviewMode: false
                 createdAt: '2026-08-01T09:00:00+09:00'
     MemberSuccess:
       description: 회원 정보
@@ -2025,7 +2029,7 @@ components:
       enum: [ACTIVE, WITHDRAWN]
     Member:
       type: object
-      required: [memberId, status, requiredTermsAgreed, locationTermsAgreed, citizenCardIssued, createdAt]
+      required: [memberId, status, requiredTermsAgreed, locationTermsAgreed, citizenCardIssued, appReviewMode, createdAt]
       properties:
         memberId:
           type: string
@@ -2045,6 +2049,9 @@ components:
           description: 공개된 현재 위치기반서비스 이용약관에 동의했는지 여부
         citizenCardIssued:
           type: boolean
+        appReviewMode:
+          type: boolean
+          description: App Store 심사 전용 계정에만 부여되는 위치 시뮬레이션 권한
         createdAt:
           type: string
           format: date-time

--- a/src/main/java/com/buyeoon/member/application/MemberQueryService.java
+++ b/src/main/java/com/buyeoon/member/application/MemberQueryService.java
@@ -25,39 +25,40 @@ public class MemberQueryService {
 		return jdbcOperations.query("""
 				SELECT member.id,
 				       member.status::text,
+				       member.app_review_mode,
 				       profile.display_name,
 				       profile.character_id,
 				       COALESCE((
 				           SELECT bool_and(COALESCE(consent.agreed, false))
 				           FROM (
 				               SELECT DISTINCT ON (term.type) term.id
-			               FROM terms term
-			               WHERE term.published = true
-			                 AND term.required = true
+				              FROM terms term
+				              WHERE term.published = true
+				                AND term.required = true
 				                 AND term.effective_at <= CURRENT_TIMESTAMP
 				               ORDER BY term.type, term.effective_at DESC
 				           ) latest_required_term
 				           LEFT JOIN term_consents consent
 				             ON consent.term_id = latest_required_term.id
 				            AND consent.member_id = member.id
-			       ), false) AS required_terms_agreed,
-			       EXISTS (
-			           SELECT 1
-			           FROM (
-			               SELECT term.id
-			               FROM terms term
-			               WHERE term.published = true
-			                 AND term.type = 'LOCATION'
-			                 AND term.effective_at <= CURRENT_TIMESTAMP
-			               ORDER BY term.effective_at DESC
-			               LIMIT 1
-			           ) current_location_term
-			           JOIN term_consents consent
-			             ON consent.term_id = current_location_term.id
-			            AND consent.member_id = member.id
-			            AND consent.agreed = true
-			       ) AS location_terms_agreed,
-			       EXISTS (
+				      ), false) AS required_terms_agreed,
+				      EXISTS (
+				          SELECT 1
+				          FROM (
+				              SELECT term.id
+				              FROM terms term
+				              WHERE term.published = true
+				                AND term.type = 'LOCATION'
+				                AND term.effective_at <= CURRENT_TIMESTAMP
+				              ORDER BY term.effective_at DESC
+				              LIMIT 1
+				          ) current_location_term
+				          JOIN term_consents consent
+				            ON consent.term_id = current_location_term.id
+				           AND consent.member_id = member.id
+				           AND consent.agreed = true
+				      ) AS location_terms_agreed,
+				      EXISTS (
 				           SELECT 1
 				           FROM citizen_cards card
 				           WHERE card.member_id = member.id
@@ -93,11 +94,13 @@ public class MemberQueryService {
 				MemberStatus.valueOf(resultSet.getString("status")), resultSet.getString("display_name"),
 				resultSet.getObject("character_id", UUID.class), resultSet.getBoolean("required_terms_agreed"),
 				resultSet.getBoolean("location_terms_agreed"), resultSet.getBoolean("citizen_card_issued"),
+				resultSet.getBoolean("app_review_mode"),
 				resultSet.getTimestamp("created_at").toInstant().atZone(ASIA_SEOUL));
 	}
 
 	public record MemberView(UUID memberId, MemberStatus status, String displayName, UUID characterId,
-			boolean requiredTermsAgreed, boolean locationTermsAgreed, boolean citizenCardIssued, ZonedDateTime createdAt) {
+			boolean requiredTermsAgreed, boolean locationTermsAgreed, boolean citizenCardIssued, boolean appReviewMode,
+			ZonedDateTime createdAt) {
 	}
 
 	public record SettingsView(boolean nearbyQuizNotificationEnabled, boolean darkModeEnabled, long version) {

--- a/src/main/resources/db/migration/V45__enable_app_review_account.sql
+++ b/src/main/resources/db/migration/V45__enable_app_review_account.sql
@@ -1,0 +1,6 @@
+ALTER TABLE members
+    ADD COLUMN app_review_mode boolean NOT NULL DEFAULT false;
+
+UPDATE members
+SET app_review_mode = true
+WHERE id = '15d96eac-79ef-4a42-b4f1-5f5b41027483';

--- a/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
+++ b/src/test/java/com/buyeoon/member/MemberMeIntegrationTests.java
@@ -89,6 +89,7 @@ class MemberMeIntegrationTests {
 		UUID sessionId = UUID.randomUUID();
 		Instant createdAt = Instant.parse("2026-08-11T03:00:00Z");
 		insertMember(memberId, "ACTIVE", createdAt);
+		jdbcTemplate.update("UPDATE members SET app_review_mode = true WHERE id = ?", memberId);
 		insertSession(sessionId, memberId, Instant.now().plus(30, ChronoUnit.DAYS), null);
 
 		mockMvc.perform(
@@ -101,6 +102,7 @@ class MemberMeIntegrationTests {
 				.andExpect(jsonPath("$.data.characterId").value((Object) null))
 				.andExpect(jsonPath("$.data.requiredTermsAgreed").value(false))
 				.andExpect(jsonPath("$.data.citizenCardIssued").value(false))
+				.andExpect(jsonPath("$.data.appReviewMode").value(true))
 				.andExpect(jsonPath("$.data.createdAt").value("2026-08-11T12:00:00+09:00"));
 	}
 


### PR DESCRIPTION
## 변경 사항
- 회원별 앱 심사 모드 플래그 추가
- buyeoON 심사 계정만 심사 모드 활성화
- 회원 응답 및 OpenAPI에 appReviewMode 추가

## 검증
- MemberMeIntegrationTests 통과
- Spotless 검사 통과