### PR TITLE
fix: 여행 시작 시 비공개 약관 제외

### DIFF
--- a/src/main/java/com/buyeoon/member/entity/TermEntity.java
+++ b/src/main/java/com/buyeoon/member/entity/TermEntity.java
@@ -43,12 +43,10 @@ public class TermEntity {
 	@Column(name = "effective_at", nullable = false)
 	private Instant effectiveAt;
 
-	public static TermEntity create(
-			TermType type,
-			String version,
-			boolean required,
-			String title,
-			String content,
+	@Column(name = "published", nullable = false)
+	private boolean published;
+
+	public static TermEntity create(TermType type, String version, boolean required, String title, String content,
 			Instant effectiveAt) {
 		TermEntity term = new TermEntity();
 		term.type = type;
@@ -57,6 +55,7 @@ public class TermEntity {
 		term.title = title;
 		term.content = content;
 		term.effectiveAt = effectiveAt;
+		term.published = true;
 		return term;
 	}
 }

--- a/src/main/java/com/buyeoon/trip/TermRepository.java
+++ b/src/main/java/com/buyeoon/trip/TermRepository.java
@@ -12,10 +12,11 @@ public interface TermRepository extends JpaRepository<TermEntity, UUID> {
 	@Query("""
 			SELECT count(currentTerm) = 0
 			FROM TermEntity currentTerm
-			WHERE currentTerm.required = true
+			WHERE currentTerm.published = true
+			  AND currentTerm.required = true
 			  AND currentTerm.effectiveAt = (
 			      SELECT max(latest.effectiveAt) FROM TermEntity latest
-			      WHERE latest.type = currentTerm.type AND latest.required = true
+			      WHERE latest.type = currentTerm.type AND latest.published = true AND latest.required = true
 			        AND latest.effectiveAt <= function('clock_timestamp')
 			  )
 			  AND currentTerm.id NOT IN (

--- a/src/test/java/com/buyeoon/trip/TripStartIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/TripStartIntegrationTests.java
@@ -106,6 +106,18 @@ class TripStartIntegrationTests {
 		assertNoTrip(member.memberId());
 	}
 
+	@Test
+	@DisplayName("공개되지 않은 과거 필수 약관은 여행 시작을 막지 않는다")
+	void unpublishedRequiredTermsAreIgnored() throws Exception {
+		AuthenticatedMember member = readyMember();
+		jdbcTemplate.update("""
+				INSERT INTO terms (type, version, required, title, content, effective_at, published)
+				VALUES ('LOCATION', 'draft', true, '비공개 약관', '비공개 본문', clock_timestamp(), false)
+				""");
+
+		performStart(member, "published-terms-key", request(36.27, 126.91)).andExpect(status().isCreated());
+	}
+
 	/** 군민증을 발급받지 않은 회원은 여행을 시작할 수 없다. */
 	@Test
 	@DisplayName("군민증 미발급은 여행 시작을 거부한다")


### PR DESCRIPTION
## 원인
여행 시작의 필수 약관 검사가 published=false인 과거 초안까지 포함해 로그인 응답과 판정이 불일치했습니다.

## 수정
- 공개된 최신 필수 약관만 여행 시작 조건으로 검사
- JPA 약관 엔티티에 published 매핑
- 비공개 필수 약관이 여행 시작을 막지 않는 회귀 테스트 추가

## 검증
- TripStartIntegrationTests 통과
- Spotless 검사 통과