### PR TITLE
feat: 여행 통계에 earnedPoints를 반환한다

### DIFF
--- a/src/main/java/com/buyeoon/point/TripEarnedPointsQuery.java
+++ b/src/main/java/com/buyeoon/point/TripEarnedPointsQuery.java
@@ -1,0 +1,28 @@
+package com.buyeoon.point;
+
+import com.buyeoon.point.entity.PointTransactionType;
+import com.buyeoon.point.repository.PointTransactionRepository;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * trip 도메인이 여행 통계의 {@code earnedPoints}를 조회할 때 사용하는 point 도메인의 공개 query seam이다.
+ * 해당 여행의 {@code EARN} 내역 합계만 반환하며 쓰기 모델을 변경하지 않는다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class TripEarnedPointsQuery {
+
+	private final PointTransactionRepository pointTransactions;
+
+	/** 여행별 포인트 내역 합계를 조회하는 repository를 주입받는다. */
+	public TripEarnedPointsQuery(PointTransactionRepository pointTransactions) {
+		this.pointTransactions = pointTransactions;
+	}
+
+	/** 해당 여행의 {@code EARN} 내역 amount 합계를 반환한다. 내역이 없으면 0이다. */
+	public long sumByTripId(UUID tripId) {
+		return pointTransactions.sumAmountByTripIdAndType(tripId, PointTransactionType.EARN);
+	}
+}

--- a/src/main/java/com/buyeoon/trip/TripController.java
+++ b/src/main/java/com/buyeoon/trip/TripController.java
@@ -101,12 +101,12 @@ public class TripController {
 		return ResponseEntity.ok(SuccessResponse.of(TripPhotoListResponse.from(photos)));
 	}
 
-	/** 이동 거리·소모 칼로리는 MVP에서 계산하지 않으므로 항상 null이다. */
+	/** 이동 거리·소모 칼로리는 MVP에서 계산하지 않으므로 항상 null이다. earnedPoints는 해당 여행 EARN 합계다. */
 	private record TripStatisticsResponse(UUID tripId, Double distanceKm, long visitedPlaceCount, long durationMinutes,
-			Integer caloriesKcal) {
+			Integer caloriesKcal, long earnedPoints) {
 		static TripStatisticsResponse from(TripStatisticsView statistics) {
 			return new TripStatisticsResponse(statistics.tripId(), null, statistics.visitedPlaceCount(),
-					statistics.durationMinutes(), null);
+					statistics.durationMinutes(), null, statistics.earnedPoints());
 		}
 	}
 
@@ -114,8 +114,7 @@ public class TripController {
 			List<FootprintVisitResponse> visits, PointSummaryView points, List<FootprintBadgeResponse> badges,
 			List<FootprintPhotoResponse> photos) {
 		static FootprintResponse from(FootprintView footprint) {
-			TripStatisticsResponse statistics = new TripStatisticsResponse(footprint.statistics().tripId(), null,
-					footprint.statistics().visitedPlaceCount(), footprint.statistics().durationMinutes(), null);
+			TripStatisticsResponse statistics = TripStatisticsResponse.from(footprint.statistics());
 			List<FootprintVisitResponse> visits = footprint.visits().stream().map(FootprintVisitResponse::from)
 					.toList();
 			List<FootprintBadgeResponse> badges = footprint.badges().stream().map(FootprintBadgeResponse::from)

--- a/src/main/java/com/buyeoon/trip/TripQueryService.java
+++ b/src/main/java/com/buyeoon/trip/TripQueryService.java
@@ -2,6 +2,7 @@ package com.buyeoon.trip;
 
 import com.buyeoon.common.storage.PrivateImageGetUrlService;
 import com.buyeoon.member.application.ResourceNotFoundException;
+import com.buyeoon.point.TripEarnedPointsQuery;
 import com.buyeoon.trip.entity.TripEntity;
 import com.buyeoon.trip.entity.TripStatus;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -28,14 +29,17 @@ public class TripQueryService {
 	private final VisitRecordRepository visitRecordRepository;
 	private final FootprintPhotoRepository photoRepository;
 	private final PrivateImageGetUrlService privateImageUrls;
+	private final TripEarnedPointsQuery tripEarnedPointsQuery;
 
 	@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Spring 싱글턴 빈을 그대로 주입받아 저장한다.")
 	public TripQueryService(TripRepository tripRepository, VisitRecordRepository visitRecordRepository,
-			FootprintPhotoRepository photoRepository, PrivateImageGetUrlService privateImageUrls) {
+			FootprintPhotoRepository photoRepository, PrivateImageGetUrlService privateImageUrls,
+			TripEarnedPointsQuery tripEarnedPointsQuery) {
 		this.tripRepository = tripRepository;
 		this.visitRecordRepository = visitRecordRepository;
 		this.photoRepository = photoRepository;
 		this.privateImageUrls = privateImageUrls;
+		this.tripEarnedPointsQuery = tripEarnedPointsQuery;
 	}
 
 	public boolean hasActiveTrip(UUID memberId) {
@@ -72,10 +76,12 @@ public class TripQueryService {
 		Instant until = trip.getStatus() == TripStatus.IN_PROGRESS ? Instant.now() : trip.getEndedAt();
 		long durationMinutes = Duration.between(trip.getStartedAt(), until).toMinutes();
 		long visitedPlaceCount = visitRecordRepository.countByTripId(tripId);
-		return new TripStatisticsView(tripId, visitedPlaceCount, durationMinutes);
+		long earnedPoints = tripEarnedPointsQuery.sumByTripId(tripId);
+		return new TripStatisticsView(tripId, visitedPlaceCount, durationMinutes, earnedPoints);
 	}
 
-	public record TripStatisticsView(UUID tripId, long visitedPlaceCount, long durationMinutes) {
+	/** 여행 통계 조회 결과다. earnedPoints는 해당 여행의 EARN 내역 합계이며 없으면 0이다. */
+	public record TripStatisticsView(UUID tripId, long visitedPlaceCount, long durationMinutes, long earnedPoints) {
 	}
 
 	/**

--- a/src/test/java/com/buyeoon/trip/FootprintIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/FootprintIntegrationTests.java
@@ -94,6 +94,7 @@ class FootprintIntegrationTests {
 				.andExpect(jsonPath("$.data.trip.status").value("SETTLED"))
 				.andExpect(jsonPath("$.data.statistics.visitedPlaceCount").value(1))
 				.andExpect(jsonPath("$.data.statistics.durationMinutes").value(50))
+				.andExpect(jsonPath("$.data.statistics.earnedPoints").value(100))
 				.andExpect(jsonPath("$.data.visits.length()").value(1))
 				.andExpect(jsonPath("$.data.visits[0].missionId").value(missionId.toString()))
 				.andExpect(jsonPath("$.data.visits[0].place.placeId").value(placeId.toString()))
@@ -220,6 +221,27 @@ class FootprintIntegrationTests {
 				.andExpect(jsonPath("$.data.photos[0].url").value("https://signed-url.example.com/only-mine"));
 	}
 
+	/** 발자취 data.statistics.earnedPoints는 같은 tripId의 통계 API 값과 같다. */
+	@Test
+	@DisplayName("발자취 statistics.earnedPoints는 같은 여행 통계 API 값과 같다")
+	void footprintEarnedPointsMatchStatisticsApi() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(2, ChronoUnit.HOURS);
+		Instant endedAt = startedAt.plus(40, ChronoUnit.MINUTES);
+		UUID tripId = insertTrip(member.memberId(), "SETTLED", startedAt, endedAt);
+		insertPointTransaction(member.memberId(), tripId, 200);
+		insertPointTransaction(member.memberId(), tripId, 100);
+		insertTransaction(member.memberId(), tripId, "LEAVE_TO_BUYEO", -300, "부여에 남기기");
+		insertLeaveToBuyeoSettlement(tripId, 300);
+
+		mockMvc.perform(
+				get("/trips/" + tripId + "/statistics").header("Authorization", "Bearer " + member.accessToken()))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.earnedPoints").value(300));
+
+		performGet(member, tripId).andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.statistics.earnedPoints").value(300));
+	}
+
 	private ResultActions performGet(AuthenticatedMember member, UUID tripId) throws Exception {
 		return mockMvc.perform(
 				get("/trips/" + tripId + "/footprint").header("Authorization", "Bearer " + member.accessToken()));
@@ -258,11 +280,9 @@ class FootprintIntegrationTests {
 
 	private UUID insertMission(UUID placeId, String title) {
 		UUID id = UUID.randomUUID();
-		jdbcTemplate.update(
-				"INSERT INTO missions (id, place_id, location, type, title, description, reward_points, "
-						+ "ox_correct_answer) VALUES (?, ?, (SELECT location FROM places WHERE id = ?), "
-						+ "'OX'::mission_type, ?, '설명', 10, true)",
-				id, placeId, placeId, title);
+		jdbcTemplate.update("INSERT INTO missions (id, place_id, location, type, title, description, reward_points, "
+				+ "ox_correct_answer) VALUES (?, ?, (SELECT location FROM places WHERE id = ?), "
+				+ "'OX'::mission_type, ?, '설명', 10, true)", id, placeId, placeId, title);
 		return id;
 	}
 
@@ -276,10 +296,19 @@ class FootprintIntegrationTests {
 	}
 
 	private void insertPointTransaction(UUID memberId, UUID tripId, long amount) {
+		insertTransaction(memberId, tripId, "EARN", amount, "적립");
+	}
+
+	private void insertTransaction(UUID memberId, UUID tripId, String type, long amount, String description) {
 		jdbcTemplate.update(
 				"INSERT INTO point_transactions (id, member_id, trip_id, type, amount, description) "
-						+ "VALUES (?, ?, ?, 'EARN'::point_transaction_type, ?, '적립')",
-				UUID.randomUUID(), memberId, tripId, amount);
+						+ "VALUES (?, ?, ?, ?::point_transaction_type, ?, ?)",
+				UUID.randomUUID(), memberId, tripId, type, amount, description);
+	}
+
+	private void insertLeaveToBuyeoSettlement(UUID tripId, long settledPoints) {
+		jdbcTemplate.update("INSERT INTO point_settlements (id, trip_id, choice, settled_points, expires_at) "
+				+ "VALUES (?, ?, 'LEAVE_TO_BUYEO', ?, NULL)", UUID.randomUUID(), tripId, settledPoints);
 	}
 
 	private UUID insertBadge(String name) {

--- a/src/test/java/com/buyeoon/trip/TripStatisticsIntegrationTests.java
+++ b/src/test/java/com/buyeoon/trip/TripStatisticsIntegrationTests.java
@@ -50,6 +50,8 @@ class TripStatisticsIntegrationTests {
 
 	@AfterEach
 	void cleanUp() {
+		jdbcTemplate.update("DELETE FROM point_settlements");
+		jdbcTemplate.update("DELETE FROM point_transactions");
 		jdbcTemplate.update("DELETE FROM visit_records");
 		jdbcTemplate.update("DELETE FROM missions");
 		jdbcTemplate.update("DELETE FROM places");
@@ -100,7 +102,7 @@ class TripStatisticsIntegrationTests {
 				.andExpect(jsonPath("$.data.tripId").value(tripId.toString()))
 				.andExpect(jsonPath("$.data.durationMinutes").value(1))
 				.andExpect(jsonPath("$.data.visitedPlaceCount").value(0))
-				.andExpect(jsonPath("$.data.distanceKm").isEmpty())
+				.andExpect(jsonPath("$.data.earnedPoints").value(0)).andExpect(jsonPath("$.data.distanceKm").isEmpty())
 				.andExpect(jsonPath("$.data.caloriesKcal").isEmpty());
 	}
 
@@ -155,6 +157,62 @@ class TripStatisticsIntegrationTests {
 		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.visitedPlaceCount").value(1));
 	}
 
+	/** 진행 중인 여행에 EARN 내역이 없으면 earnedPoints는 0이다. */
+	@Test
+	@DisplayName("EARN이 없으면 earnedPoints는 0이다")
+	void inProgressTripWithoutEarnReturnsZeroEarnedPoints() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId(), "IN_PROGRESS", Instant.now(), null);
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.earnedPoints").value(0));
+	}
+
+	/** 같은 여행의 여러 EARN 내역 amount를 합산해 earnedPoints로 반환한다. */
+	@Test
+	@DisplayName("같은 여행의 여러 EARN은 합산한다")
+	void multipleEarnsOnSameTripAreSummed() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		UUID tripId = insertTrip(member.memberId(), "IN_PROGRESS", Instant.now(), null);
+		insertTransaction(member.memberId(), tripId, "EARN", 200, "미션 보상");
+		insertTransaction(member.memberId(), tripId, "EARN", 100, "미션 보상");
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.earnedPoints").value(300));
+	}
+
+	/** 다른 여행 EARN과 같은 여행의 LEAVE_TO_BUYEO·EXPIRE·ADJUST는 earnedPoints에 넣지 않는다. */
+	@Test
+	@DisplayName("다른 여행 EARN과 같은 여행의 비EARN 내역은 earnedPoints에 넣지 않는다")
+	void excludesOtherTripEarnAndNonEarnTypes() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(2, ChronoUnit.HOURS);
+		UUID otherTripId = insertTrip(member.memberId(), "SETTLED", startedAt, startedAt.plus(20, ChronoUnit.MINUTES));
+		insertTransaction(member.memberId(), otherTripId, "EARN", 1000, "다른 여행 적립");
+
+		UUID tripId = insertTrip(member.memberId(), "IN_PROGRESS", Instant.now(), null);
+		insertTransaction(member.memberId(), tripId, "EARN", 150, "미션 보상");
+		insertTransaction(member.memberId(), tripId, "ADJUST", 50, "운영 조정");
+		insertTransaction(member.memberId(), tripId, "EXPIRE", -20, "만료");
+		insertTransaction(member.memberId(), tripId, "LEAVE_TO_BUYEO", -30, "부여에 남기기");
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.earnedPoints").value(150));
+	}
+
+	/** SETTLED이고 LEAVE_TO_BUYEO여도 earnedPoints는 그 여행의 EARN 합계 그대로다. */
+	@Test
+	@DisplayName("SETTLED+LEAVE_TO_BUYEO여도 earnedPoints는 그 여행 EARN 합계다")
+	void settledLeaveToBuyeoStillReturnsEarnSum() throws Exception {
+		AuthenticatedMember member = insertAuthenticatedMember();
+		Instant startedAt = Instant.now().minus(2, ChronoUnit.HOURS);
+		Instant endedAt = startedAt.plus(45, ChronoUnit.MINUTES);
+		UUID tripId = insertTrip(member.memberId(), "SETTLED", startedAt, endedAt);
+		insertTransaction(member.memberId(), tripId, "EARN", 200, "미션 보상");
+		insertTransaction(member.memberId(), tripId, "EARN", 100, "미션 보상");
+		insertTransaction(member.memberId(), tripId, "LEAVE_TO_BUYEO", -300, "부여에 남기기");
+		insertLeaveToBuyeoSettlement(tripId, 300);
+
+		performGet(member, tripId).andExpect(status().isOk()).andExpect(jsonPath("$.data.earnedPoints").value(300));
+	}
+
 	private ResultActions performGet(AuthenticatedMember member, UUID tripId) throws Exception {
 		return mockMvc.perform(
 				get("/trips/" + tripId + "/statistics").header("Authorization", "Bearer " + member.accessToken()));
@@ -193,17 +251,27 @@ class TripStatisticsIntegrationTests {
 
 	private UUID insertMission(UUID placeId, String title) {
 		UUID id = UUID.randomUUID();
-		jdbcTemplate.update(
-				"INSERT INTO missions (id, place_id, location, type, title, description, reward_points, "
-						+ "ox_correct_answer) VALUES (?, ?, (SELECT location FROM places WHERE id = ?), "
-						+ "'OX'::mission_type, ?, '설명', 10, true)",
-				id, placeId, placeId, title);
+		jdbcTemplate.update("INSERT INTO missions (id, place_id, location, type, title, description, reward_points, "
+				+ "ox_correct_answer) VALUES (?, ?, (SELECT location FROM places WHERE id = ?), "
+				+ "'OX'::mission_type, ?, '설명', 10, true)", id, placeId, placeId, title);
 		return id;
 	}
 
 	private void insertVisitRecord(UUID tripId, UUID missionId, UUID placeId) {
 		jdbcTemplate.update("INSERT INTO visit_records (id, trip_id, mission_id, place_id) VALUES (?, ?, ?, ?)",
 				UUID.randomUUID(), tripId, missionId, placeId);
+	}
+
+	private void insertTransaction(UUID memberId, UUID tripId, String type, long amount, String description) {
+		jdbcTemplate.update(
+				"INSERT INTO point_transactions (id, member_id, trip_id, type, amount, description) "
+						+ "VALUES (?, ?, ?, ?::point_transaction_type, ?, ?)",
+				UUID.randomUUID(), memberId, tripId, type, amount, description);
+	}
+
+	private void insertLeaveToBuyeoSettlement(UUID tripId, long settledPoints) {
+		jdbcTemplate.update("INSERT INTO point_settlements (id, trip_id, choice, settled_points, expires_at) "
+				+ "VALUES (?, ?, 'LEAVE_TO_BUYEO', ?, NULL)", UUID.randomUUID(), tripId, settledPoints);
 	}
 
 	@DynamicPropertySource


### PR DESCRIPTION
## Summary
- `GET /trips/{tripId}/statistics` 응답에 해당 여행 `EARN` 합계 `earnedPoints`를 추가한다. 적립이 없으면 `0`이다.
- trip은 `PointTransactionRepository`를 직접 쓰지 않고, 쓰기 모델을 변경하지 않는 point 공개 조회 seam `TripEarnedPointsQuery`로 합계를 읽는다.
- 발자취 `data.statistics`는 같은 통계 조회를 쓰므로 `earnedPoints`가 함께 맞춰진다.
- 정산 미리보기 API와 발자취 `data.points`는 변경하지 않는다.

Closes #277
Parent Epic: #276

## Test plan
- [x] `IN_PROGRESS` 여행에 `EARN`이 없으면 `earnedPoints`는 `0`
- [x] 같은 여행의 여러 `EARN`은 합산
- [x] 다른 여행 `EARN`과 같은 여행의 `LEAVE_TO_BUYEO`·`EXPIRE`·`ADJUST`는 제외
- [x] `SETTLED` + `LEAVE_TO_BUYEO`여도 그 여행 `EARN` 합계
- [x] 발자취 `data.statistics.earnedPoints`는 같은 `tripId`의 통계 API 값과 같다
- [x] 없거나 타 회원 여행 404, 미인증 401
- [x] `./scripts/test/format.sh`
- [x] `./scripts/test/test.sh`
- [ ] `./scripts/test/static-check.sh` — checkstyle/spotbugs 기존 위반은 이 PR과 무관
- [ ] `./scripts/test/docker-build.sh` — 이미지 빌드는 성공, 로컬 compose health는 DB 환경 제약으로 확인하지 못함